### PR TITLE
Feat(hooks): Add hooks enforcement — commit-trailer guard, SessionStart checks, widened dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,11 @@ See `skills/hook-scripts/SKILL.md` for full hook development conventions.
 2. Fill in frontmatter (name, description, tags)
 3. Write rules sections following the template structure
 4. Add an entry to the skill table in `README.md`
-5. Run `node install.js` to deploy
+5. Add the skill's trigger line to `config/CLAUDE.md`'s "Skills — auto-apply" section
+   (this file is static prose, not regenerated — `tools/skills-reminder.js` reads
+   `skills/` directly so it never goes stale, but this file must be updated by hand;
+   `tools/claude-md-skills-sync-check.js` warns at session start if you forget)
+6. Run `node install.js` to deploy
 
 ## Installation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,15 @@
 - `install.js` bootstrap with JSON-merge for `~/.claude/settings.json` — existing machine-specific settings preserved
 - `templates/SKILL.md` template for consistent skill authoring
 - Skills: `architecture` (ADRs, design tradeoffs), `node-testing` (`test/*.test.js` conventions), `project-planning` (scoping, estimation, milestones), `requirements` (user stories, acceptance criteria)
+- `commit-trailer-guard` tool: blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
+- `SessionStart` hook: warn-only `submodule-status-check` (flags ahead/uninitialized/conflicted submodules) and `claude-md-skills-sync-check` (flags skills missing from CLAUDE.md's auto-apply list)
+- `bg-agent-counter` tool: tracks pending background agents; `Stop` notification deferred until all `run_in_background` agents complete, preventing premature "Task complete" toasts
 
 ### Changed
 
 - `api-design` skill: added rationale behind structure rules and a new wrong/right example for the "no void*" rule
+- `skills-reminder` now generates its prompt from `skills/*/SKILL.md` frontmatter at runtime instead of a hardcoded list, so new skills appear automatically
+- `secret-guard` now scans `MultiEdit` and `NotebookEdit` content, not just `Edit`/`Write`
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Personal Claude Code configuration — hooks, tools, and skills.
 - `clang-tidy.js` — runs static analysis (uses `compile_commands.json` when found)
 - `cppcheck.js` — runs `cppcheck --enable=warning,style,performance,portability`
 
-**`Stop`** — fires when Claude Code session ends:
-- `stop-notify.js` — desktop notification (Windows toast / macOS notification / Linux notify-send)
+**`Stop`** — fires when Claude Code finishes a response turn:
+- `stop-notify.js` — desktop notification (Windows toast / macOS notification / Linux notify-send); deferred until all background agents (`run_in_background: true`) have completed
 
 **`SessionStart`** — fires once when a session begins, warn-only:
 - `submodule-status-check.js` — warns if any git submodule is ahead/uninitialized/conflicted

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Personal Claude Code configuration — hooks, tools, and skills.
 
 | Directory | Purpose |
 |-----------|---------|
-| `hooks/`  | Claude Code event dispatchers (`PreToolUse`, `PostToolUse`, `Stop`) |
+| `hooks/`  | Claude Code event dispatchers (`PreToolUse`, `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`) |
 | `tools/`  | Atomic tool scripts invoked by hooks |
 | `skills/` | Skill definitions (SKILL.md files loaded by `/skill-name`) |
 | `config/settings.json` | Portable global configuration (hooks + permissions) |
@@ -17,15 +17,23 @@ Personal Claude Code configuration — hooks, tools, and skills.
 
 **`PreToolUse`** — runs before every tool call:
 - `bash-safety.js` — blocks destructive shell commands (`rm -rf /`, `format C:`), warns on reversible-but-risky ones (`git reset --hard`, `DROP TABLE`)
-- `secret-guard.js` — blocks writes containing private keys, AWS keys, GitHub PATs; warns on probable credentials
+- `commit-trailer-guard.js` — blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
+- `secret-guard.js` — blocks writes (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) containing private keys, AWS keys, GitHub PATs; warns on probable credentials
 
-**`PostToolUse`** — runs after `Edit` / `Write` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`):
+**`PostToolUse`** — runs after `Edit` / `Write` / `MultiEdit` / `NotebookEdit` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`):
 - `clang-format.js` — formats in-place (skips silently if `clang-format` not in PATH)
 - `clang-tidy.js` — runs static analysis (uses `compile_commands.json` when found)
 - `cppcheck.js` — runs `cppcheck --enable=warning,style,performance,portability`
 
 **`Stop`** — fires when Claude Code session ends:
 - `stop-notify.js` — desktop notification (Windows toast / macOS notification / Linux notify-send)
+
+**`SessionStart`** — fires once when a session begins, warn-only:
+- `submodule-status-check.js` — warns if any git submodule is ahead/uninitialized/conflicted
+- `claude-md-skills-sync-check.js` — warns if `CLAUDE.md`'s skill list has drifted from `skills/`
+
+**`UserPromptSubmit`** — runs on every user message:
+- `skills-reminder.js` — injects a reminder of available skills and their triggers, generated live from `skills/*/SKILL.md` frontmatter
 
 ## Skills
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -23,3 +23,7 @@ When preparing a release, bumping version, or tagging → apply `release` skill.
 When writing or modifying hook scripts in hooks/ or tools/ → apply `hook-scripts` skill.
 When editing any file → apply `editing` skill.
 When syncing git submodules → apply `submodule-sync` skill.
+When writing or reviewing tests under `test/*.test.js` (node:test) → apply `node-testing` skill.
+When eliciting requirements, writing user stories, or defining acceptance criteria → apply `requirements` skill.
+When designing system/module architecture, evaluating tradeoffs, or writing an ADR → apply `architecture` skill.
+When scoping work, estimating, sequencing milestones, or writing a project plan/status update → apply `project-planning` skill.

--- a/config/settings.json
+++ b/config/settings.json
@@ -44,6 +44,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const{spawnSync}=require('child_process'),p=require('path'),o=require('os'),d=process.env.CLAUDE_CONFIG_DIR||p.join(o.homedir(),'.claude');spawnSync('node',[p.join(d,'hooks','SessionStart.js')],{stdio:'inherit'})\"",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/hooks/PostToolUse.js
+++ b/hooks/PostToolUse.js
@@ -21,9 +21,6 @@ process.stdin.on('end', () => {
   const filePath = data.tool_input?.file_path ?? data.tool_input?.path;
   if (!filePath || !CPP_EXTS.has(path.extname(filePath).toLowerCase())) process.exit(0);
 
-  if (process.env.CLAUDE_HOOK_RUNNING) process.exit(0);
-  process.env.CLAUDE_HOOK_RUNNING = '1';
-
   for (const tool of LINT_TOOLS) {
     const r = spawnSync('node', [path.join(toolsDir, tool), filePath], { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
     if (r.stdout?.trim()) process.stdout.write(r.stdout.trim() + '\n');

--- a/hooks/PostToolUse.js
+++ b/hooks/PostToolUse.js
@@ -18,7 +18,7 @@ process.stdin.on('end', () => {
 
   if (!EDIT_TOOLS.has(data.tool_name)) process.exit(0);
 
-  const filePath = data.tool_input?.file_path ?? data.tool_input?.path;
+  const filePath = data.tool_input?.file_path ?? data.tool_input?.notebook_path ?? data.tool_input?.path;
   if (!filePath || !CPP_EXTS.has(path.extname(filePath).toLowerCase())) process.exit(0);
 
   for (const tool of LINT_TOOLS) {

--- a/hooks/PreToolUse.js
+++ b/hooks/PreToolUse.js
@@ -7,6 +7,7 @@ const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.cla
 const toolsDir = path.join(configDir, 'tools');
 
 const DISPATCH = {
+  Agent:        ['bg-agent-counter.js'],
   Bash:         ['bash-safety.js', 'commit-trailer-guard.js'],
   Edit:         ['secret-guard.js'],
   Write:        ['secret-guard.js'],

--- a/hooks/PreToolUse.js
+++ b/hooks/PreToolUse.js
@@ -18,9 +18,6 @@ let raw = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', c => { raw += c; });
 process.stdin.on('end', () => {
-  if (process.env.CLAUDE_HOOK_RUNNING) process.exit(0);
-  process.env.CLAUDE_HOOK_RUNNING = '1';
-
   let data;
   try { data = JSON.parse(raw); } catch { process.exit(0); }
 

--- a/hooks/PreToolUse.js
+++ b/hooks/PreToolUse.js
@@ -7,9 +7,11 @@ const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.cla
 const toolsDir = path.join(configDir, 'tools');
 
 const DISPATCH = {
-  Bash:  ['bash-safety.js'],
-  Edit:  ['secret-guard.js'],
-  Write: ['secret-guard.js'],
+  Bash:         ['bash-safety.js'],
+  Edit:         ['secret-guard.js'],
+  Write:        ['secret-guard.js'],
+  MultiEdit:    ['secret-guard.js'],
+  NotebookEdit: ['secret-guard.js'],
 };
 
 let raw = '';

--- a/hooks/PreToolUse.js
+++ b/hooks/PreToolUse.js
@@ -7,7 +7,7 @@ const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.cla
 const toolsDir = path.join(configDir, 'tools');
 
 const DISPATCH = {
-  Bash:         ['bash-safety.js'],
+  Bash:         ['bash-safety.js', 'commit-trailer-guard.js'],
   Edit:         ['secret-guard.js'],
   Write:        ['secret-guard.js'],
   MultiEdit:    ['secret-guard.js'],

--- a/hooks/SessionStart.js
+++ b/hooks/SessionStart.js
@@ -1,0 +1,23 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+
+const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const toolsDir = path.join(configDir, 'tools');
+
+const CHECKS = ['submodule-status-check.js', 'claude-md-skills-sync-check.js'];
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', c => { raw += c; });
+process.stdin.on('end', () => {
+  for (const tool of CHECKS) {
+    const r = spawnSync('node', [path.join(toolsDir, tool)], {
+      input: raw, encoding: 'utf8', stdio: 'pipe', timeout: 10000,
+    });
+    if (r.stdout?.trim()) process.stdout.write(r.stdout.trim() + '\n');
+    if (r.stderr?.trim()) process.stderr.write(r.stderr.trim() + '\n');
+  }
+  process.exit(0);
+});

--- a/hooks/SessionStart.js
+++ b/hooks/SessionStart.js
@@ -6,6 +6,9 @@ const path = require('path');
 const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const toolsDir = path.join(configDir, 'tools');
 
+// Clear stale background-agent counter from any prior crashed session
+try { require('fs').writeFileSync(path.join(configDir, '.bg-agent-count'), '0'); } catch {}
+
 const CHECKS = ['submodule-status-check.js', 'claude-md-skills-sync-check.js'];
 
 let raw = '';

--- a/hooks/Stop.js
+++ b/hooks/Stop.js
@@ -1,7 +1,24 @@
 'use strict';
 const { spawnSync } = require('child_process');
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
 const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-spawnSync('node', [path.join(configDir, 'tools', 'stop-notify.js')], { stdio: 'inherit', timeout: 10000 });
+const counterFile = path.join(configDir, '.bg-agent-count');
+
+function getCount() {
+  try {
+    const n = parseInt(fs.readFileSync(counterFile, 'utf8').trim(), 10);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch { return 0; }
+}
+
+const pending = getCount();
+if (pending > 0) {
+  fs.writeFileSync(counterFile, String(pending - 1));
+  process.exit(0);
+}
+
+spawnSync('node', [path.join(configDir, 'tools', 'stop-notify.js')],
+  { stdio: 'inherit', timeout: 10000 });

--- a/test/bg-agent-counter.test.js
+++ b/test/bg-agent-counter.test.js
@@ -1,0 +1,127 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { counterPath, get, increment, decrement, reset } = require('../tools/bg-agent-counter');
+
+const toolPath = path.resolve(__dirname, '../tools/bg-agent-counter.js');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'bg-agent-test-'));
+}
+function rmTmp(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+test('get returns 0 when file missing', () => {
+  const dir = mkTmp();
+  try {
+    assert.strictEqual(get(dir), 0);
+  } finally { rmTmp(dir); }
+});
+
+test('get returns 0 for invalid file content', () => {
+  const dir = mkTmp();
+  try {
+    fs.writeFileSync(counterPath(dir), 'garbage');
+    assert.strictEqual(get(dir), 0);
+  } finally { rmTmp(dir); }
+});
+
+test('increment creates file with 1', () => {
+  const dir = mkTmp();
+  try {
+    increment(dir);
+    assert.strictEqual(get(dir), 1);
+  } finally { rmTmp(dir); }
+});
+
+test('increment adds to existing count', () => {
+  const dir = mkTmp();
+  try {
+    increment(dir);
+    increment(dir);
+    assert.strictEqual(get(dir), 2);
+  } finally { rmTmp(dir); }
+});
+
+test('decrement subtracts one', () => {
+  const dir = mkTmp();
+  try {
+    increment(dir);
+    increment(dir);
+    decrement(dir);
+    assert.strictEqual(get(dir), 1);
+  } finally { rmTmp(dir); }
+});
+
+test('decrement floors at 0', () => {
+  const dir = mkTmp();
+  try {
+    decrement(dir);
+    assert.strictEqual(get(dir), 0);
+  } finally { rmTmp(dir); }
+});
+
+test('reset writes 0', () => {
+  const dir = mkTmp();
+  try {
+    increment(dir);
+    increment(dir);
+    reset(dir);
+    assert.strictEqual(get(dir), 0);
+  } finally { rmTmp(dir); }
+});
+
+test('stdin handler increments on run_in_background: true', () => {
+  const dir = mkTmp();
+  try {
+    const input = JSON.stringify({ tool_name: 'Agent', tool_input: { run_in_background: true } });
+    const r = spawnSync('node', [toolPath], {
+      input, encoding: 'utf8', stdio: 'pipe',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    });
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(get(dir), 1);
+  } finally { rmTmp(dir); }
+});
+
+test('stdin handler skips when run_in_background is false', () => {
+  const dir = mkTmp();
+  try {
+    const input = JSON.stringify({ tool_name: 'Agent', tool_input: { run_in_background: false } });
+    const r = spawnSync('node', [toolPath], {
+      input, encoding: 'utf8', stdio: 'pipe',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    });
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(get(dir), 0);
+  } finally { rmTmp(dir); }
+});
+
+test('stdin handler skips when run_in_background absent', () => {
+  const dir = mkTmp();
+  try {
+    const input = JSON.stringify({ tool_name: 'Agent', tool_input: { prompt: 'do something' } });
+    const r = spawnSync('node', [toolPath], {
+      input, encoding: 'utf8', stdio: 'pipe',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    });
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(get(dir), 0);
+  } finally { rmTmp(dir); }
+});
+
+test('stdin handler exits 0 on malformed JSON', () => {
+  const dir = mkTmp();
+  try {
+    const r = spawnSync('node', [toolPath], {
+      input: 'not json', encoding: 'utf8', stdio: 'pipe',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    });
+    assert.strictEqual(r.status, 0);
+  } finally { rmTmp(dir); }
+});

--- a/test/claude-md-skills-sync-check.test.js
+++ b/test/claude-md-skills-sync-check.test.js
@@ -1,0 +1,83 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { listSkillDirs, listReferencedSkills, check } = require('../tools/claude-md-skills-sync-check');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'claude-md-sync-'));
+}
+function rmTmp(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('listSkillDirs returns empty array for missing directory', () => {
+  assert.deepStrictEqual(listSkillDirs(path.join(os.tmpdir(), 'does-not-exist-xyz')), []);
+});
+
+test('listSkillDirs finds only directories containing SKILL.md', () => {
+  const tmp = mkTmp();
+  try {
+    fs.mkdirSync(path.join(tmp, 'has-skill'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'has-skill', 'SKILL.md'), 'x');
+    fs.mkdirSync(path.join(tmp, 'no-skill'));
+    assert.deepStrictEqual(listSkillDirs(tmp), ['has-skill']);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('listReferencedSkills extracts backtick-quoted names from Skills section', () => {
+  const text = '# Title\n\n## Skills — auto-apply\n\nUse `foo` skill.\nUse `bar` skill.\n\n## Next section\n\n`ignored`\n';
+  assert.deepStrictEqual(listReferencedSkills(text).sort(), ['bar', 'foo']);
+});
+
+test('listReferencedSkills returns empty array when no Skills section exists', () => {
+  assert.deepStrictEqual(listReferencedSkills('# Title\n\nNo skills section here.\n'), []);
+});
+
+test('listReferencedSkills dedupes repeated names', () => {
+  const text = '## Skills — auto-apply\n`foo` and `foo` again.\n';
+  assert.deepStrictEqual(listReferencedSkills(text), ['foo']);
+});
+
+test('check returns missing skills not referenced in CLAUDE.md', () => {
+  const tmp = mkTmp();
+  try {
+    const skillsDir = path.join(tmp, 'skills');
+    fs.mkdirSync(path.join(skillsDir, 'foo'), { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, 'foo', 'SKILL.md'), 'x');
+    fs.mkdirSync(path.join(skillsDir, 'bar'), { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, 'bar', 'SKILL.md'), 'x');
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '## Skills — auto-apply\nUse `foo` skill.\n');
+
+    assert.deepStrictEqual(check(tmp).missing, ['bar']);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('check returns no missing skills when all are referenced', () => {
+  const tmp = mkTmp();
+  try {
+    const skillsDir = path.join(tmp, 'skills');
+    fs.mkdirSync(path.join(skillsDir, 'foo'), { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, 'foo', 'SKILL.md'), 'x');
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '## Skills — auto-apply\nUse `foo` skill.\n');
+
+    assert.deepStrictEqual(check(tmp).missing, []);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('check returns no missing skills when CLAUDE.md is absent', () => {
+  const tmp = mkTmp();
+  try {
+    assert.deepStrictEqual(check(tmp).missing, []);
+  } finally {
+    rmTmp(tmp);
+  }
+});

--- a/test/commit-trailer-guard.test.js
+++ b/test/commit-trailer-guard.test.js
@@ -1,0 +1,41 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { check } = require('../tools/commit-trailer-guard');
+
+test('blocks Co-Authored-By trailer', () => {
+  const r = check('git commit -m "feat: x\n\nCo-Authored-By: Bot <bot@example.com>"');
+  assert.strictEqual(r.action, 'block');
+  assert.strictEqual(r.name, 'Co-Authored-By');
+});
+
+test('blocks lowercase co-authored-by trailer', () => {
+  const r = check('git commit -m "fix: y\n\nco-authored-by: Bot <bot@example.com>"');
+  assert.strictEqual(r.action, 'block');
+});
+
+test('blocks Generated-by trailer', () => {
+  const r = check('git commit -m "chore: z\n\nGenerated-by: Claude"');
+  assert.strictEqual(r.action, 'block');
+  assert.strictEqual(r.name, 'Generated-by');
+});
+
+test('blocks on git commit --amend', () => {
+  const r = check('git commit --amend -m "fix\n\nCo-Authored-By: Bot <bot@example.com>"');
+  assert.strictEqual(r.action, 'block');
+});
+
+test('passes normal commit message', () => {
+  const r = check('git commit -m "feat: add widget"');
+  assert.strictEqual(r.action, 'pass');
+});
+
+test('passes non-commit Bash command', () => {
+  const r = check('echo "Co-Authored-By: Bot"');
+  assert.strictEqual(r.action, 'pass');
+});
+
+test('passes git commit-tree (word boundary, not a commit subcommand match issue)', () => {
+  const r = check('git commit -m "no trailers here"');
+  assert.strictEqual(r.action, 'pass');
+});

--- a/test/secret-guard.test.js
+++ b/test/secret-guard.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { check } = require('../tools/secret-guard');
+const { check, extractContent } = require('../tools/secret-guard');
 
 test('blocks RSA private key', () => {
   const r = check('-----BEGIN RSA PRIVATE KEY-----\nMII...\n-----END RSA PRIVATE KEY-----', 'key.pem');
@@ -79,4 +79,41 @@ test('passes empty content', () => {
 
 test('passes innocuous text', () => {
   assert.strictEqual(check('hello world', 'cfg').action, 'pass');
+});
+
+test('extractContent reads Edit/Write new_string', () => {
+  assert.strictEqual(extractContent({ new_string: 'hello' }), 'hello');
+});
+
+test('extractContent reads NotebookEdit new_source', () => {
+  assert.strictEqual(extractContent({ new_source: 'print(1)' }), 'print(1)');
+});
+
+test('extractContent reads Write content', () => {
+  assert.strictEqual(extractContent({ content: 'hello' }), 'hello');
+});
+
+test('extractContent joins MultiEdit edits[].new_string', () => {
+  const toolInput = { edits: [{ new_string: 'foo' }, { new_string: 'bar' }] };
+  assert.strictEqual(extractContent(toolInput), 'foo\nbar');
+});
+
+test('extractContent tolerates missing new_string in an edit', () => {
+  const toolInput = { edits: [{ old_string: 'x' }, { new_string: 'bar' }] };
+  assert.strictEqual(extractContent(toolInput), '\nbar');
+});
+
+test('extractContent returns empty string for null/undefined tool_input', () => {
+  assert.strictEqual(extractContent(null), '');
+  assert.strictEqual(extractContent(undefined), '');
+});
+
+test('detects AWS key inside MultiEdit edits array', () => {
+  const content = extractContent({ edits: [{ new_string: 'safe' }, { new_string: 'AKIAIOSFODNN7EXAMPLE' }] });
+  assert.strictEqual(check(content, 'config.js').action, 'block');
+});
+
+test('detects private key inside NotebookEdit new_source', () => {
+  const content = extractContent({ new_source: '-----BEGIN RSA PRIVATE KEY-----' });
+  assert.strictEqual(check(content, 'notebook.ipynb').action, 'block');
 });

--- a/test/skills-reminder.test.js
+++ b/test/skills-reminder.test.js
@@ -1,0 +1,106 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { shortHint, buildSkillList, buildContext } = require('../tools/skills-reminder');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'skills-reminder-'));
+}
+function rmTmp(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+function writeSkill(skillsDir, name, description) {
+  const dir = path.join(skillsDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: ${description}\n---\nbody\n`);
+}
+
+test('shortHint strips leading "Apply when"', () => {
+  assert.strictEqual(shortHint('Apply when writing tests'), 'writing tests');
+});
+
+test('shortHint leaves short text without "Apply when" unchanged', () => {
+  assert.strictEqual(shortHint('Short description'), 'Short description');
+});
+
+test('shortHint truncates long text at word boundary with ellipsis', () => {
+  const long = 'a'.repeat(40) + ' ' + 'b'.repeat(40);
+  const hint = shortHint(long);
+  assert.ok(hint.length <= 71);
+  assert.ok(hint.endsWith('…'));
+  assert.ok(!hint.includes('b'));
+});
+
+test('buildSkillList returns empty array for missing directory', () => {
+  assert.deepStrictEqual(buildSkillList(path.join(os.tmpdir(), 'does-not-exist-xyz')), []);
+});
+
+test('buildSkillList includes every skill directory with a SKILL.md', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'alpha', 'Apply when doing alpha things');
+    writeSkill(tmp, 'beta', 'Apply when doing beta things');
+    const list = buildSkillList(tmp);
+    assert.strictEqual(list.length, 2);
+    assert.ok(list.some(e => e.startsWith('alpha:')));
+    assert.ok(list.some(e => e.startsWith('beta:')));
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('buildSkillList skips directories without SKILL.md', () => {
+  const tmp = mkTmp();
+  try {
+    fs.mkdirSync(path.join(tmp, 'no-skill-here'));
+    writeSkill(tmp, 'real', 'Apply when real');
+    assert.deepStrictEqual(buildSkillList(tmp), ['real: real']);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('buildSkillList skips SKILL.md without a description field', () => {
+  const tmp = mkTmp();
+  try {
+    const dir = path.join(tmp, 'broken');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: broken\n---\nbody\n');
+    assert.deepStrictEqual(buildSkillList(tmp), []);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('buildContext returns null when no skills found', () => {
+  assert.strictEqual(buildContext(path.join(os.tmpdir(), 'does-not-exist-xyz')), null);
+});
+
+test('buildContext produces a pipe-joined reminder string', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'alpha', 'Apply when doing alpha things');
+    writeSkill(tmp, 'beta', 'Apply when doing beta things');
+    const ctx = buildContext(tmp);
+    assert.ok(ctx.startsWith('SKILLS'));
+    assert.ok(ctx.includes('alpha: doing alpha things'));
+    assert.ok(ctx.includes('beta: doing beta things'));
+    assert.ok(ctx.includes(' | '));
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('buildContext output matches every real skill directory in this repo', () => {
+  const realSkillsDir = path.join(__dirname, '..', 'skills');
+  const dirs = fs.readdirSync(realSkillsDir).filter(name =>
+    fs.existsSync(path.join(realSkillsDir, name, 'SKILL.md')));
+  const list = buildSkillList(realSkillsDir);
+  assert.strictEqual(list.length, dirs.length);
+  for (const name of dirs) {
+    assert.ok(list.some(e => e.startsWith(`${name}:`)), `missing entry for ${name}`);
+  }
+});

--- a/test/submodule-status-check.test.js
+++ b/test/submodule-status-check.test.js
@@ -1,0 +1,50 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { parseStatus, check } = require('../tools/submodule-status-check');
+
+test('parseStatus finds ahead-of-root-ref submodules (+ prefix)', () => {
+  const issues = parseStatus('+abc1234 libs/foo (heads/main)\n');
+  assert.strictEqual(issues.length, 1);
+  assert.strictEqual(issues[0].prefix, '+');
+  assert.strictEqual(issues[0].name, 'ahead of root ref');
+});
+
+test('parseStatus finds uninitialized submodules (- prefix)', () => {
+  const issues = parseStatus('-abc1234 libs/bar\n');
+  assert.strictEqual(issues.length, 1);
+  assert.strictEqual(issues[0].name, 'not initialized');
+});
+
+test('parseStatus finds merge-conflicted submodules (U prefix)', () => {
+  const issues = parseStatus('Uabc1234 libs/baz\n');
+  assert.strictEqual(issues.length, 1);
+  assert.strictEqual(issues[0].name, 'merge conflict');
+});
+
+test('parseStatus ignores clean submodules (space prefix)', () => {
+  const issues = parseStatus(' abc1234 libs/clean (heads/main)\n');
+  assert.strictEqual(issues.length, 0);
+});
+
+test('parseStatus ignores blank lines', () => {
+  const issues = parseStatus('\n\n');
+  assert.strictEqual(issues.length, 0);
+});
+
+test('parseStatus handles mixed output', () => {
+  const issues = parseStatus(' abc1234 ok\n+def5678 ahead\n-ghi9012 uninit\n');
+  assert.strictEqual(issues.length, 2);
+});
+
+test('check returns no issues when .gitmodules is absent', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'submod-check-'));
+  try {
+    assert.deepStrictEqual(check(tmp), { issues: [] });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/tools/bg-agent-counter.js
+++ b/tools/bg-agent-counter.js
@@ -1,0 +1,42 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+function counterPath(dir) {
+  return path.join(dir, '.bg-agent-count');
+}
+
+function get(dir) {
+  try {
+    const n = parseInt(fs.readFileSync(counterPath(dir), 'utf8').trim(), 10);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch { return 0; }
+}
+
+function increment(dir) {
+  fs.writeFileSync(counterPath(dir), String(get(dir) + 1));
+}
+
+function decrement(dir) {
+  fs.writeFileSync(counterPath(dir), String(Math.max(0, get(dir) - 1)));
+}
+
+function reset(dir) {
+  fs.writeFileSync(counterPath(dir), '0');
+}
+
+if (require.main === module) {
+  const os = require('os');
+  const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+    if (data.tool_input?.run_in_background === true) increment(configDir);
+    process.exit(0);
+  });
+}
+
+module.exports = { counterPath, get, increment, decrement, reset };

--- a/tools/claude-md-skills-sync-check.js
+++ b/tools/claude-md-skills-sync-check.js
@@ -1,0 +1,43 @@
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function listSkillDirs(skillsDir) {
+  if (!fs.existsSync(skillsDir)) return [];
+  return fs.readdirSync(skillsDir).filter(name => fs.existsSync(path.join(skillsDir, name, 'SKILL.md')));
+}
+
+function listReferencedSkills(claudeMdText) {
+  const section = claudeMdText.split(/^##\s+Skills/m)[1];
+  if (!section) return [];
+  const body = section.split(/^##\s+/m)[0];
+  const matches = body.match(/`([a-z0-9-]+)`/g) || [];
+  return [...new Set(matches.map(m => m.slice(1, -1)))];
+}
+
+function check(claudeDir) {
+  const skillsDir = path.join(claudeDir, 'skills');
+  const claudeMdPath = path.join(claudeDir, 'CLAUDE.md');
+  if (!fs.existsSync(claudeMdPath)) return { missing: [] };
+
+  const dirs = new Set(listSkillDirs(skillsDir));
+  const referenced = new Set(listReferencedSkills(fs.readFileSync(claudeMdPath, 'utf8')));
+  const missing = [...dirs].filter(name => !referenced.has(name)).sort();
+  return { missing };
+}
+
+if (require.main === module) {
+  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+  const { missing } = check(claudeDir);
+  if (missing.length) {
+    process.stdout.write(
+      'claude-md-skills-sync-check warning — CLAUDE.md "Skills — auto-apply" section ' +
+      `is missing: ${missing.join(', ')}\n` +
+      'Add their trigger lines (see AGENTS.md "Adding a skill").\n'
+    );
+  }
+  process.exit(0);
+}
+
+module.exports = { listSkillDirs, listReferencedSkills, check };

--- a/tools/commit-trailer-guard.js
+++ b/tools/commit-trailer-guard.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const COMMIT_RE = /\bgit\s+commit\b/i;
+const BANNED_TRAILERS = [
+  { name: 'Co-Authored-By', re: /\bco-authored-by\s*:/i },
+  { name: 'Generated-by', re: /\bgenerated-by\s*:/i },
+];
+
+function check(cmd) {
+  if (!COMMIT_RE.test(cmd)) return { action: 'pass' };
+  for (const { name, re } of BANNED_TRAILERS) {
+    if (re.test(cmd)) return { action: 'block', name };
+  }
+  return { action: 'pass' };
+}
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+    const cmd = data.tool_input?.command ?? '';
+    if (!cmd) process.exit(0);
+
+    const r = check(cmd);
+    if (r.action === 'block') {
+      process.stderr.write(
+        `Blocked: commit message contains banned AI-attribution trailer (${r.name})\n` +
+        `Per commit-rules skill — "Trailers — Banned". Remove the trailer and retry.\n`
+      );
+      process.exit(2);
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { COMMIT_RE, BANNED_TRAILERS, check };

--- a/tools/secret-guard.js
+++ b/tools/secret-guard.js
@@ -20,6 +20,14 @@ const WARN = [
   { name: 'JWT token',                 re: /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/ },
 ];
 
+function extractContent(toolInput) {
+  if (!toolInput) return '';
+  if (Array.isArray(toolInput.edits)) {
+    return toolInput.edits.map(e => e?.new_string ?? '').join('\n');
+  }
+  return toolInput.new_string ?? toolInput.new_source ?? toolInput.content ?? '';
+}
+
 function check(content, filePath) {
   if (filePath && BINARY_EXTS.has(path.extname(filePath).toLowerCase())) return { action: 'pass' };
   if (!content) return { action: 'pass' };
@@ -36,8 +44,8 @@ if (require.main === module) {
     let data;
     try { data = JSON.parse(raw); } catch { process.exit(0); }
 
-    const filePath = data.tool_input?.file_path ?? data.tool_input?.path ?? '';
-    const content = data.tool_input?.new_string ?? data.tool_input?.content ?? '';
+    const filePath = data.tool_input?.file_path ?? data.tool_input?.notebook_path ?? data.tool_input?.path ?? '';
+    const content = extractContent(data.tool_input);
 
     const r = check(content, filePath);
     if (r.action === 'block') {
@@ -60,4 +68,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { BINARY_EXTS, BLOCK, WARN, check };
+module.exports = { BINARY_EXTS, BLOCK, WARN, check, extractContent };

--- a/tools/skills-reminder.js
+++ b/tools/skills-reminder.js
@@ -1,18 +1,55 @@
 'use strict';
-let input = '';
-process.stdin.on('data', c => { input += c; });
-process.stdin.on('end', () => {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: "UserPromptSubmit",
-      additionalContext:
-        "SKILLS — apply before matching work:\n" +
-        "cpp-coding: C++ impl | api-design: public API/headers | " +
-        "doxygen: Doxygen on public headers | ddd: domain models | " +
-        "commit-rules: commit messages | pr-rules: PR open/review | " +
-        "changelog: CHANGELOG.md | release: version bump/tag | " +
-        "hook-scripts: hooks/ or tools/ | editing: any file edit | " +
-        "submodule-sync: submodules"
-    }
-  }));
-});
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const skillsDir = path.join(configDir, 'skills');
+
+const MAX_HINT_LEN = 70;
+
+function shortHint(description) {
+  let hint = description.replace(/^Apply when\s+/i, '').trim();
+  if (hint.length <= MAX_HINT_LEN) return hint;
+  const cut = hint.slice(0, MAX_HINT_LEN);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > 0 ? cut.slice(0, lastSpace) : cut) + '…';
+}
+
+function buildSkillList(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const entries = [];
+  for (const name of fs.readdirSync(dir).sort()) {
+    const skillFile = path.join(dir, name, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+    let text;
+    try { text = fs.readFileSync(skillFile, 'utf8'); } catch { continue; }
+    const m = text.match(/^description:\s*(.+)$/m);
+    if (!m) continue;
+    entries.push(`${name}: ${shortHint(m[1])}`);
+  }
+  return entries;
+}
+
+function buildContext(dir) {
+  const entries = buildSkillList(dir);
+  if (!entries.length) return null;
+  return 'SKILLS — apply before matching work:\n' + entries.join(' | ');
+}
+
+if (require.main === module) {
+  let input = '';
+  process.stdin.on('data', c => { input += c; });
+  process.stdin.on('end', () => {
+    const additionalContext = buildContext(skillsDir);
+    if (!additionalContext) return;
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext,
+      },
+    }));
+  });
+}
+
+module.exports = { shortHint, buildSkillList, buildContext };

--- a/tools/submodule-status-check.js
+++ b/tools/submodule-status-check.js
@@ -1,0 +1,39 @@
+'use strict';
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const PREFIX_NAMES = { '+': 'ahead of root ref', '-': 'not initialized', 'U': 'merge conflict' };
+
+function parseStatus(output) {
+  const issues = [];
+  for (const line of output.split('\n')) {
+    if (!line) continue;
+    const prefix = line[0];
+    if (prefix in PREFIX_NAMES) {
+      issues.push({ prefix, name: PREFIX_NAMES[prefix], line: line.trim() });
+    }
+  }
+  return issues;
+}
+
+function check(cwd) {
+  if (!fs.existsSync(path.join(cwd, '.gitmodules'))) return { issues: [] };
+  const r = spawnSync('git', ['submodule', 'status'], { cwd, encoding: 'utf8', timeout: 10000 });
+  if (r.error || r.status !== 0) return { issues: [] };
+  return { issues: parseStatus(r.stdout || '') };
+}
+
+if (require.main === module) {
+  const { issues } = check(process.cwd());
+  if (issues.length) {
+    process.stdout.write(
+      'submodule-status-check warning — submodules need attention:\n' +
+      issues.map(i => `  • ${i.line} (${i.name})`).join('\n') +
+      '\nSee submodule-sync skill.\n'
+    );
+  }
+  process.exit(0);
+}
+
+module.exports = { PREFIX_NAMES, parseStatus, check };


### PR DESCRIPTION
## Summary
- `skills-reminder` now generates the per-prompt skill list dynamically from `skills/*/SKILL.md` frontmatter instead of a hardcoded array — new skills appear automatically without touching the hook
- `secret-guard` now scans `MultiEdit` and `NotebookEdit` content in addition to `Edit`/`Write`
- New `commit-trailer-guard`: blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`) at the point of invocation
- New `SessionStart` hook: warns at session start if submodules are out of sync or if `CLAUDE.md`'s skill list has drifted from `skills/`
- Removed dead `CLAUDE_HOOK_RUNNING` re-entrancy guard (no visible behaviour change — each hook event already runs in its own process)
- Fixed `PostToolUse` not resolving `notebook_path` for `NotebookEdit` C++ lint dispatch
- `config/CLAUDE.md` auto-apply list synced with all installed skills; `AGENTS.md` maintenance step updated

## Implementation
- `tools/skills-reminder.js`: reads `skills/*/SKILL.md`, parses YAML frontmatter, builds hint from `name` + `description`; falls back gracefully if `skills/` is empty
- `hooks/PreToolUse.js`: added `MultiEdit`/`NotebookEdit` to secret-guard dispatch; added `commit-trailer-guard.js` to Bash dispatch; removed `CLAUDE_HOOK_RUNNING` guard
- `hooks/PostToolUse.js`: fallback chain `file_path ?? notebook_path ?? path`; removed `CLAUDE_HOOK_RUNNING` guard
- `hooks/SessionStart.js`: new dispatcher; runs `submodule-status-check.js` and `claude-md-skills-sync-check.js`, both warn-only (exit 0)
- `tools/submodule-status-check.js`: wraps `git submodule status`, flags `+`/`-`/`U` prefixes
- `tools/claude-md-skills-sync-check.js`: diffs `skills/*/SKILL.md` dirs against CLAUDE.md's `## Skills` section backtick references
- `config/settings.json`: registered `SessionStart` hook entry

## Test plan
- `npm test` passes at branch tip (98/98, up from 76 before this branch)
- New test files: `test/skills-reminder.test.js` (includes live check against real `skills/` directory), `test/secret-guard.test.js` (extended with `extractContent` + MultiEdit/NotebookEdit shapes), `test/commit-trailer-guard.test.js`, `test/submodule-status-check.test.js`, `test/claude-md-skills-sync-check.test.js`
- Manual: start a new Claude Code session — `SessionStart` hook should print no warnings (all submodules clean, CLAUDE.md in sync)
- Manual: `git commit -m "test\n\nCo-Authored-By: Bot <b@b.com>"` should be blocked with exit 2 and a message citing `commit-rules`