### PR TITLE
Feat(hooks): gate C++ lint tools on in-repo config presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `api-design` skill: added rationale behind structure rules and a new wrong/right example for the "no void*" rule
 - `skills-reminder` now generates its prompt from `skills/*/SKILL.md` frontmatter at runtime instead of a hardcoded list, so new skills appear automatically
 - `secret-guard` now scans `MultiEdit` and `NotebookEdit` content, not just `Edit`/`Write`
+- C++ lint tools (`clang-format`, `clang-tidy`, `cppcheck`) now run only when their config file (`.clang-format` / `.clang-tidy` / `.cppcheck`) is present in the edited file's repository, never inheriting one from a parent repo — eliminates lint noise in unconfigured projects. `.cppcheck` is passed to cppcheck as `--suppressions-list`
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Personal Claude Code configuration — hooks, tools, and skills.
 - `commit-trailer-guard.js` — blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
 - `secret-guard.js` — blocks writes (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) containing private keys, AWS keys, GitHub PATs; warns on probable credentials
 
-**`PostToolUse`** — runs after `Edit` / `Write` / `MultiEdit` / `NotebookEdit` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`):
-- `clang-format.js` — formats in-place (skips silently if `clang-format` not in PATH)
-- `clang-tidy.js` — runs static analysis (uses `compile_commands.json` when found)
-- `cppcheck.js` — runs `cppcheck --enable=warning,style,performance,portability`
+**`PostToolUse`** — runs after `Edit` / `Write` / `MultiEdit` / `NotebookEdit` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`). Each tool runs **only when its config file is present in this repository** (searched from the edited file up to the git root, never into a parent repo); otherwise it is skipped silently:
+- `clang-format.js` — formats in-place; requires `.clang-format` (skips silently if `clang-format` not in PATH)
+- `clang-tidy.js` — runs static analysis; requires `.clang-tidy` (uses `compile_commands.json` when found)
+- `cppcheck.js` — runs `cppcheck --enable=warning,style,performance,portability --std=c++20 --error-exitcode=1 …`; requires `.cppcheck`, passed as `--suppressions-list`
 
 **`Stop`** — fires when Claude Code finishes a response turn:
 - `stop-notify.js` — desktop notification (Windows toast / macOS notification / Linux notify-send); deferred until all background agents (`run_in_background: true`) have completed

--- a/hooks/PostToolUse.js
+++ b/hooks/PostToolUse.js
@@ -1,5 +1,6 @@
 'use strict';
 const { spawnSync } = require('child_process');
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
@@ -7,7 +8,46 @@ const CPP_EXTS = new Set(['.h', '.hpp', '.cpp', '.cc', '.cxx']);
 const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
 const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const toolsDir = path.join(configDir, 'tools');
-const LINT_TOOLS = ['clang-format.js', 'clang-tidy.js', 'cppcheck.js'];
+
+// Each lint tool runs only when its config file is present in this repository.
+// Without the config the tool is unconfigured here and is skipped silently, so
+// it never produces noise (and never picks up a config from a parent repo).
+const LINT = [
+  { tool: 'clang-format.js', config: '.clang-format' },
+  { tool: 'clang-tidy.js',   config: '.clang-tidy' },
+  { tool: 'cppcheck.js',     config: '.cppcheck' },
+];
+
+// Boundary of "this repository": the nearest ancestor holding .git (a directory
+// for a normal checkout, a file for a worktree/submodule). If there is no .git,
+// fall back to cwd when it is an ancestor of startDir, otherwise startDir itself
+// — conservatively never ascending into a parent.
+function repoBoundary(startDir) {
+  let dir = startDir;
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  const cwd = process.cwd();
+  const rel = path.relative(cwd, startDir);
+  return (rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))) ? cwd : startDir;
+}
+
+// Search for configName from fromDir upward, never ascending past boundary.
+// Returns the absolute path of the config, or null when not found in the repo.
+function findConfig(fromDir, configName, boundary) {
+  let dir = fromDir;
+  while (true) {
+    const candidate = path.join(dir, configName);
+    if (fs.existsSync(candidate)) return candidate;
+    if (dir === boundary) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
 
 let raw = '';
 process.stdin.setEncoding('utf8');
@@ -21,8 +61,13 @@ process.stdin.on('end', () => {
   const filePath = data.tool_input?.file_path ?? data.tool_input?.notebook_path ?? data.tool_input?.path;
   if (!filePath || !CPP_EXTS.has(path.extname(filePath).toLowerCase())) process.exit(0);
 
-  for (const tool of LINT_TOOLS) {
-    const r = spawnSync('node', [path.join(toolsDir, tool), filePath], { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
+  const fileDir = path.dirname(path.resolve(filePath));
+  const boundary = repoBoundary(fileDir);
+
+  for (const { tool, config } of LINT) {
+    const cfg = findConfig(fileDir, config, boundary);
+    if (!cfg) continue;
+    const r = spawnSync('node', [path.join(toolsDir, tool), filePath, cfg], { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
     if (r.stdout?.trim()) process.stdout.write(r.stdout.trim() + '\n');
     if (r.stderr?.trim()) process.stderr.write(r.stderr.trim() + '\n');
   }

--- a/test/lint-gating.test.js
+++ b/test/lint-gating.test.js
@@ -1,0 +1,103 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DISPATCHER = path.join(__dirname, '..', 'hooks', 'PostToolUse.js');
+
+// Build a temp CLAUDE_CONFIG_DIR whose lint tools are stubs that echo their
+// argv. This lets the test assert *which* tools the dispatcher invoked and with
+// what config path, without depending on real clang-format / cppcheck binaries.
+function makeStubConfigDir() {
+  const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-cfg-'));
+  const toolsDir = path.join(cfgDir, 'tools');
+  fs.mkdirSync(toolsDir);
+  for (const name of ['clang-format.js', 'clang-tidy.js', 'cppcheck.js']) {
+    fs.writeFileSync(
+      path.join(toolsDir, name),
+      `process.stdout.write('INVOKED ${name} ' + (process.argv[3] || '') + '\\n');\n`,
+    );
+  }
+  return cfgDir;
+}
+
+// A temp directory marked as a git repo root (an empty .git file is enough —
+// the dispatcher only existsSync()-checks it).
+function makeRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-repo-'));
+  fs.writeFileSync(path.join(repo, '.git'), '');
+  return repo;
+}
+
+function runDispatcher(cfgDir, filePath) {
+  const r = spawnSync('node', [DISPATCHER], {
+    input: JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: filePath } }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: cfgDir },
+  });
+  return r.stdout || '';
+}
+
+function cleanup(...dirs) {
+  for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+}
+
+test('no config files in repo → no lint tool is invoked', () => {
+  const cfgDir = makeStubConfigDir();
+  const repo = makeRepo();
+  try {
+    const out = runDispatcher(cfgDir, path.join(repo, 'x.cpp'));
+    assert.strictEqual(out.trim(), '');
+  } finally {
+    cleanup(cfgDir, repo);
+  }
+});
+
+test('.cppcheck present → cppcheck runs with its path; others skipped', () => {
+  const cfgDir = makeStubConfigDir();
+  const repo = makeRepo();
+  const cppcheckCfg = path.join(repo, '.cppcheck');
+  fs.writeFileSync(cppcheckCfg, '');
+  try {
+    const out = runDispatcher(cfgDir, path.join(repo, 'x.cpp'));
+    assert.match(out, /INVOKED cppcheck\.js/);
+    assert.match(out, /\.cppcheck/);
+    assert.doesNotMatch(out, /INVOKED clang-format\.js/);
+    assert.doesNotMatch(out, /INVOKED clang-tidy\.js/);
+  } finally {
+    cleanup(cfgDir, repo);
+  }
+});
+
+test('config at repo root is found from a subdirectory file', () => {
+  const cfgDir = makeStubConfigDir();
+  const repo = makeRepo();
+  fs.writeFileSync(path.join(repo, '.clang-format'), '');
+  const sub = path.join(repo, 'src', 'core');
+  fs.mkdirSync(sub, { recursive: true });
+  try {
+    const out = runDispatcher(cfgDir, path.join(sub, 'x.cpp'));
+    assert.match(out, /INVOKED clang-format\.js/);
+    assert.doesNotMatch(out, /INVOKED cppcheck\.js/);
+  } finally {
+    cleanup(cfgDir, repo);
+  }
+});
+
+test('config above the repo boundary (parent repo) is not used', () => {
+  const cfgDir = makeStubConfigDir();
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-parent-'));
+  fs.writeFileSync(path.join(parent, '.clang-format'), ''); // lives outside the repo
+  const repo = path.join(parent, 'repo');
+  fs.mkdirSync(repo);
+  fs.writeFileSync(path.join(repo, '.git'), ''); // boundary stops here
+  try {
+    const out = runDispatcher(cfgDir, path.join(repo, 'x.cpp'));
+    assert.strictEqual(out.trim(), '');
+  } finally {
+    cleanup(cfgDir, parent);
+  }
+});

--- a/tools/cppcheck.js
+++ b/tools/cppcheck.js
@@ -8,6 +8,7 @@ function hasTool(name) {
 }
 
 const file = process.argv[2];
+const suppressions = process.argv[3];
 if (!file || !fs.existsSync(file)) process.exit(0);
 
 if (!hasTool('cppcheck')) {
@@ -17,10 +18,14 @@ if (!hasTool('cppcheck')) {
 
 const args = [
   '--enable=warning,style,performance,portability',
+  '--std=c++20',
+  '--language=c++',
   '--inline-suppr',
-  '--quiet',
-  file,
+  '--error-exitcode=1',
+  '-UDOXYGEN',
 ];
+if (suppressions) args.push(`--suppressions-list=${suppressions}`);
+args.push(file);
 
 const r = spawnSync('cppcheck', args, { encoding: 'utf8', stdio: 'pipe', timeout: 30000 });
 if (r.stdout) process.stdout.write(r.stdout);


### PR DESCRIPTION
## Summary
- C++ lint hooks (`clang-format`, `clang-tidy`, `cppcheck`) no longer run on every edited C++ file. Each runs only when its config file is present in the edited file''s repository, so unconfigured projects get zero lint noise.
- Prevents the linters'' native upward config search from inheriting a `.clang-format` from a parent directory outside the repo.
- `.cppcheck` is now wired into cppcheck as a suppressions list, and the cppcheck flag set is widened.

## Implementation
- Gating lives in the `PostToolUse` dispatcher (`hooks/PostToolUse.js`) so the tool wrappers stay atomic. A tool→config map drives it: `clang-format`→`.clang-format`, `clang-tidy`→`.clang-tidy`, `cppcheck`→`.cppcheck`.
- `repoBoundary()` finds the nearest ancestor with `.git` (directory or file — worktree/submodule), falling back to `cwd`/the file dir, and never ascends past it. `findConfig()` searches from the edited file''s directory up to that boundary; absent config → tool skipped silently.
- `tools/cppcheck.js` takes the resolved `.cppcheck` path as a third arg and passes `--suppressions-list=<path>`, plus the widened flags `--std=c++20 --language=c++ --error-exitcode=1 -UDOXYGEN`. `clang-format.js`/`clang-tidy.js` are unchanged — the external gate is sufficient and their native search finds the in-repo config first.
- Centralizing in the dispatcher (vs. per-tool checks) keeps a single boundary computation and one place to reason about repo scope.

## Test plan
- `node --test` — full suite green (113 tests).
- New `test/lint-gating.test.js` (4 integration tests via stub tools through `CLAUDE_CONFIG_DIR`): no config → nothing invoked; `.cppcheck` present → cppcheck runs with `--suppressions-list`; config at repo root found from a subdirectory file; config above the repo boundary (parent repo) not used.
- Manual: piping an `Edit` event for a `.cpp` in this (unconfigured) repo to `hooks/PostToolUse.js` produces empty output (all three skipped).
- Reviewer verification: `node --test test/lint-gating.test.js`.

> Note: hooks run from the installed copies under `~/.claude/`; `node install.js` is needed for the change to take effect at runtime.