### PR TITLE
Feat(skills): Add SDLC skills — node-testing, requirements, architecture, project-planning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ No hardcoded user paths anywhere. No npm dependencies.
 1. Create `tools/<name>.js` — reads stdin JSON, writes to stdout (warn) or stderr+exit(2) (block)
 2. Add it to the appropriate dispatcher in `hooks/PreToolUse.js` or `hooks/PostToolUse.js`
 3. Export pure logic (regexes, helpers) and add tests under `test/<name>.test.js`
+   (see `skills/node-testing/SKILL.md` for conventions: flat `test()`, fixtures, `CLAUDE_CONFIG_DIR` isolation)
 4. Run `npm test`
 
 See `skills/hook-scripts/SKILL.md` for full hook development conventions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 - Portable `config/settings.json` using `CLAUDE_CONFIG_DIR` / `os.homedir()` — no hardcoded user paths
 - `install.js` bootstrap with JSON-merge for `~/.claude/settings.json` — existing machine-specific settings preserved
 - `templates/SKILL.md` template for consistent skill authoring
+- Skills: `architecture` (ADRs, design tradeoffs), `node-testing` (`test/*.test.js` conventions), `project-planning` (scoping, estimation, milestones), `requirements` (user stories, acceptance criteria)
+
+### Changed
+
+- `api-design` skill: added rationale behind structure rules and a new wrong/right example for the "no void*" rule
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | Skill | Description |
 |-------|-------------|
 | `api-design` | C++ public API structure and hygiene |
+| `architecture` | System/module architecture design, ADRs, tradeoffs |
 | `changelog` | Keep a Changelog format |
 | `commit-rules` | Conventional Commits format |
 | `cpp-coding` | C++ implementation conventions |
@@ -40,8 +41,11 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | `doxygen` | Doxygen tag coverage for public headers |
 | `editing` | File editing workflow (re-read before edit) |
 | `hook-scripts` | Writing Claude Code hooks and tools |
+| `node-testing` | Conventions for this repo's `test/*.test.js` (node:test) |
 | `pr-rules` | PR title, description, merge strategy |
+| `project-planning` | Scoping, estimation, milestones, risk, status updates |
 | `release` | Semver release workflow |
+| `requirements` | Requirements gathering, user stories, acceptance criteria |
 | `submodule-sync` | Git submodule sync discipline |
 
 ## Installation

--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -16,14 +16,15 @@ Apply when designing new API, adding public headers, or reviewing public interfa
 
 ## Structural Rules
 
-- **Namespace hierarchy**: public symbols in consistent `lib::` or `lib::module::` namespace; check project `AGENTS.md` for exact namespace
+- **Namespace hierarchy**: public symbols in consistent `lib::` or `lib::module::` namespace; check project `AGENTS.md` for exact namespace.
+  **Why:** a consumer including the library should be able to predict where a symbol lives without grepping — inconsistent namespacing forces them to search instead of guess.
 - Identifier and comment language: follow project AGENTS.md
 
 ## Dependencies
 
-- No runtime dependencies in public API
-- No external headers in public API headers
-- No compiler-specific extensions directly — abstract via macro or type_traits helpers
+- **No runtime dependencies in public API.** A public header that pulls in a third-party type leaks that dependency to every consumer — they now need it on their include path too, and an upgrade on either side can break the other.
+- **No external headers in public API headers.** Forward-declare or wrap; push the actual `#include` into the `.cpp` file. Keeps the dependency private to the implementation.
+- **No compiler-specific extensions directly** — abstract via macro or type_traits helpers, so the header still compiles for consumers on a different compiler.
 - Use C++ feature test macros for version/compiler guards:
   ```cpp
   #if defined(__cpp_concepts) && __cpp_concepts >= 202002L
@@ -33,8 +34,8 @@ Apply when designing new API, adding public headers, or reviewing public interfa
 
 ## Compatibility
 
-- Target the minimum C++ standard the project declares (check `AGENTS.md`)
-- No UB, no implementation-defined behaviour in public paths
+- Target the minimum C++ standard the project declares (check `AGENTS.md`) — a public header compiled at a higher standard than the project promises silently breaks consumers stuck on the older one.
+- No UB, no implementation-defined behaviour in public paths — these are exactly the bugs that only show up on the consumer's compiler/platform, not yours.
 
 ## Breaking Changes
 
@@ -59,8 +60,20 @@ Breaking change = removing or renaming any public symbol, or changing its observ
   ```
   Exception: predicates returning `bool` are fine — the rule applies to parameters, not return types.
 
-- Template parameters: prefer full descriptive names (`ValueType`, `Executor`, `Allocator`); use short conventional names (`T`, `Iter`) only for generic algorithms
-- **No `void*` in public API** — use templates, `std::any`, or `std::variant`
+- Template parameters: prefer full descriptive names (`ValueType`, `Executor`, `Allocator`); use short conventional names (`T`, `Iter`) only for generic algorithms.
+  **Why:** a descriptive name doubles as documentation at the call site and in compiler errors; `T` only reads fine when the algorithm is generic enough that no more specific name would help.
+- **No `void*` in public API** — use templates, `std::any`, or `std::variant`. A `void*` parameter erases the type at the boundary, so the compiler can no longer catch a caller passing the wrong thing — the bug surfaces at runtime, in the consumer's code, far from where it was introduced.
+
+  ```cpp
+  // Wrong: caller and callee must agree on the real type out-of-band
+  void process(void* data, int type_tag);
+
+  // Correct: type is part of the signature, checked at compile time
+  template <typename T>
+  void process(T data);
+  // or, when the set of types is closed and known up front:
+  void process(std::variant<Foo, Bar, Baz> data);
+  ```
 
 ## Adding a New Header
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: architecture
+version: "1.0.0"
+description: Apply when designing system or module architecture, evaluating architectural tradeoffs, writing an Architecture Decision Record, or choosing between competing designs
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - architecture
+    - planning
+---
+
+# Skill: Software Architecture Design
+
+Apply when designing system or module architecture, evaluating tradeoffs between
+competing designs, or writing an Architecture Decision Record (ADR).
+
+- This skill covers how modules/services/processes fit together. A single public
+  interface's own hygiene (namespacing, no `void*`, breaking-change policy) →
+  `api-design` skill.
+- Modelling one bounded context's domain objects and invariants → `ddd` skill.
+  Architecture decides where the boundaries between contexts are; `ddd` decides what
+  goes on inside one of them.
+- The requirements that motivate an architectural decision should already exist →
+  `requirements` skill. Don't design against an unstated requirement.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its
+own architecture process or ADR location, follow those instead. This skill is the
+fallback for projects that do not specify their own.
+
+---
+
+## When Architecture Work Is Warranted
+
+Not every change needs an architectural decision. The signal that it does: the
+decision is expensive to reverse (changes a module boundary, a data ownership model, a
+synchronous/asynchronous split, a build vs buy call), or it constrains future
+decisions in a way that's hard to see from inside a single PR. A decision you could
+freely change next week in one PR doesn't need this ceremony — write the code, explain
+it in the commit body, move on. Forcing an ADR on every small decision trains people to
+skip the process for the ones that actually matter.
+
+## Architecture Decision Record (ADR) Format
+
+```markdown
+# ADR-<n>: <short title>
+
+## Context
+What situation/requirement made a decision necessary. What constraints applied.
+
+## Decision
+What was decided, stated plainly — one sentence if possible.
+
+## Alternatives Considered
+Each alternative and why it was rejected. Not exhaustive — the ones seriously weighed.
+
+## Consequences
+What this makes easier, what it makes harder, what it forecloses. Include the
+downsides — an ADR that only lists upsides reads as advocacy, not a decision record,
+and won't help the next person who hits the downside in production.
+```
+
+Store ADRs wherever the project's `AGENTS.md` specifies; if unspecified, a flat
+`docs/adr/NNNN-title.md` sequence is a reasonable default — the point of numbering is
+a stable reference (`ADR-0007`) that a commit or PR description can point at.
+
+## Common Tradeoff Axes
+
+Naming the axis you're trading off on makes the decision legible to someone reviewing
+it later, instead of looking like an arbitrary preference:
+
+- **Coupling vs duplication** — sharing code couples two call sites to one
+  implementation; duplicating avoids the coupling at the cost of two things to keep in
+  sync. Favor duplication until the shared logic has proven it changes for the same
+  reason in both places.
+- **Consistency vs availability** — under partition or failure, can you stay correct or
+  must you stay responsive? Most internal-tool architectures over-index on consistency
+  by default without ever interrogating whether availability matters more here.
+- **Build vs buy/reuse** — building gives full control and a maintenance burden; reuse
+  trades control for less code to own. Check `api-design`'s "no runtime dependencies in
+  public API" rule before reuse decisions that would leak a third-party type across a
+  public boundary.
+- **Synchronous vs asynchronous boundary** — sync is easier to reason about and debug;
+  async decouples failure/load between components at the cost of that ease.
+
+## Evaluating Competing Designs
+
+When two or more designs are genuinely in contention, write out each one's answer to
+the same set of questions rather than describing them in different terms — that's what
+makes the comparison real instead of rhetorical:
+
+- What does it cost to build, and what does it cost to change later?
+- What does it cost to operate (debug, monitor, scale)?
+- What failure modes does it introduce, and how would you detect them?
+- Which tradeoff axis (above) does it lean on, and is that the right lean for this
+  context specifically — not as a general preference?
+
+## Keeping Decisions Honest
+
+An architecture decision is a bet under uncertainty, not a proof. State the
+assumptions it depends on (expected load, team size, lifespan of the system) so that
+when one of those assumptions stops holding, whoever's reading the ADR can tell the
+decision needs revisiting — rather than treating it as permanent because no one wrote
+down why it was made.

--- a/skills/node-testing/SKILL.md
+++ b/skills/node-testing/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: node-testing
+version: "1.0.0"
+description: Apply when writing or reviewing tests under test/*.test.js for Claude Code hooks, tools, or install/uninstall logic
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - testing
+    - node
+---
+
+# Skill: Node Test Conventions
+
+Apply when writing or reviewing tests under `test/*.test.js` for Claude Code hooks,
+tools, or install/uninstall logic (e.g. `~/.claude/hooks/`, `~/.claude/tools/` —
+see `hook-scripts` skill).
+
+- Writing the hook/tool itself → `hook-scripts` skill.
+- C++ unit tests → `cpp-testing` skill (different language, different runner — do not
+  mix the two conventions).
+
+---
+
+## Runner and Assertions
+
+Use Node's built-in `node:test` and `node:assert` only — no Jest, Mocha, or other
+third-party test framework. A claude-config-style hooks/tools project typically has
+no npm dependencies (see `hook-scripts` skill); pulling in a test framework would be
+the one exception that breaks that invariant.
+
+```javascript
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+```
+
+## Flat Tests, Descriptive Names
+
+Write flat `test('description', fn)` calls rather than nesting in `describe` blocks.
+A test file like `bash-safety.test.js` reads as a flat list of behaviors
+checked, which is itself a spec for the regex/logic under test — nesting buries that
+spec under an extra layer of indirection for no benefit at this file size.
+
+```javascript
+test('blocks rm -rf /', () => {
+  assert.strictEqual(check('rm -rf /').action, 'block');
+});
+
+test('warns on rm -r foo/', () => {
+  assert.strictEqual(check('rm -r foo/').action, 'warn');
+});
+```
+
+Name the test after the behavior, not the input — `'blocks rm -rf /'`, not
+`'test case 1'` or `'check function'`. A failing test name should tell you what broke
+without opening the file.
+
+Only reach for `describe` if a file's tests genuinely split into unrelated concerns
+that would otherwise be hard to scan — most tool/hook test files won't need it.
+
+## One Behavior Per Test
+
+Each `test()` checks one input → one expected outcome. Don't fold multiple unrelated
+assertions into a single test — when it fails, you want the test name to already tell
+you which case broke, not "one of these five assertions."
+
+## Testing Pure Logic Directly
+
+Prefer exporting the pure logic from the tool (`exports.check`, etc.) and calling it
+directly in the test, rather than spawning the tool as a subprocess:
+
+```javascript
+const { check } = require('../tools/bash-safety');
+assert.strictEqual(check('rm -rf /').action, 'block');
+```
+
+**Why:** a direct call is faster, gives you a real stack trace on failure, and tests
+the logic in isolation from the stdin-JSON plumbing. Reserve `spawnSync` for the cases
+that actually need it — verifying exit codes, or the stdin → stdout/stderr contract a
+dispatcher relies on:
+
+```javascript
+const { spawnSync } = require('node:child_process');
+const r = spawnSync('node', [path.join(toolsDir, 'my-tool.js')], {
+  input: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } }),
+  encoding: 'utf8', stdio: 'pipe',
+});
+assert.strictEqual(r.status, 2);
+```
+
+## Filesystem Fixtures
+
+Any test that touches the filesystem (install/uninstall, manifest writes) must run
+against a temp directory, never the real `~/.claude/`. Use the `CLAUDE_CONFIG_DIR`
+env override (the same one the hooks themselves resolve against — see `hook-scripts`
+skill) to redirect the script under test into an isolated temp dir:
+
+```javascript
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'claude-config-test-'));
+}
+function rmTmp(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+test('install creates files and manifest on empty dir', () => {
+  const dir = mkTmp();
+  try {
+    const r = spawnSync('node', [installJs, '--no-git-hook'], {
+      cwd: repoDir,
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+      encoding: 'utf8',
+    });
+    assert.strictEqual(r.status, 0, `install failed: ${r.stderr}`);
+    assert.ok(fs.existsSync(path.join(dir, '.claude-config-manifest.json')));
+  } finally { rmTmp(dir); }
+});
+```
+
+Always clean up in a `finally` block — a failed assertion must not leave a stray temp
+directory behind, and must not skip cleanup either.
+
+## What to Cover
+
+- The regex/logic boundary cases a hook or tool relies on (e.g. every `rm` variant
+  `bash-safety` is supposed to catch, plus near-misses it should *not* flag).
+- The stdin-JSON contract: malformed JSON should not crash the process (exit 0, not
+  throw).
+- For install/uninstall: round-trip — install then uninstall restores the directory
+  to its pre-install state byte-for-byte, including the case where files already
+  existed before install (backup/restore path).
+
+## Running
+
+```bash
+npm test
+# equivalent to:
+node --test "test/**/*.test.js"
+```

--- a/skills/project-planning/SKILL.md
+++ b/skills/project-planning/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: project-planning
+version: "1.0.0"
+description: Apply when scoping work, breaking a feature down into tasks, estimating effort, sequencing milestones, identifying risk or dependencies, or writing a project plan or status update
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - planning
+    - project-management
+---
+
+# Skill: Project Planning & Management
+
+Apply when scoping work, breaking a feature into tasks, estimating effort, sequencing
+milestones, identifying risk/dependencies, or writing a project plan or status update
+meant for stakeholders.
+
+- This is for project-level planning artifacts shared with stakeholders — a roadmap, a
+  scoping doc, a status report. It is not the same thing as Claude's own in-conversation
+  task plan (the `Plan`/writing-plans tooling used to plan a single coding task); don't
+  conflate the two, and don't apply this skill's ceremony to a plan that's just
+  "what I'm about to do this turn."
+- A plan is built from settled requirements — if those don't exist yet, go get them
+  first → `requirements` skill.
+- PR Size discipline and the release checklist are the execution-time tail end of a
+  plan made here → `pr-rules`, `release` skills.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its
+own planning process or templates, follow those instead. This skill is the fallback
+for projects that do not specify their own.
+
+---
+
+## Breaking Work Into Increments
+
+Decompose a requirement or architectural decision into pieces that are each
+independently shippable — each one should leave the system in a working state, even
+if the full feature isn't done. This is the same discipline `pr-rules`' "PR Size"
+section asks for at the commit/PR level; planning is where you decide the sequence of
+increments before any of them are coded.
+
+A good increment:
+- Delivers something verifiable on its own (a test can pass, a reviewer can assess it).
+- Doesn't require a later increment to avoid leaving the system broken.
+- Is small enough that if it turns out to be wrong, the cost of discarding it is small.
+
+If you can't see how to split a requirement this way, that's usually a sign the
+requirement itself is still too vague — go back and sharpen it rather than forcing an
+artificial split.
+
+## Estimation
+
+Estimate the increments, not the whole feature — a whole-feature estimate is really
+just the sum of guesses about pieces nobody has thought through yet, and it hides which
+piece carries the most uncertainty. Track uncertainty explicitly (e.g. "well
+understood" vs "depends on an unknown" vs "speculative") rather than collapsing it into
+a single number — a stakeholder reading "3 days" treats it as a number to hold you to,
+even if it was really "3 days if X works as expected, otherwise unknown."
+
+## Identifying Dependencies and Risk
+
+Before sequencing, ask: which increments block others, and which depend on something
+outside your control (another team, an external API, an unresolved requirements
+question)? Surface the externally-dependent ones early — not because you can resolve
+them yourself, but because the people who can need lead time, and a risk discovered in
+week 1 is cheap; the same risk discovered in week 4 has already cost three weeks of
+work built on top of an assumption that didn't hold.
+
+A risk worth naming explicitly has: what could go wrong, how you'd notice it happening,
+and what the fallback is if it does. A risk list without those three things is just a
+list of worries, not something the plan can act on.
+
+## What a Milestone Plan Should Contain
+
+A milestone is a checkpoint, not just a date. State for each one:
+
+- **Scope** — which increments land in this milestone, specifically.
+- **Sequence** — what must finish before this milestone can start.
+- **Risk** — what's uncertain about this milestone specifically, not the project as a
+  whole.
+- **Exit criteria** — how you know the milestone is actually done, not just "time's
+  up." Tie this to the acceptance criteria from `requirements` where possible.
+
+A plan that's only a list of dates with no scope or exit criteria attached can't be
+checked against reality — it just gets quietly redefined as the dates slip.
+
+## Status Updates
+
+A status update earns its place by changing what the reader does next — report what
+changed since the last update, what's blocked and on what, and what the next checkpoint
+is. "Things are progressing" tells the reader nothing actionable; "increment 2 is
+blocked on the external API's rate-limit fix, ETA from their team is Friday" tells them
+exactly what to watch for and who to follow up with.

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: requirements
+version: "1.0.0"
+description: Apply when eliciting requirements, writing user stories or use cases, defining acceptance criteria, or turning a vague ask into a spec before design starts
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - requirements
+    - planning
+---
+
+# Skill: Requirements Gathering
+
+Apply when eliciting requirements, writing user stories or use cases, defining
+acceptance criteria, or turning a vague ask into a spec before design starts.
+
+- Once a requirement is settled and design begins → `architecture` skill.
+- The vocabulary used while gathering requirements should become the vocabulary used
+  in the domain model, not get re-invented later → `ddd` skill.
+- Breaking settled requirements into shippable work → `project-planning` skill.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its
+own requirements process, follow those instead. This skill is the fallback for projects
+that do not specify their own.
+
+---
+
+## Why Write This Down at All
+
+A requirement that lives only in a chat message gets reinterpreted differently by
+whoever implements it, whoever tests it, and whoever reviews it — each fills the gaps
+with their own assumption. Writing it down once, in a shared format, means everyone
+fills the gaps the same way, and disagreements surface before code is written instead
+of in review.
+
+## Structure of a Requirement
+
+Every requirement should make these explicit, even briefly:
+
+- **Actor** — who wants this (a user role, an external system, an internal caller).
+- **Goal** — what they're trying to achieve, not the mechanism for achieving it.
+- **Context** — when/why this comes up; the situation that triggers the need.
+
+If you can't fill in actor and goal, the request isn't a requirement yet — it's a
+solution looking for a problem. Push back and ask what it's for before specifying how.
+
+## User Story Format
+
+```
+As a <role>, I want <goal>, so that <benefit>.
+```
+
+The "so that" clause is not decoration — it's what lets you tell whether a proposed
+implementation actually satisfies the requirement, or just satisfies the literal
+wording while missing the point.
+
+### Acceptance Criteria (Given/When/Then)
+
+```
+Given <starting state>,
+When <action>,
+Then <observable outcome>.
+```
+
+Write acceptance criteria as outcomes a reviewer or tester can check without reading
+the implementation — "the export finishes in under 2 seconds for a 10k-row file," not
+"the export is fast." A criterion that can't be checked isn't a criterion, it's a hope.
+
+## Functional vs Non-Functional
+
+- **Functional** — what the system does (behavior, inputs/outputs, business rules).
+- **Non-functional** — how well it does it (performance, security, availability,
+  usability) and constraints it must operate under (compliance, platform support).
+
+Non-functional requirements are easy to omit because they're rarely volunteered by the
+person asking — "fast," "secure," and "works offline" are usually implied, not stated.
+Ask explicitly rather than assuming silence means "no constraint."
+
+## Flagging Ambiguity and Conflict
+
+When a requirement is ambiguous (admits more than one reasonable interpretation) or
+conflicts with an existing one, say so before proceeding — don't silently pick an
+interpretation and hope it's the right one. A wrong guess costs far more once it's
+built than a clarifying question costs now.
+
+## Definition of Done
+
+State up front what "done" means for the requirement: which acceptance criteria must
+pass, what documentation/tests are expected, what's explicitly out of scope. A
+requirement without a stated boundary tends to grow during implementation as edge
+cases get discovered — better to decide the boundary deliberately than let it drift.
+
+## Traceability
+
+Keep a requirement traceable to what it produced: which design decision addressed it,
+which code/tests implement it. This doesn't need heavyweight tooling for small
+projects — a reference in a commit body, PR description, or ADR (see `architecture`
+skill) is often enough. The point is being able to answer "why does this code exist"
+without archaeology.


### PR DESCRIPTION
## Summary
- Added `node-testing` skill: conventions for `test/*.test.js` (node:test only, flat tests, pure-logic-first, CLAUDE_CONFIG_DIR fixture isolation)
- Added `requirements` skill: actor/goal/context structure, user stories, Given/When/Then acceptance criteria, ambiguity flagging
- Added `architecture` skill: ADR format, tradeoff axes, when architecture work is warranted vs over-engineering
- Added `project-planning` skill: independently-shippable increments, estimation with uncertainty, milestone plans, actionable status updates
- Improved `api-design` skill: added rationale behind structure rules with wrong/right examples
- Updated README skill table and CHANGELOG

## Implementation
- Each skill is a standalone `skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`, `version`) and a Markdown body
- `node-testing` cross-links from `AGENTS.md`'s "Adding a new tool check" step so new tool authors find it immediately
- All skill descriptions are phrased generically (no "this repo" scope) so they apply correctly when installed globally to `~/.claude/skills/`
- README rows added per-skill; CHANGELOG lists all four under `[Unreleased] → Added`

## Test plan
- `npm test` passes at branch tip (58/58)
- Verify skill files exist: `ls skills/{node-testing,requirements,architecture,project-planning}/SKILL.md`
- Verify no "this repo" / "this project" wording: `grep -rniE "this (repo|project)" skills/`
- Verify `api-design` diff adds rationale section: `git diff main...ssoft/feat/sdlc-skills -- skills/api-design/SKILL.md`