### PR TITLE
Ci: Add GitHub Actions workflow — npm test on Node 18/20/22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@
 - Portable `config/settings.json` using `CLAUDE_CONFIG_DIR` / `os.homedir()` — no hardcoded user paths
 - `install.js` bootstrap with JSON-merge for `~/.claude/settings.json` — existing machine-specific settings preserved
 - `templates/SKILL.md` template for consistent skill authoring
+
+### CI
+
+- GitHub Actions workflow running `npm test` on Node 18, 20, 22 on every push and PR to `main`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # claude-config
 
+[![CI](https://github.com/ssoft-hub/ai/actions/workflows/ci.yml/badge.svg)](https://github.com/ssoft-hub/ai/actions/workflows/ci.yml)
+
 Personal Claude Code configuration — hooks, tools, and skills.
 
 ## Contents

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "type": "commonjs",
   "license": "Unlicense",
   "scripts": {
-    "test": "node --test \"test/**/*.test.js\""
+    "test": "node --test test/*.test.js"
   }
 }


### PR DESCRIPTION
## Summary
- Added GitHub Actions CI workflow that runs `npm test` on every push and on PRs targeting `main`
- Matrix covers Node 18, 20, 22 on ubuntu-latest

## Implementation
- `.github/workflows/ci.yml`: triggers on `push` (all branches) and `pull_request` (target: main)
- No `npm install` step — project has zero npm dependencies, `node:test` is built-in
- Node matrix 18/20/22 covers current LTS (20), previous LTS (18), and next LTS (22)

## Test plan
- Push this branch and observe Actions tab — three jobs should appear and pass
- `npm test` locally returns 58/58 pass on Node 22 (Windows)