### PR TITLE
Feat: Initial AI configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Project-local Claude Code settings (auto-managed by Claude Code)
+.claude/
+
+# Node.js
+node_modules/
+
+# Temporary and backup files
+*.bak
+*.tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md — claude-config
+
+Configuration repository for Claude Code.
+
+## Repository layout
+
+```
+hooks/      Event dispatcher scripts (PreToolUse, PostToolUse, Stop)
+tools/      Atomic tool scripts invoked by hooks
+skills/     Skill definitions loaded by /skill-name slash commands
+settings.json   Portable global Claude Code configuration
+install.js  Bootstrap script — copies files to ~/.claude/
+```
+
+## Hook architecture
+
+Hooks follow dispatcher → tool separation:
+
+- `hooks/<Event>.js` — reads stdin JSON, routes to one or more tools
+- `tools/<action>.js` — one responsibility, no side effects outside its purpose
+
+All paths resolved via `process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude')`.
+No hardcoded user paths anywhere. No npm dependencies.
+
+## Adding a new tool check
+
+1. Create `tools/<name>.js` — reads stdin JSON, writes to stdout (warn) or stderr+exit(2) (block)
+2. Add it to the appropriate dispatcher in `hooks/PreToolUse.js` or `hooks/PostToolUse.js`
+3. Export pure logic (regexes, helpers) and add tests under `test/<name>.test.js`
+4. Run `npm test`
+
+See `skills/hook-scripts/SKILL.md` for full hook development conventions.
+
+## Adding a skill
+
+1. Copy `templates/SKILL.md` to `skills/<name>/SKILL.md`
+2. Fill in frontmatter (name, description, tags)
+3. Write rules sections following the template structure
+4. Add an entry to the skill table in `README.md`
+5. Run `node install.js` to deploy
+
+## Installation
+
+```
+node install.js              # install to ~/.claude/
+node install.js --dry-run    # preview without writing
+node install.js --no-git-hook # skip .git/hooks/pre-commit copy
+node uninstall.js            # full restore to pre-install state
+```
+
+`settings.json` is JSON-merged into `~/.claude/settings.json`; existing machine-specific settings are preserved (`defaultMode`, user `allow`/`ask`/`deny` entries). `CLAUDE.md` and git pre-commit hook are overwritten with backups. A manifest at `~/.claude/.claude-config-manifest.json` records every created file and every backup so `uninstall.js` can restore the exact prior state byte-for-byte.
+
+## Tests
+
+```
+npm test
+```
+
+Tests live in `test/<name>.test.js` using node's built-in `node:test` runner. They cover regex correctness (bash-safety, secret-guard), escape functions (stop-notify), and install/uninstall round-trip against a temp `CLAUDE_CONFIG_DIR`.
+
+## Commit conventions
+
+See `skills/commit-rules/SKILL.md`. Direct commits to `main` are blocked — use feature branches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+- Hook dispatch system: `PreToolUse`, `PostToolUse`, `Stop`, `UserPromptSubmit` event handlers
+- Safety tools: `bash-safety` (blocks destructive shell commands), `secret-guard` (blocks credential leaks)
+- C++ lint tools: `clang-format`, `clang-tidy`, `cppcheck` wrappers running on every edited C++ file
+- Desktop stop notification via `stop-notify` (Windows / macOS / Linux)
+- Skills: `api-design`, `changelog`, `commit-rules`, `cpp-coding`, `cpp-testing`, `ddd`, `doxygen`, `editing`, `hook-scripts`, `pr-rules`, `release`, `submodule-sync`
+- `UserPromptSubmit` hook: injects active skills reminder into each prompt
+- Portable `config/settings.json` using `CLAUDE_CONFIG_DIR` / `os.homedir()` — no hardcoded user paths
+- `install.js` bootstrap with JSON-merge for `~/.claude/settings.json` — existing machine-specific settings preserved
+- `templates/SKILL.md` template for consistent skill authoring

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Commit format
+
+Conventional Commits — see `skills/commit-rules/SKILL.md` for full rules.
+
+```
+type(scope): subject
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `chore`, `test`, `ci`.
+Subject: imperative mood, lowercase after colon, ≤ 72 chars total.
+Body: describe what changed and why. Do not enumerate file names or reference commit hashes.
+
+No `Co-Authored-By` or AI-attribution trailers.
+
+## Hook and tool scripts
+
+- Node.js built-ins only — no npm, no third-party `require`
+- No hardcoded paths — use `process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude')`
+- Exit codes: `0` = allow/warn (stdout), `2` = block (stderr). Never `1`.
+
+See `skills/hook-scripts/SKILL.md` for full conventions.
+
+## Skills
+
+Each skill lives in `skills/<name>/SKILL.md`. Skills are plain Markdown loaded
+by Claude Code at runtime — no build step.
+
+Keep skill content focused on rules and patterns, not explanations of why
+Claude Code works the way it does.
+
+Use `templates/SKILL.md` as the starting template when creating a new skill:
+
+1. Copy `templates/SKILL.md` to `skills/<name>/SKILL.md`
+2. Fill in frontmatter (name, description, tags)
+3. Write rules sections following the template structure
+4. Add entry to the skill table in `README.md`
+5. Run `node install.js` to deploy
+
+## Branches
+
+Work on feature branches. Direct commits to `main` are blocked by the pre-commit hook.
+
+Branch naming: `<owner>/feat/<topic>`, `<owner>/fix/<topic>`, `<owner>/chore/<topic>`.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,93 @@
+# claude-config
+
+Personal Claude Code configuration — hooks, tools, and skills.
+
+## Contents
+
+| Directory | Purpose |
+|-----------|---------|
+| `hooks/`  | Claude Code event dispatchers (`PreToolUse`, `PostToolUse`, `Stop`) |
+| `tools/`  | Atomic tool scripts invoked by hooks |
+| `skills/` | Skill definitions (SKILL.md files loaded by `/skill-name`) |
+| `config/settings.json` | Portable global configuration (hooks + permissions) |
+
+## Hooks
+
+**`PreToolUse`** — runs before every tool call:
+- `bash-safety.js` — blocks destructive shell commands (`rm -rf /`, `format C:`), warns on reversible-but-risky ones (`git reset --hard`, `DROP TABLE`)
+- `secret-guard.js` — blocks writes containing private keys, AWS keys, GitHub PATs; warns on probable credentials
+
+**`PostToolUse`** — runs after `Edit` / `Write` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`):
+- `clang-format.js` — formats in-place (skips silently if `clang-format` not in PATH)
+- `clang-tidy.js` — runs static analysis (uses `compile_commands.json` when found)
+- `cppcheck.js` — runs `cppcheck --enable=warning,style,performance,portability`
+
+**`Stop`** — fires when Claude Code session ends:
+- `stop-notify.js` — desktop notification (Windows toast / macOS notification / Linux notify-send)
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `api-design` | C++ public API structure and hygiene |
+| `changelog` | Keep a Changelog format |
+| `commit-rules` | Conventional Commits format |
+| `cpp-coding` | C++ implementation conventions |
+| `cpp-testing` | Unit test structure (AAA, naming, coverage) |
+| `ddd` | Domain-Driven Design patterns in C++ |
+| `doxygen` | Doxygen tag coverage for public headers |
+| `editing` | File editing workflow (re-read before edit) |
+| `hook-scripts` | Writing Claude Code hooks and tools |
+| `pr-rules` | PR title, description, merge strategy |
+| `release` | Semver release workflow |
+| `submodule-sync` | Git submodule sync discipline |
+
+## Installation
+
+Requires Node.js (no npm packages needed).
+
+```
+node install.js
+```
+
+Copies `hooks/`, `tools/`, and `skills/` into `~/.claude/` and merges `config/settings.json`
+into `~/.claude/settings.json` (existing machine-specific settings are preserved).
+`CLAUDE.md` and `.git/hooks/pre-commit` are overwritten with backups.
+
+`install.js` writes a manifest at `~/.claude/.claude-config-manifest.json` recording every
+created file and every backup. `uninstall.js` reads the manifest and restores the exact
+pre-install state byte-for-byte.
+
+```
+node install.js --dry-run      # preview without writing
+node install.js --no-git-hook  # skip .git/hooks/pre-commit copy
+node uninstall.js              # full restore using manifest
+node uninstall.js --dry-run    # preview what would be restored
+```
+
+## Tests
+
+```
+npm test
+```
+
+Uses node's built-in `node:test` runner. Covers safety regexes, shell-escape functions,
+and install/uninstall round-trip in a temporary `CLAUDE_CONFIG_DIR`.
+
+See [install.js](install.js) for options and dry-run mode.
+
+## Manual setup
+
+Copy the directories manually:
+
+```
+# Windows (PowerShell)
+Copy-Item -Recurse hooks $env:USERPROFILE\.claude\hooks
+Copy-Item -Recurse tools $env:USERPROFILE\.claude\tools
+Copy-Item -Recurse skills $env:USERPROFILE\.claude\skills
+
+# Linux / macOS
+cp -r hooks tools skills ~/.claude/
+```
+
+Then copy or merge `settings.json` into `~/.claude/settings.json`.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npm test
 Uses node's built-in `node:test` runner. Covers safety regexes, shell-escape functions,
 and install/uninstall round-trip in a temporary `CLAUDE_CONFIG_DIR`.
 
-See [install.js](install.js) for options and dry-run mode.
+See [install.js](install.js) for details.
 
 ## Manual setup
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,0 +1,25 @@
+# Global Rules
+
+## Actions outside working directory require confirmation
+
+Before any action that affects state outside a git-controlled working directory — ask the user. This includes but is not limited to:
+- `git push` (any form), `gh` CLI, `glab` CLI, GitHub/GitLab API calls
+- Writing or modifying files outside the current project (e.g. `~/.config`, `/etc/`, system paths)
+- Installing or updating system packages (winget, choco, npm -g, pip, apt, brew)
+- Any operation the user cannot roll back with standard VCS tools
+
+Local commits, local file edits within a git repo, and read operations do not require confirmation.
+
+## Skills — auto-apply
+
+When writing or reviewing C++ implementation code → apply `cpp-coding` skill.
+When designing public API, adding public headers, or reviewing public interface → apply `api-design` skill.
+When adding or modifying Doxygen comments on public headers → apply `doxygen` skill.
+When modelling domain objects, aggregates, or bounded contexts → apply `ddd` skill.
+When writing commit messages → apply `commit-rules` skill.
+When opening, reviewing, or preparing a PR → apply `pr-rules` skill.
+When updating CHANGELOG.md → apply `changelog` skill.
+When preparing a release, bumping version, or tagging → apply `release` skill.
+When writing or modifying hook scripts in hooks/ or tools/ → apply `hook-scripts` skill.
+When editing any file → apply `editing` skill.
+When syncing git submodules → apply `submodule-sync` skill.

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const{spawnSync}=require('child_process'),p=require('path'),o=require('os'),d=process.env.CLAUDE_CONFIG_DIR||p.join(o.homedir(),'.claude');spawnSync('node',[p.join(d,'hooks','PreToolUse.js')],{stdio:'inherit'})\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const{spawnSync}=require('child_process'),p=require('path'),o=require('os'),d=process.env.CLAUDE_CONFIG_DIR||p.join(o.homedir(),'.claude');spawnSync('node',[p.join(d,'hooks','PostToolUse.js')],{stdio:'inherit'})\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const{spawnSync}=require('child_process'),p=require('path'),o=require('os'),d=process.env.CLAUDE_CONFIG_DIR||p.join(o.homedir(),'.claude');spawnSync('node',[p.join(d,'hooks','Stop.js')],{stdio:'inherit'})\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const{spawnSync}=require('child_process'),p=require('path'),o=require('os'),d=process.env.CLAUDE_CONFIG_DIR||p.join(o.homedir(),'.claude');spawnSync('node',[p.join(d,'hooks','UserPromptSubmit.js')],{stdio:'inherit'})\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "Bash(*)",
+      "PowerShell(*)",
+      "WebFetch(*)",
+      "WebSearch(*)"
+    ],
+    "ask": [
+      "Bash(git push *)",
+      "Bash(winget *)",
+      "Bash(choco *)",
+      "Bash(npm install -g *)",
+      "Bash(pip install *)",
+      "PowerShell(winget *)",
+      "PowerShell(choco *)",
+      "PowerShell(npm install -g *)",
+      "PowerShell(pip install *)"
+    ]
+  }
+}

--- a/hooks/PostToolUse.js
+++ b/hooks/PostToolUse.js
@@ -1,0 +1,34 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+
+const CPP_EXTS = new Set(['.h', '.hpp', '.cpp', '.cc', '.cxx']);
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const toolsDir = path.join(configDir, 'tools');
+const LINT_TOOLS = ['clang-format.js', 'clang-tidy.js', 'cppcheck.js'];
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', c => { raw += c; });
+process.stdin.on('end', () => {
+  let data;
+  try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+  if (!EDIT_TOOLS.has(data.tool_name)) process.exit(0);
+
+  const filePath = data.tool_input?.file_path ?? data.tool_input?.path;
+  if (!filePath || !CPP_EXTS.has(path.extname(filePath).toLowerCase())) process.exit(0);
+
+  if (process.env.CLAUDE_HOOK_RUNNING) process.exit(0);
+  process.env.CLAUDE_HOOK_RUNNING = '1';
+
+  for (const tool of LINT_TOOLS) {
+    const r = spawnSync('node', [path.join(toolsDir, tool), filePath], { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
+    if (r.stdout?.trim()) process.stdout.write(r.stdout.trim() + '\n');
+    if (r.stderr?.trim()) process.stderr.write(r.stderr.trim() + '\n');
+  }
+
+  process.exit(0);
+});

--- a/hooks/PreToolUse.js
+++ b/hooks/PreToolUse.js
@@ -1,0 +1,37 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+
+const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const toolsDir = path.join(configDir, 'tools');
+
+const DISPATCH = {
+  Bash:  ['bash-safety.js'],
+  Edit:  ['secret-guard.js'],
+  Write: ['secret-guard.js'],
+};
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', c => { raw += c; });
+process.stdin.on('end', () => {
+  if (process.env.CLAUDE_HOOK_RUNNING) process.exit(0);
+  process.env.CLAUDE_HOOK_RUNNING = '1';
+
+  let data;
+  try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+  const tools = DISPATCH[data.tool_name] ?? [];
+  if (!tools.length) process.exit(0);
+
+  for (const tool of tools) {
+    const r = spawnSync('node', [path.join(toolsDir, tool)], {
+      input: raw, encoding: 'utf8', stdio: 'pipe', timeout: 30000,
+    });
+    if (r.stdout?.trim()) process.stdout.write(r.stdout);
+    if (r.stderr?.trim()) process.stderr.write(r.stderr);
+    if (r.status === 2) process.exit(2);
+  }
+  process.exit(0);
+});

--- a/hooks/Stop.js
+++ b/hooks/Stop.js
@@ -1,0 +1,7 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+
+const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+spawnSync('node', [path.join(configDir, 'tools', 'stop-notify.js')], { stdio: 'inherit', timeout: 10000 });

--- a/hooks/UserPromptSubmit.js
+++ b/hooks/UserPromptSubmit.js
@@ -1,0 +1,18 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+
+const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const toolsDir = path.join(configDir, 'tools');
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', c => { raw += c; });
+process.stdin.on('end', () => {
+  const r = spawnSync('node', [path.join(toolsDir, 'skills-reminder.js')], {
+    input: raw, encoding: 'utf8', stdio: 'pipe', timeout: 5000,
+  });
+  if (r.error) { process.stderr.write(`skills-reminder error: ${r.error.message}\n`); return; }
+  if (r.stdout?.trim()) process.stdout.write(r.stdout);
+});

--- a/hooks/git/pre-commit
+++ b/hooks/git/pre-commit
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+user_name=$(git config --local --get user.name || echo "")
+user_email=$(git config --local --get user.email || echo "")
+
+if [ -z "$user_name" ] || [ -z "$user_email" ]; then
+  echo "Error: user.name and user.email must be set locally (in this repository)."
+  echo "Please run:"
+  echo "  git config --local user.name \"Your Name\""
+  echo "  git config --local user.email \"you@example.com\""
+  exit 1
+fi
+
+# ── Protected branches ─────────────────────────────────────────────
+FORBIDDEN_BRANCHES="^(main|master|dev|develop)$"
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+if [[ "$CURRENT_BRANCH" =~ $FORBIDDEN_BRANCHES ]]; then
+    echo "error: direct commit to '$CURRENT_BRANCH' is not allowed."
+    echo "       create a feature branch: git checkout -b feature/my-change"
+    exit 1
+fi
+
+# ── clang-format staged files ──────────────────────────────────────
+EXTENSIONS="\.([ch]|[ch]pp|[ch]xx|cc|hh)$"
+
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM \
+               | grep -E "$EXTENSIONS" || true)
+
+if [[ -z "$STAGED_FILES" ]]; then
+    exit 0
+fi
+
+if ! command -v clang-format &>/dev/null; then
+    echo "warning: clang-format not found, skipping formatting."
+    exit 0
+fi
+
+echo "clang-format: formatting staged C/C++ files..."
+
+REFORMATTED=()
+while IFS= read -r FILE; do
+    [[ -f "$FILE" ]] || continue
+    BEFORE=$(git show ":$FILE" | git hash-object --stdin)
+    clang-format -i "$FILE"
+    AFTER=$(git hash-object -- "$FILE")
+    if [[ "$BEFORE" != "$AFTER" ]]; then
+        git add "$FILE"
+        REFORMATTED+=("$FILE")
+    fi
+done <<< "$STAGED_FILES"
+
+if (( ${#REFORMATTED[@]} > 0 )); then
+    printf "  reformatted: %s\n" "${REFORMATTED[@]}"
+fi
+
+exit 0

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/install.js
+++ b/install.js
@@ -1,0 +1,197 @@
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const SKIP_GIT = process.argv.includes('--no-git-hook');
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const repoDir = __dirname;
+const manifestPath = path.join(claudeDir, '.claude-config-manifest.json');
+const backupsDir = path.join(claudeDir, '.claude-config-backups');
+const logPrefix = DRY_RUN ? '[dry]' : '    ';
+
+function log(msg) { process.stdout.write(msg + '\n'); }
+function warn(msg) { process.stderr.write('warn: ' + msg + '\n'); }
+
+let manifest = { version: 1, installedAt: new Date().toISOString(), createdFiles: [], backups: [] };
+if (fs.existsSync(manifestPath)) {
+  try { manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')); }
+  catch { warn(`existing manifest unreadable — overwriting: ${manifestPath}`); }
+}
+
+function isTracked(dest) {
+  return manifest.createdFiles.includes(dest) || manifest.backups.some(b => b.dest === dest);
+}
+
+function backupPathFor(dest) {
+  const ts = Date.now();
+  return path.join(backupsDir, `${path.basename(dest)}.${ts}.bak`);
+}
+
+function backupBeforeWrite(dest) {
+  if (isTracked(dest)) return;
+  if (!fs.existsSync(dest)) {
+    manifest.createdFiles.push(dest);
+    return;
+  }
+  const bak = backupPathFor(dest);
+  if (!DRY_RUN) {
+    fs.mkdirSync(path.dirname(bak), { recursive: true });
+    fs.copyFileSync(dest, bak);
+  }
+  manifest.backups.push({ dest, backup: bak });
+}
+
+function copyFile(src, dest) {
+  const wasMissing = !fs.existsSync(dest);
+  if (!DRY_RUN) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+  if (wasMissing && !isTracked(dest)) manifest.createdFiles.push(dest);
+  log(`  ${logPrefix} ${path.relative(repoDir, src)} → ${dest}`);
+}
+
+function copyDir(srcDir, destDir, exclude = new Set()) {
+  if (!fs.existsSync(srcDir)) { warn(`source not found: ${srcDir}`); return; }
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    if (exclude.has(entry.name)) continue;
+    const src = path.join(srcDir, entry.name);
+    const dest = path.join(destDir, entry.name);
+    if (entry.isDirectory()) copyDir(src, dest);
+    else copyFile(src, dest);
+  }
+}
+
+function mergeUnique(existing, incoming) {
+  return [...new Set([...existing, ...incoming])];
+}
+
+function mergeHookEvent(existing, incoming) {
+  const existingCmds = new Set();
+  for (const entry of existing)
+    for (const h of (entry.hooks || []))
+      if (h.command) existingCmds.add(h.command);
+
+  const result = [...existing];
+  let added = 0;
+  for (const entry of incoming) {
+    const newHooks = (entry.hooks || []).filter(h => !existingCmds.has(h.command));
+    if (newHooks.length) { result.push({ ...entry, hooks: newHooks }); added += newHooks.length; }
+  }
+  return { result, added };
+}
+
+function mergeSettings(existing, repo) {
+  const out = structuredClone(existing);
+  const additions = {};
+
+  if (repo.hooks) {
+    out.hooks = out.hooks || {};
+    for (const [ev, entries] of Object.entries(repo.hooks)) {
+      const { result, added } = mergeHookEvent(out.hooks[ev] || [], entries);
+      out.hooks[ev] = result;
+      if (added) additions[ev] = added;
+    }
+  }
+
+  if (repo.permissions) {
+    out.permissions = out.permissions || {};
+    for (const key of ['allow', 'ask', 'deny'])
+      if (repo.permissions[key])
+        out.permissions[key] = mergeUnique(out.permissions[key] || [], repo.permissions[key]);
+  }
+
+  return { out, additions };
+}
+
+function installSettings() {
+  const src = path.join(repoDir, 'config', 'settings.json');
+  if (!fs.existsSync(src)) { warn(`source not found: ${src}`); return; }
+  const dest = path.join(claudeDir, 'settings.json');
+  const repo = JSON.parse(fs.readFileSync(src, 'utf8'));
+
+  backupBeforeWrite(dest);
+
+  if (!fs.existsSync(dest)) {
+    if (!DRY_RUN) {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.copyFileSync(src, dest);
+    }
+    log(`  ${logPrefix} config/settings.json → ${dest} (created)`);
+    return;
+  }
+  let existing;
+  try { existing = JSON.parse(fs.readFileSync(dest, 'utf8')); }
+  catch { warn(`${dest} is not valid JSON — skipping merge`); return; }
+  const { out: merged, additions } = mergeSettings(existing, repo);
+  if (!DRY_RUN) fs.writeFileSync(dest, JSON.stringify(merged, null, 2) + '\n');
+  log(`  ${logPrefix} config/settings.json → ${dest} (merged)`);
+  for (const [ev, n] of Object.entries(additions))
+    log(`      added ${n} hook${n === 1 ? '' : 's'} to ${ev}`);
+}
+
+function installCLAUDEmd() {
+  const src = path.join(repoDir, 'config', 'CLAUDE.md');
+  if (!fs.existsSync(src)) { warn(`source not found: ${src}`); return; }
+  const dest = path.join(claudeDir, 'CLAUDE.md');
+  backupBeforeWrite(dest);
+  if (!DRY_RUN) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+  log(`  ${logPrefix} config/CLAUDE.md → ${dest}`);
+}
+
+function installGitHook() {
+  const preCommitSrc = path.join(repoDir, 'hooks', 'git', 'pre-commit');
+  const gitDir = path.join(repoDir, '.git');
+  if (!fs.existsSync(preCommitSrc) || !fs.existsSync(gitDir)) {
+    warn('hooks/git/pre-commit not found or .git missing, skipping');
+    return;
+  }
+  const dest = path.join(gitDir, 'hooks', 'pre-commit');
+  backupBeforeWrite(dest);
+  if (!DRY_RUN) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(preCommitSrc, dest);
+    fs.chmodSync(dest, 0o755);
+  }
+  log(`  ${logPrefix} hooks/git/pre-commit → ${dest}`);
+}
+
+log(`Installing to: ${claudeDir}${DRY_RUN ? ' (dry run)' : ''}\n`);
+
+log('hooks/');
+copyDir(path.join(repoDir, 'hooks'), path.join(claudeDir, 'hooks'), new Set(['git']));
+
+log('\ntools/');
+copyDir(path.join(repoDir, 'tools'), path.join(claudeDir, 'tools'));
+
+log('\nskills/');
+const skillsDir = path.join(repoDir, 'skills');
+if (!fs.existsSync(skillsDir)) {
+  warn(`source not found: ${skillsDir}`);
+} else {
+  for (const name of fs.readdirSync(skillsDir)) {
+    const skillFile = path.join(skillsDir, name, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+    copyFile(skillFile, path.join(claudeDir, 'skills', name, 'SKILL.md'));
+  }
+}
+
+log('\nsettings.json');
+installSettings();
+
+log('\nCLAUDE.md');
+installCLAUDEmd();
+
+if (!SKIP_GIT) {
+  log('\ngit hooks');
+  installGitHook();
+}
+
+if (!DRY_RUN) fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+log(`\nManifest: ${manifestPath}`);
+log('Done.');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "claude-config",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "license": "Unlicense",
+  "scripts": {
+    "test": "node --test \"test/**/*.test.js\""
+  }
+}

--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: api-design
+version: "1.0.0"
+description: Apply when designing new API, adding public headers, or reviewing public interface
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - cpp
+    - api
+---
+
+# Skill: C++ API Design
+
+Apply when designing new API, adding public headers, or reviewing public interface changes.
+
+## Structural Rules
+
+- **Namespace hierarchy**: public symbols in consistent `lib::` or `lib::module::` namespace; check project `AGENTS.md` for exact namespace
+- Identifier and comment language: follow project AGENTS.md
+
+## Dependencies
+
+- No runtime dependencies in public API
+- No external headers in public API headers
+- No compiler-specific extensions directly — abstract via macro or type_traits helpers
+- Use C++ feature test macros for version/compiler guards:
+  ```cpp
+  #if defined(__cpp_concepts) && __cpp_concepts >= 202002L
+  // concepts-based overload
+  #endif
+  ```
+
+## Compatibility
+
+- Target the minimum C++ standard the project declares (check `AGENTS.md`)
+- No UB, no implementation-defined behaviour in public paths
+
+## Breaking Changes
+
+Breaking change = removing or renaming any public symbol, or changing its observable behaviour.
+- Requires `MAJOR` version bump (semver)
+- Document in `CHANGELOG.md` under `### Removed` or `### Changed`
+- Prefer deprecation (`[[deprecated("use X instead")]]`) before removal
+- Avoid unless necessary
+
+## API Hygiene
+
+- **No `bool` parameters in public API** — use `enum class` instead:
+  ```cpp
+  // Wrong: caller can't tell what true/false means at call site
+  void open(bool read_only);
+  open(true);
+
+  // Correct: intent visible without reading declaration
+  enum class OpenMode { ReadWrite, ReadOnly };
+  void open(OpenMode mode);
+  open(OpenMode::ReadOnly);
+  ```
+  Exception: predicates returning `bool` are fine — the rule applies to parameters, not return types.
+
+- Template parameters: prefer full descriptive names (`ValueType`, `Executor`, `Allocator`); use short conventional names (`T`, `Iter`) only for generic algorithms
+- **No `void*` in public API** — use templates, `std::any`, or `std::variant`
+
+## Adding a New Header
+
+1. Create the header at the path the project declares (check `AGENTS.md`)
+2. Add `#pragma once` (classic headers) — C++20+ module projects use `export module <name>;` instead; the two are mutually exclusive
+3. Add Doxygen `@defgroup` or `@ingroup` (see `doxygen` skill)
+4. Add a test file alongside the implementation

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: changelog
+version: "1.0.0"
+description: Apply when editing CHANGELOG.md or asked about changelog format
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - git
+    - changelog
+---
+
+# Skill: Changelog
+
+Apply when editing `CHANGELOG.md` or asked about changelog format.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own changelog conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+## Format
+
+Keep a Changelog (https://keepachangelog.com/en/1.1.0/) + Semantic Versioning.
+
+```
+# Changelog
+
+## [Unreleased]
+### Added
+- New feature description.
+
+## [X.Y.Z] - YYYY-MM-DD
+### Changed
+- What changed and why it matters to users.
+```
+
+## Subsections
+
+Use only what applies. Order:
+`Added` → `Changed` → `Deprecated` → `Removed` → `Fixed` → `CI`
+
+## Bullet Rules
+
+- Past tense, present-user perspective ("Added", not "Adding")
+- Describe the WHAT and WHY for the user — not the implementation
+- One logical change per bullet
+- No PR numbers, no commit hashes, no internal refactor details
+
+## What Goes In
+
+- New public API / behaviour
+- Behaviour changes (even if backwards-compatible)
+- Deprecations and removals
+- Breaking changes (mark clearly)
+- CI changes visible to contributors
+
+## What Stays Out
+
+- Pure internal refactors with no visible effect
+- Comment-only changes
+- Formatting / style fixes
+- Test-only changes (unless they affect contributor workflow)
+
+## On Release
+
+1. Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` (today's date)
+2. Prepend a new empty `## [Unreleased]` section above it
+3. Leave empty subsections out — add them only when there's content

--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: commit-rules
+version: "1.0.0"
+description: Apply when writing or reviewing commit messages
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - git
+    - commits
+---
+
+# Skill: Commit Rules
+
+Apply when writing commit messages or reviewing commits.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own commit conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## Format
+
+```
+type(scope): subject
+
+Body explaining the change.
+```
+
+**First line:** `type(scope): subject` — total length ≤ 72 characters.
+**Scope** is optional; use when the change is clearly scoped to one module/component.
+**Subject:** imperative mood, lowercase after the colon, no trailing period.
+
+> Merge commits follow `pr-rules` Merge Strategy format (`Merge PR #<n>: …`, subject ≤ 120 chars), not this section.
+
+```
+feat(hash): add SipHash-2-4 keyed 64-bit hash
+fix(wrapper): correct noexcept propagation through executor chain
+chore: update submodule refs to current branch heads
+```
+
+---
+
+## Types
+
+| Type | When |
+|------|------|
+| `feat` | New user-visible functionality |
+| `fix` | Bug fix |
+| `refactor` | Code change with no behaviour change |
+| `perf` | Performance improvement |
+| `docs` | Documentation only |
+| `test` | Test additions or changes |
+| `chore` | Build, tooling, dependency, submodule updates |
+| `ci` | CI/CD workflow changes |
+| `style` | Formatting only (no logic change) |
+
+`BREAKING CHANGE:` in body (or `!` after type) for breaking public API changes.
+
+---
+
+## Body
+
+Blank line between subject and body. Lines ≤ 72 characters.
+
+Body is **always required** — no exceptions.
+
+Write in plain language — no rigid sections, no headers. Explain:
+
+- **why** the change was made
+- **what problem** it solves
+- **how** it was approached (when the approach is non-obvious)
+
+```
+feat(hash): add SipHash-2-4 keyed 64-bit hash
+
+SipHash provides hash-flooding resistance missing in fnv1a/djb2.
+Implements the reference SipHash-2-4 algorithm with a 128-bit key.
+Key is passed as two uint64_t values to avoid struct padding issues.
+```
+
+---
+
+## Consistency Rules
+
+- **Check branch before committing** — confirm you are on a feature branch, not `main`.
+  Direct commits to `main` are blocked by the pre-commit hook.
+- **Repository must be consistent at every commit** — docs, tests, and implementation
+  must not diverge within a single commit. A commit that adds a feature must also
+  update any documentation or tests that reference it.
+- **Do not describe a result before it exists** — a commit that only adds tests for
+  feature X must not say "add feature X". The subject must match what is actually
+  committed, not what will be committed later.
+
+---
+
+## Fixup Commits
+
+When correcting an earlier commit on the same branch, use `--fixup` instead of a free-form commit:
+
+```bash
+git commit --fixup=<hash>          # creates "fixup! <original subject>"
+git rebase -i --autosquash <base>  # squashes fixups automatically before merge
+```
+
+Use `--fixup` when the change belongs to a specific earlier commit — reviewer sees the correction attached to its target, not floating. Use a normal commit only when the change is logically independent.
+
+## Fixup / Squash Merges
+
+Squash fixup commits before opening the PR — not at merge time.
+
+When squashing, rewrite the body to describe the actual final change — not the fixup history. The merged commit must read as if it was written that way from the start.
+
+## No Correction Commits Within a PR
+
+A PR branch must not contain correction commits (fixups, renames, moves) for mistakes introduced earlier in the same branch. If a commit is wrong, rewrite history — do not layer a fix on top.
+
+**Rule:** If a correction belongs to an earlier commit in the same PR, rebase and amend that commit. A reviewer should see each commit as correct from the start, not as a sequence of mistake + fix.
+
+---
+
+## Trailers — Banned
+
+No `Co-Authored-By`, no `Co-authored-by`, no AI-attribution trailers of any kind.
+
+```
+# Never:
+Co-Authored-By: Claude <noreply@anthropic.com>
+Generated-by: AI
+```

--- a/skills/cpp-coding/SKILL.md
+++ b/skills/cpp-coding/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: cpp-coding
+version: "1.0.0"
+description: Apply when writing or reviewing C++ implementation code
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - cpp
+    - coding
+---
+
+# Skill: C++ Coding
+
+Apply when writing or reviewing C++ implementation code.
+
+Scope: project-level implementation conventions (not the C++ standard). Public API structure → `api-design`. Docs → `doxygen`. Naming, namespaces, file layout → project `AGENTS.md`.
+
+Reference: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#s-philosophy
+
+## Philosophy
+
+- **Value semantics over pointers** — prefer values and move semantics; use references for observation, not ownership
+- **Types express invariants** — make illegal states unrepresentable through the type system
+- **Express ideas directly in code** — types must carry meaning:
+  ```cpp
+  Month month() const;  // correct — type expresses intent
+  int   month() const;  // wrong   — caller must guess the unit
+  ```
+- **Local type aliases** — every type in a class's public interface must have a local alias:
+  ```cpp
+  using Counter         = int;
+  using OptionalCounter = ::std::optional<Counter>;
+  using Expected        = ::std::expected<Counter, ::std::error_code>;
+  // use OptionalCounter everywhere — not std::optional<int>
+  ```
+- **Const by default** — declare everything `const` unless mutation is required
+- **Composition over inheritance** — use virtual/inheritance only for runtime polymorphism
+
+## Performance
+
+Performance is a primary concern, not an afterthought.
+
+- **Avoid unnecessary copies** — pass by `const&`, return by value with NRVO/move, apply `::std::move` on the last use of a named local
+- **Prefer views over materialisation** — `::std::span`, `::std::string_view`, `::std::ranges::views::*` instead of allocating intermediate containers
+- **Lazy algorithms** — compose `::std::ranges::views::filter` / `transform` / `take` / `drop` pipelines that defer work until consumed
+- **Reserve capacity** — `vector::reserve` / `string::reserve` when the final size is known or bounded
+- **Hot-path discipline** — no allocations in tight loops; prefer stack buffers and small-buffer-optimised types
+
+## Include Order
+
+Applies to `.cpp` / `.cc` files. Alphabetical within each group.
+
+```cpp
+// 1. Same-named own header — ""
+#include "foo.h"
+
+// 2. All project and 3rdparty API headers — <> even from the same repo
+#include <bar/baz.h>
+#include <qux/qux.h>
+
+// 3. Standard library — <>
+#include <optional>
+#include <vector>
+
+// 4. Private / implementation-detail headers — ""
+#include "detail/foo_impl.h"
+#include "foo_detail.h"
+
+// 5. Export / DLL-visibility macro header — last, "", separate group
+#include "export.h"
+```
+
+In public API headers: include only what the header directly uses.
+
+## Header Guards
+
+Every header file starts with `#pragma once` before any other content.
+
+## Type Safety
+
+- `enum class` not plain `enum` — scoped, no implicit conversion to `int`; if C compatibility is required, declare outside class scope and document why
+- `nullptr` not `NULL` or `0`
+- Explicit casts only: `static_cast`, `reinterpret_cast`, `const_cast` — no C-style `(T)x`
+- No `dynamic_cast` — redesign with virtual dispatch or `::std::variant`/`::std::visit`
+- Prefer smart wrapper types over raw pointers: `::std::reference_wrapper`, `::std::polymorphic`, `::std::indirect`, or custom RAII types
+
+## Resource Management
+
+- No naked `new` / `delete` — RAII only
+- `std::unique_ptr` by default; `std::shared_ptr` only when multiple owners required
+- RAII wrappers for all OS handles (file descriptors, sockets, mutexes, etc.)
+- Prefer smart wrappers (`reference_wrapper`, `polymorphic`, `indirect`, custom) over raw pointer members
+- No mutable global state
+
+## Function Qualifiers
+
+- `const` on member functions that do not mutate observable state
+- `noexcept` on functions that cannot throw; compute it where correct:
+  ```cpp
+  void swap(Foo& other) noexcept(noexcept(::std::swap(value_, other.value_)));
+  ```
+- `constexpr` on functions where compile-time evaluation is possible
+- `explicit` on single-argument constructors and conversion operators
+
+## Attributes
+
+Standard attributes — apply where appropriate:
+
+| Attribute | When |
+|-----------|------|
+| `[[nodiscard("reason")]]` | Return value must not be discarded (error codes, resources) |
+| `[[maybe_unused]]` | Parameter or variable intentionally unused |
+| `[[likely]]` / `[[unlikely]]` | Branch probability hint for hot paths |
+| `[[deprecated("use X")]]` | Mark obsolete API before removal |
+
+Library and project attribute macros (e.g. `Q_INVOKABLE`, `MY_LIB_EXPORT`, `BOOST_FORCEINLINE`) follow the same discipline: use only those declared in the project; document the full set in `AGENTS.md`.
+
+## Modern Idioms
+
+- Range-for over index loops when the index is not needed
+- Structured bindings for pairs and tuples: `auto [key, val] = ...`
+- `auto` preferred — use freely; avoid only when the type name itself carries important semantic intent
+- `if constexpr` instead of SFINAE for compile-time branching
+- `::std::move` — apply on the last use of a named object being passed or returned
+- Prefer `::std::ranges::` algorithms over raw iterator pairs

--- a/skills/cpp-testing/SKILL.md
+++ b/skills/cpp-testing/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: cpp-testing
+version: "1.0.0"
+description: Apply when writing, reviewing, or adding tests to C++ code
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - cpp
+    - testing
+---
+
+# Skill: C++ Unit Testing
+
+Apply when writing, reviewing, or adding tests to C++ code.
+
+Framework choice is project-specific (check `AGENTS.md`). This skill covers principles only.
+
+---
+
+## What to Test
+
+- Every public API function must have tests — private implementation details are not tested directly
+- Test behaviour, not implementation: if internal refactoring breaks a test, the test was wrong
+- Every bug fix gets a regression test that reproduces the bug before the fix
+
+## Test Structure — AAA
+
+Each test follows three clearly separated phases:
+
+```cpp
+TEST(Money, AdditionProducesSumInSameCurrency) {
+    // Arrange
+    const Money a{100, "USD"};
+    const Money b{200, "USD"};
+
+    // Act
+    const Money result = a + b;
+
+    // Assert
+    EXPECT_EQ(result, Money(300, "USD"));
+}
+```
+
+Never merge phases. "Arrange" sets up state. "Act" calls exactly one thing. "Assert" checks outcome.
+
+## One Reason to Fail
+
+Each test checks one behaviour — one logical assertion. Multiple `EXPECT_*` are allowed only when they together verify a single concept.
+
+- Bad: a test that checks addition, subtraction, and formatting in one body
+- Good: three separate tests, each failing for a distinct reason
+
+When a test fails, the name alone must tell the reader what broke.
+
+## Test Names as Documentation
+
+Name = `Subject_Condition_ExpectedOutcome`:
+
+```
+Money_AddSameCurrency_ReturnsSummedAmount
+Money_AddDifferentCurrency_Throws
+Money_DefaultConstructed_HasZeroAmount
+Container_InsertBeyondCapacity_GrowsAutomatically
+```
+
+No `Test` prefix, no `test_` prefix — the framework already marks it as a test.
+
+## Boundary Cases Are Mandatory
+
+For every function, write tests for:
+
+| Boundary | Examples |
+|----------|---------|
+| Empty / zero | empty string, 0, empty range |
+| Minimum / maximum | `INT_MIN`, `INT_MAX`, single-element container |
+| Off-by-one | size == capacity, index == last |
+| Invalid input | null pointer, negative where positive expected |
+| Exact threshold | values at `==`, `<`, `>` of a documented limit |
+
+If the function documents a precondition, test the boundary just inside and just outside it.
+
+## Test Isolation
+
+- Tests must not share mutable state — each test starts from a clean, deterministic state
+- No global variables mutated across tests; use fixtures (setup/teardown) instead
+- No order dependency — tests must pass in any execution order
+
+## Unit Test Scope
+
+Unit tests are fast and isolated:
+
+- No network, no disk I/O, no database — mock or stub infrastructure at the boundary
+- No `sleep` or time-based waits — use injectable clocks or time abstractions
+- Each test completes in milliseconds
+
+## Do Not
+
+- Do not test private members directly — redesign if they need testing
+- Do not copy production code into tests to "validate" it — test through the public interface
+- Do not suppress or ignore failing tests — fix or explicitly skip with a documented reason
+- Do not write tests that always pass (assertion-free tests)

--- a/skills/ddd/SKILL.md
+++ b/skills/ddd/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: ddd
+version: "1.0.0"
+description: Apply when designing domain models, domain APIs, or structuring a module around a business domain
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - cpp
+    - ddd
+    - architecture
+---
+
+# Skill: Domain-Driven Design
+
+Apply when designing domain models, domain APIs, or structuring a module around a business domain.
+
+C++ mechanics → `cpp-coding`, `api-design`. This skill covers domain modelling only.
+
+Reference: Eric Evans, *Domain-Driven Design* (2003). Patterns below are the strategic and tactical core.
+
+---
+
+## Ubiquitous Language
+
+Code speaks the domain language. Developers and domain experts share the same vocabulary.
+
+- Identifiers use domain terms, not technical jargon:
+  ```cpp
+  invoice.submit(payment);   // domain term
+  dataProcessor.process(r);  // technical noise — avoid
+  ```
+- No generic suffixes unless the domain itself uses them: avoid `Manager`, `Handler`, `Processor`, `Helper`, `Util` in domain layer types
+- When a domain expert reads the code, the intent must be clear without translation
+
+---
+
+## Value Objects
+
+Defined by their value, not identity. Immutable.
+
+**Rules:**
+- Equality by value — all fields equal → objects equal
+- No identity field (no `id`)
+- Immutable — no setters; operations return new objects
+- Copyable and cheap to copy (or move)
+
+**C++ pattern:**
+```cpp
+class Money {
+public:
+    using Amount   = std::int64_t;   // in minor currency units
+    using Currency = std::string_view;
+
+    constexpr Money(Amount amount, Currency currency) noexcept;
+
+    [[nodiscard]] bool  operator==(const Money&) const noexcept = default;
+    [[nodiscard]] Money operator+(const Money& other) const;    // returns new value
+
+private:
+    Amount   amount_;
+    Currency currency_;
+};
+```
+
+Examples: `Money`, `DateRange`, `Temperature`, `EmailAddress`, `Coordinates`.
+
+---
+
+## Entities
+
+Defined by identity, not value. Mutable lifecycle.
+
+**Rules:**
+- Identity field (e.g., `Id`) determines equality — two objects with same `id` are the same entity even if other fields differ
+- Mutable state — encapsulate mutations through methods that reflect domain operations
+
+**C++ pattern:**
+```cpp
+class Order {
+public:
+    using Id = std::uint64_t;
+
+    [[nodiscard]] bool operator==(const Order& other) const noexcept { return id_ == other.id_; }
+
+    void add_line(OrderLine line);    // domain operation — not setLine
+    void submit();                    // domain operation — not setStatus(Status::Submitted)
+
+    Order(const Order&)            = delete;
+    Order& operator=(const Order&) = delete;
+
+private:
+    Id id_;
+    // ...
+};
+```
+
+---
+
+## Aggregates and Bounded Context
+
+### Aggregate
+
+A cluster of domain objects (entities + value objects) treated as a unit for consistency.
+
+**Rules:**
+- One **aggregate root** per aggregate — the only externally reachable entry point
+- External objects hold references only to the root, never to internal members
+- All mutations go through the root; the root enforces invariants
+- Small aggregates — one or a few entities per aggregate; avoid large clusters
+
+**C++ pattern:**
+```cpp
+class Order {                         // aggregate root
+public:
+    void add_line(Product, Quantity); // modifies internal OrderLine — caller never touches OrderLine directly
+    void remove_line(LineId);
+    [[nodiscard]] Money total() const;
+
+private:
+    std::vector<OrderLine> lines_;    // internal — not exposed
+};
+```
+
+### Bounded Context
+
+A module, library, or subsystem with its own model. The same word can mean different things in different contexts.
+
+**Rules:**
+- Each bounded context owns its model — do not share domain types across contexts
+- Cross-context integration uses an **anti-corruption layer** (ACL): a translation layer that maps foreign models to the local ubiquitous language
+- Bounded context boundary = module/namespace boundary in code
+
+---
+
+## Domain Services
+
+Stateless domain operations that do not naturally belong to a single entity or value object.
+
+**Rules:**
+- Stateless — no mutable members; prefer free functions or static methods
+- Named after the domain operation, not technical role:
+  ```cpp
+  Money calculate_tax(const Invoice&, const TaxPolicy&);  // domain operation
+  // not: TaxService::process(...)
+  ```
+- Accept and return domain types, not raw primitives
+- Live in the domain layer — no infrastructure dependencies (no DB, no HTTP)
+
+**C++ pattern:**
+```cpp
+// Free function — stateless domain operation
+[[nodiscard]] TransferResult transfer_funds(Account& from, Account& to, Money amount);
+```

--- a/skills/doxygen/SKILL.md
+++ b/skills/doxygen/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: doxygen
+version: "1.0.0"
+description: Apply when adding or modifying Doxygen comments on public C++ headers
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - cpp
+    - doxygen
+    - docs
+---
+
+# Skill: Doxygen
+
+Apply when adding or modifying public C++ headers.
+
+Header structure, namespace rules, `#pragma once` → `api-design` / `cpp-coding` skills.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own documentation conventions (language, placement, required tags), follow those instead. This skill is the fallback for projects that do not specify their own.
+
+## Documentation Placement
+
+The declaration must stay readable at a glance. Extensive documentation lives away from the declaration.
+
+- **Header declarations** — `@brief` only, plus the structural tags (`@tparam`, `@param`, `@return`, `@ingroup`). One short line per tag, no prose paragraphs.
+- **`.cpp` definitions** — full descriptions, invariants, complexity notes, algorithm rationale, examples, `@note` / `@warning` / `@see` blocks.
+- **Free functions and templates that have no `.cpp`** — keep the header block to `@brief` + structural tags; put extended prose into a separate companion file (`foo_doc.h` or a `@page` in the module's docs header) referenced via `@see`.
+
+A reader scanning a public header must see the signature and one-line intent without scrolling past a wall of comments.
+
+## Coverage
+
+Every public entity must have a Doxygen block:
+classes, structs, functions, type aliases, variables, enums, enum values.
+
+## Required Tags
+
+| Tag | When |
+|-----|------|
+| `@brief` | Always — one-line description |
+| `@tparam Name` | Each template parameter |
+| `@param name` | Each function parameter |
+| `@return` | Return value; omit for `void` |
+| `@ingroup GroupId` | Every entity — links to its group |
+
+Optional: `@note`, `@warning`, `@throws`, `@pre`, `@post`, `@see`.
+
+## Group System
+
+Define groups in the top-level module header or a dedicated group header:
+```cpp
+/// @defgroup MyLib_Hash Hash utilities
+/// @ingroup MyLib
+```
+
+Wrap group members:
+```cpp
+/// @{
+// ... entities with @ingroup MyLib_Hash ...
+/// @}
+```
+
+Every entity must declare `@ingroup` even when wrapped in `@{` / `@}`.
+
+## Style Rules
+
+- Language: follow the project's `AGENTS.md`
+- Document the CONTRACT, not the implementation
+- `@brief` is one line — no period at end
+- `@param` and `@tparam` descriptions: lowercase start, no period
+- Align tag columns for readability when there are multiple params
+
+## Example
+
+```cpp
+/// @defgroup MyLib_Hash Hash utilities
+/// @ingroup MyLib
+/// @{
+
+/// @brief Computes FNV-1a 64-bit hash over a byte range
+/// @ingroup MyLib_Hash
+/// @tparam Iter  input iterator over byte-sized elements
+/// @param  first begin of range
+/// @param  last  end of range
+/// @return 64-bit FNV-1a digest
+template <typename Iter>
+constexpr uint64_t fnv1a(Iter first, Iter last) noexcept;
+
+/// @}
+```
+
+## What to Skip
+
+- Private / implementation-detail entities (inside `detail/` or `namespace detail`)
+- Internal macros not part of the public API
+- Trivial getters/setters that are self-explanatory — still document, keep `@brief` minimal

--- a/skills/editing/SKILL.md
+++ b/skills/editing/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: editing
+version: "1.0.0"
+description: Apply when editing any file in the project
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - workflow
+    - editing
+---
+
+# Skill: File Editing Workflow
+
+Apply when editing any file in the project.
+
+## Re-Read Before Edit
+
+Always issue a fresh `Read` of the target file immediately before editing it — even if it was read earlier in the same session.
+
+**Why:** The user edits files directly between Claude interactions (build error fixes, manual corrections, formatting). A cached read from earlier in the session may be stale; editing from stale state overwrites user changes silently.
+
+**Rule:** One `Read` → one `Edit` block. If multiple edits to the same file are needed in one turn, read once, then apply all edits. Do not re-read between edits within the same turn.
+
+## Edit Scope
+
+- Edit only files explicitly in scope for the current task.
+- Do not touch adjacent files unless the user requested it.
+- Prefer `Edit` (diff) over `Write` (full overwrite) for existing files.

--- a/skills/hook-scripts/SKILL.md
+++ b/skills/hook-scripts/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: hook-scripts
+version: "1.0.0"
+description: Apply when writing or modifying hook scripts in hooks/ or tools/
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - hooks
+    - workflow
+---
+
+# Skill: Claude Code Hook Scripts
+
+Apply when writing or modifying hook scripts in `~/.claude/hooks/` or `~/.claude/tools/`.
+
+## Hard Rules
+
+- **Only Node.js built-ins.** No npm, no third-party `require`. Allowed: `child_process`, `fs`, `path`, `os`, `crypto`, `stream`, `util`.
+- **No shell logic.** No `bash -c`, `cmd /c`, PowerShell. Shell is only the `node -e` launcher in settings.json; all logic lives in `.js` files.
+- **No hardcoded paths.** Use `process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude')` and `path.join()` everywhere.
+
+## Architecture
+
+```
+hooks/<EventName>.js   ← dispatcher: routing only, named after Claude Code event
+tools/<action>.js      ← atomic tool: one responsibility, one action
+```
+
+Hook event names (exact, case-sensitive): `PreToolUse`, `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`, `SubagentStop`, `PreCompact`.
+
+## Dispatcher Skeleton
+
+```javascript
+'use strict';
+const { spawnSync } = require('child_process');
+const os = require('os'), path = require('path');
+const d = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+
+const DISPATCH = { ToolName: ['tool-name.js'], OtherTool: ['other-tool.js'] };
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', c => { raw += c; });
+process.stdin.on('end', () => {
+  let data; try { data = JSON.parse(raw); } catch { process.exit(0); }
+  for (const tool of DISPATCH[data.tool_name] ?? []) {
+    const r = spawnSync('node', [path.join(d, 'tools', tool)], { input: raw, encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
+    if (r.stdout?.trim()) process.stdout.write(r.stdout);
+    if (r.stderr?.trim()) process.stderr.write(r.stderr);
+    if (r.status === 2) process.exit(2);
+  }
+  process.exit(0);
+});
+```
+
+## Tool Skeleton
+
+```javascript
+'use strict';
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', c => { raw += c; });
+process.stdin.on('end', () => {
+  let data; try { data = JSON.parse(raw); } catch { process.exit(0); }
+  const command  = data.tool_input?.command ?? '';
+  const filePath = data.tool_input?.file_path ?? data.tool_input?.path ?? '';
+  const content  = data.tool_input?.new_string ?? data.tool_input?.content ?? '';
+  // ... logic ...
+  process.exit(0);
+});
+```
+
+## Exit Codes
+
+| Code | Meaning | Channel |
+|------|---------|---------|
+| `0` | Allow / warning | stdout → Claude sees it |
+| `2` | Deny / block | stderr → shown to user |
+
+Never use `1` — unpredictable behavior.
+
+## Hook JSON Fields
+
+```
+tool_name:  'Edit' | 'Write' | 'Bash' | 'Read' | ...
+tool_input: { file_path, old_string, new_string }  // Edit
+            { file_path, content }                  // Write
+            { command }                             // Bash
+```
+
+## PATH Resolution
+
+```javascript
+function findTool(name) {
+  // --version works for most CLI tools; if a tool uses different flags,
+  // check r.error?.code === 'ENOENT' only — ignore non-zero exit status.
+  const r = require('child_process').spawnSync(name, ['--version'], { stdio: 'pipe', timeout: 5000 });
+  return r.error?.code === 'ENOENT' ? null : name;
+}
+// If null → stderr.write warning + exit(0)
+```
+
+No `where.exe`, no `which`. Node.js `spawnSync` searches PATH on all platforms.
+
+## settings.json Registration
+
+```json
+"PreToolUse": [{
+  "hooks": [{
+    "type": "command",
+    "command": "node -e \"const{spawnSync}=require('child_process'),p=require('path'),o=require('os'),d=process.env.CLAUDE_CONFIG_DIR||p.join(o.homedir(),'.claude');spawnSync('node',[p.join(d,'hooks','PreToolUse.js')],{stdio:'inherit',timeout:5000})\"",
+    "timeout": 5
+  }]
+}]
+```
+
+Filename must match the event name exactly (`PreToolUse.js`, `PostToolUse.js`, etc.).
+`"timeout"` in settings.json = seconds (Claude Code). `timeout` in `spawnSync` = milliseconds (Node.js).
+For `PostToolUse` use `timeout: 30` / `timeout:30000`, `Stop` use `timeout: 10` / `timeout:10000`.
+`stdio:'inherit'` forwards Claude Code's stdin pipe to the hook process — verified working.
+For project-level: `"command": "node .claude/hooks/PreToolUse.js"` (relative path, no launcher needed).
+
+Scripts are portable global↔project without changes — only the command path differs.
+
+## Useful Patterns
+
+**Extension filter:**
+```javascript
+const CPP_EXTS = new Set(['.h', '.hpp', '.cpp', '.cc', '.cxx']);
+if (!CPP_EXTS.has(path.extname(filePath).toLowerCase())) process.exit(0);
+```
+
+**Skip if project overrides global:**
+```javascript
+// ProjectHookName.js — name of the project-level hook file that overrides this global one
+if (require('fs').existsSync(path.join(process.cwd(), '.claude', 'hooks', 'ProjectHookName.js'))) process.exit(0);
+```
+
+**Test without shell quoting issues:**
+```javascript
+const r = spawnSync('node', [path.join(toolsDir, 'my-tool.js')], {
+  input: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } }),
+  encoding: 'utf8', stdio: 'pipe',
+});
+console.log(`exit=${r.status}`, r.stdout?.trim(), r.stderr?.trim());
+```

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pr-rules
+version: "1.0.0"
+description: Apply when opening, reviewing, or preparing a PR/MR
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - git
+    - pr
+---
+
+# Skill: Pull Request Rules
+
+Apply when opening, reviewing, or preparing a PR/MR.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own PR conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## PR Title
+
+Conventional Commits format, uppercase first letter, ≤ 120 characters:
+
+```
+Feat(hash): add SipHash-2-4 keyed 64-bit hash
+Fix(wrapper): correct noexcept propagation through executor chain
+```
+
+---
+
+## Description Structure
+
+```markdown
+## Summary
+- What changed and why (user-visible perspective, not implementation details)
+- One bullet per logical change
+
+## Implementation
+- What was changed and how (technical perspective)
+- Why this approach over alternatives
+
+## Test plan
+- What was tested and how
+- Edge cases covered
+- How a reviewer can verify the change locally
+```
+
+All three sections are required. A PR with no test plan is not ready to review.
+
+---
+
+## Pre-Open Checklist
+
+- [ ] CI green on all targets declared in the project
+- [ ] `CHANGELOG.md` updated — every user-visible change documented
+- [ ] `git submodule status` — no `+` prefix on any module
+- [ ] Every commit in the branch builds independently (no broken intermediate state)
+- [ ] Commit trailers conform to `commit-rules` skill
+- [ ] Branch is rebased onto the current target branch (no stale merge base)
+
+---
+
+## Merge Strategy
+
+**Rebase, then merge with `--no-ff`** — explicit merge commit per topic; linear first-parent history on protected branches.
+
+### Rules
+
+1. **Rebase before merge.** `git rebase <target>` first; merge only when the branch sits on the current target tip.
+2. **`--no-ff` only.** No fast-forward merge. No squash merge.
+3. **Merge subject:** `Merge PR #<pr-number>: <pr subject>` — copy the PR subject verbatim. Do not re-prefix with `type(scope):` (the PR title already carries it; re-prefixing duplicates the type in the merged log).
+4. **Merge subject length:** ≤ 120 characters (same limit as PR title; supersedes the 72-char rule in `commit-rules` for merge commits only).
+5. **Merge body required** — same rule as ordinary commits (`commit-rules`). Body explains what was integrated and why; never empty.
+6. **Trailers:** same ban as `commit-rules` — no AI-attribution. `Co-authored-by` injected by GitHub when committer differs from author is allowed.
+7. **Cleanup before opening the PR.** Squash fixups via `git commit --fixup=<hash>` + `git rebase -i --autosquash` (per `commit-rules`). Never at merge time.
+8. **Rewrite squashed commit bodies** to reflect the final state (see `commit-rules`).
+
+### Rationale
+
+- `--no-ff` keeps the topic boundary visible. `git log --first-parent <branch>` on a protected branch shows one entry per integrated PR.
+- Rebase before merge ensures no interleaved history under the merge commit.
+- Protected branches — the canonical set is defined and enforced by `hooks/git/pre-commit`. Feature branches commit freely.
+
+### GitHub equivalent
+
+```
+gh pr merge <n> --merge -t "<subject>" -b "<body>" --delete-branch
+```
+
+### Repo settings prerequisites
+
+- "Allow merge commits" — ON
+- "Require linear history" — OFF (blocks `--no-ff`)
+
+---
+
+## PR Size
+
+One logical change per PR. Do not mix:
+
+- Feature + refactoring
+- Bug fix + unrelated cleanup
+- Multiple unrelated features
+
+If a PR touches too many things, split it. A PR that cannot be summarised in one sentence is too large.

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: release
+version: "1.0.0"
+description: Apply when preparing a release, bumping version, or tagging
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - git
+    - release
+    - semver
+---
+
+# Skill: Release Preparation
+
+Apply when user says "release", "bump version", "prepare release", or "tag".
+Project `AGENTS.md` specifies which files contain version strings.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own release process, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+## Step 1 — Decide Version (semver)
+
+| Bump | When |
+|------|------|
+| `MAJOR` (X) | Breaking public API change |
+| `MINOR` (Y) | New backwards-compatible functionality |
+| `PATCH` (Z) | Backwards-compatible bug fix |
+
+Version string format: `X.Y.Z` (no `v` prefix in files).
+Git tag format: `vX.Y.Z`.
+
+## Step 2 — Update CHANGELOG.md
+
+See `changelog` skill for format details.
+
+1. Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` (today's date, ISO 8601)
+2. Ensure all notable changes since last release are documented
+
+## Step 3 — Bump Version Strings
+
+Find all occurrences of old version (substitute actual version number, e.g. `1.2.3`):
+```bash
+git grep -F "1.2.3"
+```
+
+Update in every location the project declares (check `AGENTS.md` for the list).
+Typical locations: `CMakeLists.txt`, `Doxyfile` (`PROJECT_NUMBER`), `README.md` badges.
+
+Verify nothing remains:
+```bash
+git grep -F "1.2.3"   # must return empty
+```
+
+## Step 4 — Verify
+
+- [ ] Build passes on all compilers declared in project (check AGENTS.md)
+- [ ] All tests pass
+- [ ] No breaking API change without `MAJOR` bump
+- [ ] `CHANGELOG.md` covers all changes since last release
+
+## Step 5 — Commit and Tag
+
+```bash
+git add CHANGELOG.md <version-files>
+git commit -m "chore(release): bump version to X.Y.Z"
+git tag vX.Y.Z
+git push
+git push --tags    # separate push — triggers CI release workflow
+```
+
+## Step 6 — Submodule Root Update (if applicable)
+
+If this library is a submodule in a root repo:
+1. After pushing the tag, update the submodule ref in root
+2. See `submodule-sync` skill for the exact workflow
+
+## Pre-Release Checklist
+
+- [ ] `CHANGELOG.md` updated — `[Unreleased]` renamed, new section added
+- [ ] Version string consistent across **all** version files (grep confirms)
+- [ ] CI green on all compiler targets
+- [ ] Submodule ref updated in root repo (if applicable)
+- [ ] Commit trailers conform to `commit-rules` skill

--- a/skills/submodule-sync/SKILL.md
+++ b/skills/submodule-sync/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: submodule-sync
+version: "1.0.0"
+description: Apply when syncing git submodules or working across submodule boundaries
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - git
+    - submodules
+---
+
+# Skill: Submodule Sync
+
+Apply before root repo commits, before PR, before release, when working across submodules.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own submodule workflow, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+## Core Concept
+
+Root repo records a specific commit SHA for each submodule.
+`git submodule status` prefix meanings:
+- ` ` (space) — ref matches what root records ✓
+- `+` — submodule is ahead of what root records (needs `git add`)
+- `-` — submodule not initialized
+- `U` — merge conflict
+
+## Correct Workflow
+
+```
+# 1. Commit changes inside the module repo
+cd module/foo
+git add <changed-files>
+git commit -m "feat: ..."
+
+# 2. Back in root — record the new submodule ref
+cd ../..
+git add module/foo
+git status   # should show "modified: module/foo (new commits)"
+git commit -m "chore: update module/foo ref"
+```
+
+## Pre-PR / Pre-Release Check
+
+```bash
+git submodule status          # no '+' prefix allowed
+git submodule foreach git status  # all modules clean
+```
+
+## Common Operations
+
+```bash
+# Pull latest remote module state into root
+git submodule update --remote module/foo
+
+# Initialize all submodules after clone
+git submodule update --init --recursive
+
+# Check which commit each submodule is at
+git submodule status
+```
+
+## Rules
+
+- Never record a root ref pointing to an uncommitted module state
+- Submodule changes and root ref update are separate commits
+- Always verify `git submodule status` before opening a PR

--- a/templates/SKILL.md
+++ b/templates/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: <kebab-case-name>
+version: "1.0.0"
+description: <one-line description of when to use this skill>
+license: <license identifier, e.g. MIT>
+metadata:
+  author: <author or team name>
+  tags:
+    - <primary-tag>
+    - <secondary-tag>
+---
+
+# Skill: <Name>
+
+Apply when <trigger condition — one line, specific, actionable>.
+
+<!-- Cross-references: list related skills that cover adjacent concerns.
+     Include when this skill intentionally omits something covered elsewhere. -->
+<!-- <Adjacent concern> → `<skill-name>` skill. -->
+
+<!-- External reference (optional): authoritative source this skill is based on. -->
+<!-- Reference: <Author>, *<Title>* (<Year>). -->
+
+---
+
+## <Primary Section>
+
+<!-- Lead with the most important rules. Use bullet lists for rules,
+     tables for mappings, fenced code blocks for examples. -->
+
+- **<Rule>** — explanation of why
+
+```cpp
+// example
+```
+
+---
+
+## <Secondary Section>
+
+<!-- Add sections as needed. Common section names:
+     Rules, Format, Structure, What to Test, Architecture,
+     Hard Rules, Coverage, Types, Workflow, Examples -->
+
+<!-- Guidelines for section content:
+     - Rules: short, imperative, bold the key term
+     - Tables: use for type→when or tag→purpose mappings
+     - Code: show the correct pattern; optionally pair with wrong pattern
+     - No section needed for obvious things — only what surprises or is missed -->
+
+---
+
+## Cross-References
+
+<!-- List skills that should be consulted alongside this one.
+     Omit section if there are no meaningful cross-references. -->
+
+- `<skill-name>` — <what it covers that this skill does not>

--- a/test/bash-safety.test.js
+++ b/test/bash-safety.test.js
@@ -1,0 +1,98 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { check } = require('../tools/bash-safety');
+
+test('blocks rm -rf /', () => {
+  assert.strictEqual(check('rm -rf /').action, 'block');
+});
+
+test('blocks rm -fr /', () => {
+  assert.strictEqual(check('rm -fr /').action, 'block');
+});
+
+test('blocks rm -Rf /', () => {
+  assert.strictEqual(check('rm -Rf /').action, 'block');
+});
+
+test('blocks rm -rfv ~/', () => {
+  assert.strictEqual(check('rm -rfv ~/').action, 'block');
+});
+
+test('blocks rm -rf $HOME/', () => {
+  assert.strictEqual(check('rm -rf $HOME/').action, 'block');
+});
+
+test('blocks rmdir /s /q C:\\', () => {
+  assert.strictEqual(check('rmdir /s /q C:\\').action, 'block');
+});
+
+test('blocks format C:', () => {
+  assert.strictEqual(check('format C:').action, 'block');
+});
+
+test('blocks sudo rm -rf /', () => {
+  assert.strictEqual(check('sudo rm -rf /').action, 'block');
+});
+
+test('blocks rm -rf "$HOME" (quoted, no trailing slash)', () => {
+  assert.strictEqual(check('rm -rf "$HOME"').action, 'block');
+});
+
+test('blocks rm -rf $HOME (no trailing slash, unquoted)', () => {
+  assert.strictEqual(check('rm -rf $HOME').action, 'block');
+});
+
+test('warns on DEL /Q /S reversed order', () => {
+  assert.strictEqual(check('DEL /Q /S foo').action, 'warn');
+});
+
+test('warns on DEL /S /Q uppercase', () => {
+  assert.strictEqual(check('DEL /S /Q foo').action, 'warn');
+});
+
+test('warns on rm -r foo/', () => {
+  assert.strictEqual(check('rm -r foo/').action, 'warn');
+});
+
+test('warns on rm -fr foo (recursive but not root)', () => {
+  assert.strictEqual(check('rm -fr foo').action, 'warn');
+});
+
+test('warns on git push --force', () => {
+  const r = check('git push --force origin main');
+  assert.strictEqual(r.action, 'warn');
+  assert.ok(r.warnings.some(w => /--force/.test(w.msg)));
+});
+
+test('warns on git push -f', () => {
+  assert.strictEqual(check('git push -f origin main').action, 'warn');
+});
+
+test('warns on git reset --hard', () => {
+  assert.strictEqual(check('git reset --hard HEAD').action, 'warn');
+});
+
+test('warns on git clean -fd', () => {
+  assert.strictEqual(check('git clean -fd').action, 'warn');
+});
+
+test('warns on DROP TABLE', () => {
+  assert.strictEqual(check('DROP TABLE users').action, 'warn');
+});
+
+test('warns on Remove-Item -Recurse -Force', () => {
+  assert.strictEqual(check('Remove-Item -Recurse -Force foo').action, 'warn');
+});
+
+test('passes safe rm', () => {
+  assert.strictEqual(check('rm foo.txt').action, 'pass');
+});
+
+test('passes git status', () => {
+  assert.strictEqual(check('git status').action, 'pass');
+});
+
+test('passes ls -la', () => {
+  assert.strictEqual(check('ls -la').action, 'pass');
+});

--- a/test/install-uninstall.test.js
+++ b/test/install-uninstall.test.js
@@ -1,0 +1,175 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoDir = path.resolve(__dirname, '..');
+const installJs = path.join(repoDir, 'install.js');
+const uninstallJs = path.join(repoDir, 'uninstall.js');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'claude-config-test-'));
+}
+
+function rmTmp(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+function runInstall(dir, extraArgs = []) {
+  const r = spawnSync('node', [installJs, '--no-git-hook', ...extraArgs], {
+    cwd: repoDir,
+    env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    encoding: 'utf8',
+  });
+  return r;
+}
+
+function runUninstall(dir, extraArgs = []) {
+  const r = spawnSync('node', [uninstallJs, ...extraArgs], {
+    cwd: repoDir,
+    env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    encoding: 'utf8',
+  });
+  return r;
+}
+
+test('install creates files and manifest on empty dir', () => {
+  const dir = mkTmp();
+  try {
+    const r = runInstall(dir);
+    assert.strictEqual(r.status, 0, `install failed: ${r.stderr}`);
+    assert.ok(fs.existsSync(path.join(dir, '.claude-config-manifest.json')));
+    assert.ok(fs.existsSync(path.join(dir, 'hooks', 'PreToolUse.js')));
+    assert.ok(fs.existsSync(path.join(dir, 'tools', 'bash-safety.js')));
+    assert.ok(fs.existsSync(path.join(dir, 'skills', 'cpp-coding', 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(dir, 'settings.json')));
+    assert.ok(fs.existsSync(path.join(dir, 'CLAUDE.md')));
+  } finally { rmTmp(dir); }
+});
+
+test('uninstall removes everything when nothing was preexisting', () => {
+  const dir = mkTmp();
+  try {
+    const ri = runInstall(dir);
+    assert.strictEqual(ri.status, 0, ri.stderr);
+    const ru = runUninstall(dir);
+    assert.strictEqual(ru.status, 0, ru.stderr);
+    const remaining = fs.readdirSync(dir);
+    assert.deepStrictEqual(remaining, [], `expected empty dir, got: ${remaining.join(', ')}`);
+  } finally { rmTmp(dir); }
+});
+
+test('install+uninstall restores preexisting settings.json byte-for-byte', () => {
+  const dir = mkTmp();
+  try {
+    const settingsPath = path.join(dir, 'settings.json');
+    const original = {
+      permissions: { allow: ['Bash(ls)'], deny: ['Bash(rm -rf /)'] },
+      customField: 'preserved',
+      hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: 'user-hook' }] }] },
+    };
+    const originalText = JSON.stringify(original, null, 2);
+    fs.writeFileSync(settingsPath, originalText);
+
+    const ri = runInstall(dir);
+    assert.strictEqual(ri.status, 0, ri.stderr);
+
+    const merged = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.ok(merged.permissions.allow.includes('Bash(ls)'), 'preserved user allow');
+    assert.ok(merged.customField === 'preserved', 'preserved unknown field');
+    assert.ok(merged.hooks.PreToolUse.length >= 2, 'merged hook entries');
+
+    const ru = runUninstall(dir);
+    assert.strictEqual(ru.status, 0, ru.stderr);
+
+    const restoredText = fs.readFileSync(settingsPath, 'utf8');
+    assert.strictEqual(restoredText, originalText, 'settings.json restored byte-for-byte');
+  } finally { rmTmp(dir); }
+});
+
+test('install merges hooks into a partial settings.json missing some events', () => {
+  const dir = mkTmp();
+  try {
+    const settingsPath = path.join(dir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({ permissions: { allow: ['Bash(ls)'] } }, null, 2));
+
+    const ri = runInstall(dir);
+    assert.strictEqual(ri.status, 0, ri.stderr);
+
+    const merged = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.ok(merged.hooks?.PreToolUse?.length >= 1, 'PreToolUse added');
+    assert.ok(merged.hooks?.PostToolUse?.length >= 1, 'PostToolUse added');
+    assert.ok(merged.hooks?.Stop?.length >= 1, 'Stop added');
+    assert.ok(merged.hooks?.UserPromptSubmit?.length >= 1, 'UserPromptSubmit added');
+    assert.ok(merged.permissions.allow.includes('Bash(ls)'), 'user allow preserved');
+    assert.ok(merged.permissions.ask?.some(p => p.includes('git push')), 'repo ask permissions merged');
+  } finally { rmTmp(dir); }
+});
+
+test('install+uninstall restores preexisting CLAUDE.md', () => {
+  const dir = mkTmp();
+  try {
+    const claudeMdPath = path.join(dir, 'CLAUDE.md');
+    const original = '# User CLAUDE.md\n\nCustom rules.\n';
+    fs.writeFileSync(claudeMdPath, original);
+
+    runInstall(dir);
+    assert.notStrictEqual(fs.readFileSync(claudeMdPath, 'utf8'), original, 'install overwrites with backup');
+
+    runUninstall(dir);
+    assert.strictEqual(fs.readFileSync(claudeMdPath, 'utf8'), original, 'CLAUDE.md restored');
+  } finally { rmTmp(dir); }
+});
+
+test('install preserves user defaultMode when repo settings has none', () => {
+  const dir = mkTmp();
+  try {
+    const settingsPath = path.join(dir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({ permissions: { defaultMode: 'acceptEdits' } }));
+
+    runInstall(dir);
+    const merged = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.strictEqual(merged.permissions.defaultMode, 'acceptEdits', 'user defaultMode preserved');
+  } finally { rmTmp(dir); }
+});
+
+test('reinstall does not double-backup', () => {
+  const dir = mkTmp();
+  try {
+    const settingsPath = path.join(dir, 'settings.json');
+    const original = JSON.stringify({ permissions: { allow: ['Bash(echo)'] } }, null, 2);
+    fs.writeFileSync(settingsPath, original);
+
+    runInstall(dir);
+    runInstall(dir);
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(dir, '.claude-config-manifest.json'), 'utf8'));
+    const settingsBackups = manifest.backups.filter(b => b.dest === settingsPath);
+    assert.strictEqual(settingsBackups.length, 1, 'only one backup for settings.json across reinstalls');
+
+    runUninstall(dir);
+    assert.strictEqual(fs.readFileSync(settingsPath, 'utf8'), original, 'restored original after double install');
+  } finally { rmTmp(dir); }
+});
+
+test('dry-run does not write files', () => {
+  const dir = mkTmp();
+  try {
+    const r = runInstall(dir, ['--dry-run']);
+    assert.strictEqual(r.status, 0, r.stderr);
+    assert.ok(!fs.existsSync(path.join(dir, 'hooks', 'PreToolUse.js')));
+    assert.ok(!fs.existsSync(path.join(dir, '.claude-config-manifest.json')));
+  } finally { rmTmp(dir); }
+});
+
+test('uninstall on dir with no manifest is a no-op', () => {
+  const dir = mkTmp();
+  try {
+    const r = runUninstall(dir);
+    assert.strictEqual(r.status, 0);
+    assert.deepStrictEqual(fs.readdirSync(dir), []);
+  } finally { rmTmp(dir); }
+});

--- a/test/secret-guard.test.js
+++ b/test/secret-guard.test.js
@@ -1,0 +1,82 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { check } = require('../tools/secret-guard');
+
+test('blocks RSA private key', () => {
+  const r = check('-----BEGIN RSA PRIVATE KEY-----\nMII...\n-----END RSA PRIVATE KEY-----', 'key.pem');
+  assert.strictEqual(r.action, 'block');
+});
+
+test('blocks OpenSSH private key', () => {
+  const r = check('-----BEGIN OPENSSH PRIVATE KEY-----', 'id_rsa');
+  assert.strictEqual(r.action, 'block');
+});
+
+test('blocks ED25519 private key', () => {
+  assert.strictEqual(check('-----BEGIN ED25519 PRIVATE KEY-----', 'id_ed25519').action, 'block');
+});
+
+test('blocks DSA private key', () => {
+  assert.strictEqual(check('-----BEGIN DSA PRIVATE KEY-----', 'id_dsa').action, 'block');
+});
+
+test('blocks PGP private key block', () => {
+  assert.strictEqual(check('-----BEGIN PGP PRIVATE KEY BLOCK-----', 'secret.asc').action, 'block');
+});
+
+test('blocks AWS Access Key', () => {
+  assert.strictEqual(check('AKIAIOSFODNN7EXAMPLE', 'config.js').action, 'block');
+});
+
+test('blocks GitHub PAT ghp_', () => {
+  assert.strictEqual(check('token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"', 'cfg').action, 'block');
+});
+
+test('blocks GitHub PAT ghs_', () => {
+  assert.strictEqual(check('token = "ghs_abcdefghijklmnopqrstuvwxyz0123456789"', 'cfg').action, 'block');
+});
+
+test('blocks GitHub PAT ghu_ (user)', () => {
+  assert.strictEqual(check('token = "ghu_abcdefghijklmnopqrstuvwxyz0123456789"', 'cfg').action, 'block');
+});
+
+test('blocks GitHub PAT gho_ (OAuth)', () => {
+  assert.strictEqual(check('token = "gho_abcdefghijklmnopqrstuvwxyz0123456789"', 'cfg').action, 'block');
+});
+
+test('blocks GitHub PAT ghr_ (refresh)', () => {
+  assert.strictEqual(check('token = "ghr_abcdefghijklmnopqrstuvwxyz0123456789"', 'cfg').action, 'block');
+});
+
+test('blocks GitHub fine-grained PAT', () => {
+  const pat = 'github_pat_' + 'A'.repeat(82);
+  assert.strictEqual(check(`token = "${pat}"`, 'cfg').action, 'block');
+});
+
+test('skips binary by extension', () => {
+  assert.strictEqual(check('-----BEGIN RSA PRIVATE KEY-----', 'image.png').action, 'pass');
+});
+
+test('warns on api_key assignment', () => {
+  const r = check('api_key = "abcdefghijklmnopqrstuvwxyz123"', 'cfg.js');
+  assert.strictEqual(r.action, 'warn');
+});
+
+test('warns on Bearer token', () => {
+  const r = check('Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456', 'cfg');
+  assert.strictEqual(r.action, 'warn');
+});
+
+test('warns on JWT', () => {
+  const jwt = 'eyJ' + 'A'.repeat(30) + '.' + 'B'.repeat(30) + '.' + 'C'.repeat(30);
+  assert.strictEqual(check(`token=${jwt}`, 'cfg').action, 'warn');
+});
+
+test('passes empty content', () => {
+  assert.strictEqual(check('', 'cfg').action, 'pass');
+});
+
+test('passes innocuous text', () => {
+  assert.strictEqual(check('hello world', 'cfg').action, 'pass');
+});

--- a/test/stop-notify.test.js
+++ b/test/stop-notify.test.js
@@ -1,0 +1,36 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { escPS, escAS } = require('../tools/stop-notify');
+
+test('escPS escapes single quote', () => {
+  assert.strictEqual(escPS("it's done"), "it''s done");
+});
+
+test('escPS leaves safe text alone', () => {
+  assert.strictEqual(escPS('hello'), 'hello');
+});
+
+test('escPS escapes multiple quotes', () => {
+  assert.strictEqual(escPS("'a'b'"), "''a''b''");
+});
+
+test('escPS coerces non-string', () => {
+  assert.strictEqual(escPS(42), '42');
+});
+
+test('escAS escapes backslash', () => {
+  assert.strictEqual(escAS('C:\\path'), 'C:\\\\path');
+});
+
+test('escAS escapes double quote', () => {
+  assert.strictEqual(escAS('say "hi"'), 'say \\"hi\\"');
+});
+
+test('escAS escapes backslash before quote', () => {
+  assert.strictEqual(escAS('\\"'), '\\\\\\"');
+});
+
+test('escAS leaves safe text alone', () => {
+  assert.strictEqual(escAS('hello'), 'hello');
+});

--- a/tools/bash-safety.js
+++ b/tools/bash-safety.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const BLOCK = [
+  { re: /(?:sudo\s+)?rm\s+-(?=[a-zA-Z]*r)(?=[a-zA-Z]*f)[a-zA-Z]+\s+["']?(\/|~\/?|\$HOME\/?|%USERPROFILE%\\?)["']?(\s|$)/i, msg: 'rm -rf on root/home — destroys filesystem' },
+  { re: /rmdir\s+\/s\s+\/q\s+[a-zA-Z]:\\/i, msg: 'rmdir /s /q on drive root' },
+  { re: /format\s+[a-zA-Z]:/i, msg: 'disk format command' },
+];
+
+const WARN = [
+  { re: /git\s+push\b.*(?:--force\b|\s-f\b)/i, msg: 'git push --force/-f — overwrites remote history' },
+  { re: /git\s+reset\s+--hard\b/i, msg: 'git reset --hard — discards uncommitted work' },
+  { re: /git\s+checkout\s+--\s*\./i, msg: 'git checkout -- . — discards all working tree changes' },
+  { re: /git\s+clean\s+-[a-zA-Z]*f/i, msg: 'git clean -f — deletes untracked files' },
+  { re: /\bDROP\s+TABLE\b/i, msg: 'DROP TABLE — irreversible database operation' },
+  { re: /\bDROP\s+DATABASE\b/i, msg: 'DROP DATABASE — irreversible database operation' },
+  { re: /\bTRUNCATE\s+TABLE\b/i, msg: 'TRUNCATE TABLE — deletes all rows' },
+  { re: /(?:sudo\s+)?rm\s+-(?=[a-zA-Z]*r)[a-zA-Z]+\b/i, msg: 'rm -r — recursive delete, verify target' },
+  { re: /\bdel\s+(?:\/[sq]\s+){2}/i, msg: 'del /s /q — mass file deletion' },
+  { re: /Remove-Item\s+-Recurse\s+-Force\b/i, msg: 'Remove-Item -Recurse -Force — mass deletion' },
+];
+
+function check(cmd) {
+  for (const { re, msg } of BLOCK) if (re.test(cmd)) return { action: 'block', msg };
+  const warnings = WARN.filter(({ re }) => re.test(cmd));
+  return { action: warnings.length ? 'warn' : 'pass', warnings };
+}
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+    const cmd = data.tool_input?.command ?? '';
+    if (!cmd) process.exit(0);
+
+    const r = check(cmd);
+    if (r.action === 'block') {
+      process.stderr.write(`Blocked: ${r.msg}\nCommand: ${cmd.slice(0, 200)}\n`);
+      process.exit(2);
+    }
+    if (r.action === 'warn') {
+      process.stdout.write(
+        'bash-safety warning — destructive command detected:\n' +
+        r.warnings.map(w => `  • ${w.msg}`).join('\n') +
+        `\nCommand: ${cmd.slice(0, 200)}\n`
+      );
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { BLOCK, WARN, check };

--- a/tools/clang-format.js
+++ b/tools/clang-format.js
@@ -1,0 +1,20 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+
+function hasTool(name) {
+  const r = spawnSync(name, ['--version'], { stdio: 'pipe', timeout: 5000 });
+  return !r.error && r.status === 0;
+}
+
+const file = process.argv[2];
+if (!file || !fs.existsSync(file)) process.exit(0);
+
+if (!hasTool('clang-format')) {
+  process.stderr.write('Warning: clang-format not found in PATH, skipping\n');
+  process.exit(0);
+}
+
+const r = spawnSync('clang-format', ['-i', file], { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
+if (r.stdout) process.stdout.write(r.stdout);
+if (r.stderr) process.stderr.write(r.stderr);

--- a/tools/clang-tidy.js
+++ b/tools/clang-tidy.js
@@ -1,0 +1,36 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function hasTool(name) {
+  const r = spawnSync(name, ['--version'], { stdio: 'pipe', timeout: 5000 });
+  return !r.error && r.status === 0;
+}
+
+function findCompileCommands(startDir) {
+  let dir = startDir;
+  while (true) {
+    if (fs.existsSync(path.join(dir, 'compile_commands.json'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+const file = process.argv[2];
+if (!file || !fs.existsSync(file)) process.exit(0);
+
+if (!hasTool('clang-tidy')) {
+  process.stderr.write('Warning: clang-tidy not found in PATH, skipping\n');
+  process.exit(0);
+}
+
+const compileDir = findCompileCommands(path.dirname(path.resolve(file)));
+const args = compileDir
+  ? ['-p', compileDir, file]
+  : [file, '--', '-std=c++20'];
+
+const r = spawnSync('clang-tidy', args, { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
+if (r.stdout) process.stdout.write(r.stdout);
+if (r.stderr) process.stderr.write(r.stderr);

--- a/tools/cppcheck.js
+++ b/tools/cppcheck.js
@@ -1,0 +1,27 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+
+function hasTool(name) {
+  const r = spawnSync(name, ['--version'], { stdio: 'pipe', timeout: 5000 });
+  return !r.error && r.status === 0;
+}
+
+const file = process.argv[2];
+if (!file || !fs.existsSync(file)) process.exit(0);
+
+if (!hasTool('cppcheck')) {
+  process.stderr.write('Warning: cppcheck not found in PATH, skipping\n');
+  process.exit(0);
+}
+
+const args = [
+  '--enable=warning,style,performance,portability',
+  '--inline-suppr',
+  '--quiet',
+  file,
+];
+
+const r = spawnSync('cppcheck', args, { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
+if (r.stdout) process.stdout.write(r.stdout);
+if (r.stderr) process.stderr.write(r.stderr);

--- a/tools/secret-guard.js
+++ b/tools/secret-guard.js
@@ -1,0 +1,63 @@
+'use strict';
+const path = require('path');
+
+const BINARY_EXTS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.ico', '.bmp', '.webp',
+  '.exe', '.dll', '.so', '.dylib', '.bin', '.obj', '.o', '.a', '.lib',
+  '.zip', '.tar', '.gz', '.7z', '.rar', '.pdf',
+]);
+
+const BLOCK = [
+  { name: 'Private Key',  re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |ED25519 |PGP )?PRIVATE KEY(?: BLOCK)?-----/ },
+  { name: 'AWS Access Key', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'GitHub PAT',   re: /\bgh[psuor]_[A-Za-z0-9]{36}\b|\bgithub_pat_[A-Za-z0-9_]{82}\b/ },
+];
+
+const WARN = [
+  { name: 'Generic API key assignment', re: /(?:api[_-]?key|apikey|secret[_-]?key)\s*[:=]\s*['"`]([A-Za-z0-9+/\-_]{20,})['"`]/ },
+  { name: 'Password assignment',        re: /(?<![a-zA-Z])(?:password|passwd)\s*[:=]\s*['"`][^'"`\s]{6,}['"`]/ },
+  { name: 'Bearer token',              re: /Bearer\s+[A-Za-z0-9\-._~+/]{30,}/ },
+  { name: 'JWT token',                 re: /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/ },
+];
+
+function check(content, filePath) {
+  if (filePath && BINARY_EXTS.has(path.extname(filePath).toLowerCase())) return { action: 'pass' };
+  if (!content) return { action: 'pass' };
+  for (const { name, re } of BLOCK) if (re.test(content)) return { action: 'block', name };
+  const warnings = WARN.filter(({ re }) => re.test(content));
+  return { action: warnings.length ? 'warn' : 'pass', warnings };
+}
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+    const filePath = data.tool_input?.file_path ?? data.tool_input?.path ?? '';
+    const content = data.tool_input?.new_string ?? data.tool_input?.content ?? '';
+
+    const r = check(content, filePath);
+    if (r.action === 'block') {
+      process.stderr.write(
+        `Blocked: possible secret in file content — ${r.name}\n` +
+        `File: ${filePath || '(unknown)'}\n` +
+        `Use env vars or a secrets manager instead of hardcoded values.\n`
+      );
+      process.exit(2);
+    }
+    if (r.action === 'warn') {
+      process.stdout.write(
+        'secret-guard warning — possible credentials in file content:\n' +
+        r.warnings.map(w => `  • ${w.name}`).join('\n') +
+        `\nFile: ${filePath || '(unknown)'}\n` +
+        `Verify these are not real secrets before committing.\n`
+      );
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { BINARY_EXTS, BLOCK, WARN, check };

--- a/tools/skills-reminder.js
+++ b/tools/skills-reminder.js
@@ -1,0 +1,18 @@
+'use strict';
+let input = '';
+process.stdin.on('data', c => { input += c; });
+process.stdin.on('end', () => {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext:
+        "SKILLS — apply before matching work:\n" +
+        "cpp-coding: C++ impl | api-design: public API/headers | " +
+        "doxygen: Doxygen on public headers | ddd: domain models | " +
+        "commit-rules: commit messages | pr-rules: PR open/review | " +
+        "changelog: CHANGELOG.md | release: version bump/tag | " +
+        "hook-scripts: hooks/ or tools/ | editing: any file edit | " +
+        "submodule-sync: submodules"
+    }
+  }));
+});

--- a/tools/stop-notify.js
+++ b/tools/stop-notify.js
@@ -1,0 +1,40 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const os = require('os');
+
+function escPS(s) { return String(s).replace(/'/g, "''"); }
+function escAS(s) { return String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"'); }
+
+function notifyWindows(title, message) {
+  const t = escPS(title);
+  const m = escPS(message);
+  const script = [
+    'Add-Type -AssemblyName System.Windows.Forms',
+    '$n = New-Object System.Windows.Forms.NotifyIcon',
+    '$n.Icon = [System.Drawing.SystemIcons]::Information',
+    '$n.Visible = $true',
+    `$n.ShowBalloonTip(4000, '${t}', '${m}', [System.Windows.Forms.ToolTipIcon]::Info)`,
+    'Start-Sleep -Milliseconds 500',
+    '$n.Dispose()',
+  ].join('; ');
+  spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden', '-Command', script], { stdio: 'pipe', timeout: 5000 });
+}
+
+function notifyMac(title, message) {
+  const t = escAS(title);
+  const m = escAS(message);
+  spawnSync('osascript', ['-e', `display notification "${m}" with title "${t}"`], { stdio: 'pipe', timeout: 5000 });
+}
+
+function notifyLinux(title, message) {
+  spawnSync('notify-send', ['--', title, message], { stdio: 'pipe', timeout: 5000 });
+}
+
+const NOTIFIERS = { win32: notifyWindows, darwin: notifyMac };
+
+if (require.main === module) {
+  const notify = NOTIFIERS[os.platform()] || notifyLinux;
+  notify('Claude Code', 'Task complete');
+}
+
+module.exports = { escPS, escAS, notifyWindows, notifyMac, notifyLinux };

--- a/uninstall.js
+++ b/uninstall.js
@@ -1,0 +1,82 @@
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const manifestPath = path.join(claudeDir, '.claude-config-manifest.json');
+const backupsDir = path.join(claudeDir, '.claude-config-backups');
+
+function log(msg) { process.stdout.write(msg + '\n'); }
+function warn(msg) { process.stderr.write('warn: ' + msg + '\n'); }
+
+if (!fs.existsSync(manifestPath)) {
+  warn(`no manifest at ${manifestPath} — nothing to uninstall`);
+  process.exit(0);
+}
+
+let manifest;
+try { manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')); }
+catch (e) { warn(`manifest unreadable: ${e.message}`); process.exit(1); }
+
+log(`Uninstalling using manifest from ${manifest.installedAt}${DRY_RUN ? ' (dry run)' : ''}\n`);
+
+log('removing files created by install:');
+for (const f of manifest.createdFiles) {
+  if (!fs.existsSync(f)) continue;
+  if (!DRY_RUN) fs.unlinkSync(f);
+  log(`  ${DRY_RUN ? '[dry]' : '    '} removed ${f}`);
+}
+
+log('\nrestoring backups:');
+let restoreFailed = false;
+for (const { dest, backup } of manifest.backups) {
+  if (!fs.existsSync(backup)) {
+    warn(`backup missing: ${backup} — cannot restore ${dest}`);
+    restoreFailed = true;
+    continue;
+  }
+  if (!DRY_RUN) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(backup, dest);
+    fs.unlinkSync(backup);
+  }
+  log(`  ${DRY_RUN ? '[dry]' : '    '} restored ${dest} ← ${backup}`);
+}
+
+function isInside(dir, stopAt) {
+  const rel = path.relative(stopAt, dir);
+  return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+function pruneEmptyDirs(start, stopAt) {
+  if (DRY_RUN) return;
+  let dir = start;
+  while (isInside(dir, stopAt) && fs.existsSync(dir)) {
+    try {
+      if (fs.readdirSync(dir).length) break;
+      fs.rmdirSync(dir);
+    } catch { break; }
+    dir = path.dirname(dir);
+  }
+}
+
+log('\ncleaning empty dirs:');
+const dirsToClean = new Set(manifest.createdFiles.map(f => path.dirname(f)));
+for (const dir of dirsToClean) pruneEmptyDirs(dir, claudeDir);
+
+if (fs.existsSync(backupsDir)) {
+  try {
+    if (!fs.readdirSync(backupsDir).length && !DRY_RUN) fs.rmdirSync(backupsDir);
+  } catch {}
+}
+
+if (restoreFailed) {
+  warn(`one or more backups missing — manifest kept at ${manifestPath} for retry`);
+  process.exit(1);
+}
+
+if (!DRY_RUN) fs.unlinkSync(manifestPath);
+log(`\nremoved manifest: ${manifestPath}`);
+log('Done.');


### PR DESCRIPTION
## Summary

- Portable global Claude Code configuration under version control
- Hook dispatch: PreToolUse (bash-safety, secret-guard), PostToolUse (clang-format, clang-tidy, cppcheck), Stop (desktop notify)
- Skills: commit-rules, pr-rules, changelog, release, submodule-sync, api-design, cpp-coding, cpp-testing, ddd, doxygen, editing, hook-scripts
- `config/settings.json` — portable config, no hardcoded paths, no machine-specific plugins
- `config/CLAUDE.md` — global rules: skill auto-apply triggers, confirmation requirement for actions outside working directory
- `install.js` — zero-dependency bootstrap, copies hooks/tools/skills to `~/.claude/`, installs git pre-commit hook

## Test plan

- [x] `node install.js --dry-run` — paths resolve to `~/.claude/`
- [x] `node install.js` on clean machine — all files land correctly
- [x] Pre-commit hook blocks direct commits to main/master
- [x] PreToolUse hook blocks dangerous `rm -rf` patterns and credential writes