### PR TITLE
Fix(install): revert settings.json by subtraction, not snapshot restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `skills-reminder` now generates its prompt from `skills/*/SKILL.md` frontmatter at runtime instead of a hardcoded list, so new skills appear automatically
 - `secret-guard` now scans `MultiEdit` and `NotebookEdit` content, not just `Edit`/`Write`
 - C++ lint tools (`clang-format`, `clang-tidy`, `cppcheck`) now run only when their config file (`.clang-format` / `.clang-tidy` / `.cppcheck`) is present in the edited file's repository, never inheriting one from a parent repo — eliminates lint noise in unconfigured projects. `.cppcheck` is passed to cppcheck as `--suppressions-list`
+- `uninstall` now reverts `settings.json` by subtracting only the hooks and permissions `install` added, instead of restoring a snapshot taken at install time. Settings written to the file afterwards by other tools or by hand are preserved; `install` records the exact additions in the manifest (no more `settings.json` backup)
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ into `~/.claude/settings.json` (existing machine-specific settings are preserved
 `CLAUDE.md` and `.git/hooks/pre-commit` are overwritten with backups.
 
 `install.js` writes a manifest at `~/.claude/.claude-config-manifest.json` recording every
-created file and every backup. `uninstall.js` reads the manifest and restores the exact
-pre-install state byte-for-byte.
+created file, every backup, and exactly which hooks and permissions it merged into
+`settings.json`. `uninstall.js` reads the manifest and reverses each: created files are
+removed, backed-up files (`CLAUDE.md`, `pre-commit`) are restored, and `settings.json` is
+reverted by **subtracting only the entries install added** — so hooks or permissions added
+to it afterwards by other tools or by hand are kept intact.
 
 ```
 node install.js --dry-run      # preview without writing

--- a/install.js
+++ b/install.js
@@ -75,35 +75,77 @@ function mergeHookEvent(existing, incoming) {
       if (h.command) existingCmds.add(h.command);
 
   const result = [...existing];
-  let added = 0;
+  const addedCommands = [];
   for (const entry of incoming) {
     const newHooks = (entry.hooks || []).filter(h => !existingCmds.has(h.command));
-    if (newHooks.length) { result.push({ ...entry, hooks: newHooks }); added += newHooks.length; }
+    if (newHooks.length) {
+      result.push({ ...entry, hooks: newHooks });
+      for (const h of newHooks) if (h.command) addedCommands.push(h.command);
+    }
   }
-  return { result, added };
+  return { result, addedCommands };
 }
 
+// Merge repo hooks/permissions into existing, recording the exact items added
+// (hook command strings per event, permission entries per key). Uninstall later
+// subtracts precisely these, so post-install changes by other tools survive.
 function mergeSettings(existing, repo) {
   const out = structuredClone(existing);
-  const additions = {};
+  const additions = { hooks: {}, permissions: {} };
 
   if (repo.hooks) {
     out.hooks = out.hooks || {};
     for (const [ev, entries] of Object.entries(repo.hooks)) {
-      const { result, added } = mergeHookEvent(out.hooks[ev] || [], entries);
+      const { result, addedCommands } = mergeHookEvent(out.hooks[ev] || [], entries);
       out.hooks[ev] = result;
-      if (added) additions[ev] = added;
+      if (addedCommands.length) additions.hooks[ev] = addedCommands;
     }
   }
 
   if (repo.permissions) {
     out.permissions = out.permissions || {};
-    for (const key of ['allow', 'ask', 'deny'])
-      if (repo.permissions[key])
-        out.permissions[key] = mergeUnique(out.permissions[key] || [], repo.permissions[key]);
+    for (const key of ['allow', 'ask', 'deny']) {
+      if (!repo.permissions[key]) continue;
+      const existingArr = out.permissions[key] || [];
+      const existingSet = new Set(existingArr);
+      const addedPerms = repo.permissions[key].filter(p => !existingSet.has(p));
+      out.permissions[key] = mergeUnique(existingArr, repo.permissions[key]);
+      if (addedPerms.length) additions.permissions[key] = addedPerms;
+    }
   }
 
   return { out, additions };
+}
+
+// Additions when settings.json is created from scratch: everything the repo
+// settings contribute (the whole file is install-owned).
+function additionsFromRepo(repo) {
+  const additions = { hooks: {}, permissions: {} };
+  for (const [ev, entries] of Object.entries(repo.hooks || {})) {
+    const cmds = [];
+    for (const entry of entries)
+      for (const h of (entry.hooks || []))
+        if (h.command) cmds.push(h.command);
+    if (cmds.length) additions.hooks[ev] = cmds;
+  }
+  for (const key of ['allow', 'ask', 'deny'])
+    if (repo.permissions?.[key]?.length) additions.permissions[key] = [...repo.permissions[key]];
+  return additions;
+}
+
+// Record (or accumulate across reinstalls) what install added to settings.json.
+// The earliest `preexisted` flag wins; additions are unioned so a reinstall with
+// a newer repo settings still registers any extra items for removal.
+function recordSettings(dest, preexisted, additions) {
+  if (!manifest.settings || manifest.settings.dest !== dest) {
+    manifest.settings = { dest, preexisted, additions };
+    return;
+  }
+  const s = manifest.settings;
+  for (const [ev, cmds] of Object.entries(additions.hooks || {}))
+    s.additions.hooks[ev] = [...new Set([...(s.additions.hooks[ev] || []), ...cmds])];
+  for (const [key, vals] of Object.entries(additions.permissions || {}))
+    s.additions.permissions[key] = [...new Set([...(s.additions.permissions[key] || []), ...vals])];
 }
 
 function installSettings() {
@@ -112,13 +154,14 @@ function installSettings() {
   const dest = path.join(claudeDir, 'settings.json');
   const repo = JSON.parse(fs.readFileSync(src, 'utf8'));
 
-  backupBeforeWrite(dest);
-
+  // settings.json is merged, not snapshot-replaced: uninstall reverts by
+  // subtracting exactly what was added, so no backup is taken here.
   if (!fs.existsSync(dest)) {
     if (!DRY_RUN) {
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       fs.copyFileSync(src, dest);
     }
+    recordSettings(dest, false, additionsFromRepo(repo));
     log(`  ${logPrefix} config/settings.json → ${dest} (created)`);
     return;
   }
@@ -127,9 +170,10 @@ function installSettings() {
   catch { warn(`${dest} is not valid JSON — skipping merge`); return; }
   const { out: merged, additions } = mergeSettings(existing, repo);
   if (!DRY_RUN) fs.writeFileSync(dest, JSON.stringify(merged, null, 2) + '\n');
+  recordSettings(dest, true, additions);
   log(`  ${logPrefix} config/settings.json → ${dest} (merged)`);
-  for (const [ev, n] of Object.entries(additions))
-    log(`      added ${n} hook${n === 1 ? '' : 's'} to ${ev}`);
+  for (const [ev, cmds] of Object.entries(additions.hooks))
+    log(`      added ${cmds.length} hook${cmds.length === 1 ? '' : 's'} to ${ev}`);
 }
 
 function installCLAUDEmd() {

--- a/test/install-uninstall.test.js
+++ b/test/install-uninstall.test.js
@@ -62,7 +62,7 @@ test('uninstall removes everything when nothing was preexisting', () => {
   } finally { rmTmp(dir); }
 });
 
-test('install+uninstall restores preexisting settings.json byte-for-byte', () => {
+test('install+uninstall reverts a preexisting settings.json to its prior content', () => {
   const dir = mkTmp();
   try {
     const settingsPath = path.join(dir, 'settings.json');
@@ -71,8 +71,7 @@ test('install+uninstall restores preexisting settings.json byte-for-byte', () =>
       customField: 'preserved',
       hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: 'user-hook' }] }] },
     };
-    const originalText = JSON.stringify(original, null, 2);
-    fs.writeFileSync(settingsPath, originalText);
+    fs.writeFileSync(settingsPath, JSON.stringify(original, null, 2));
 
     const ri = runInstall(dir);
     assert.strictEqual(ri.status, 0, ri.stderr);
@@ -85,8 +84,38 @@ test('install+uninstall restores preexisting settings.json byte-for-byte', () =>
     const ru = runUninstall(dir);
     assert.strictEqual(ru.status, 0, ru.stderr);
 
-    const restoredText = fs.readFileSync(settingsPath, 'utf8');
-    assert.strictEqual(restoredText, originalText, 'settings.json restored byte-for-byte');
+    // Reverting the merge yields the original content (the user's hook and
+    // permissions remain; install's additions are gone).
+    assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), original);
+  } finally { rmTmp(dir); }
+});
+
+test('uninstall preserves settings added by other tools after install', () => {
+  const dir = mkTmp();
+  try {
+    const ri = runInstall(dir); // creates settings.json from scratch
+    assert.strictEqual(ri.status, 0, ri.stderr);
+
+    const settingsPath = path.join(dir, 'settings.json');
+    const s = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    // A second tool extends the shared settings.json after our install.
+    s.hooks.PreCompact = [{ hooks: [{ type: 'command', command: 'other-tool-hook' }] }];
+    s.permissions.allow.push('Bash(othertool *)');
+    s.mcpServers = { foo: { command: 'foo' } };
+    fs.writeFileSync(settingsPath, JSON.stringify(s, null, 2) + '\n');
+
+    const ru = runUninstall(dir);
+    assert.strictEqual(ru.status, 0, ru.stderr);
+
+    assert.ok(fs.existsSync(settingsPath), 'file kept because foreign settings remain');
+    const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    // Foreign additions survive…
+    assert.deepStrictEqual(after.hooks.PreCompact, s.hooks.PreCompact, 'foreign hook kept');
+    assert.ok(after.permissions.allow.includes('Bash(othertool *)'), 'foreign permission kept');
+    assert.deepStrictEqual(after.mcpServers, { foo: { command: 'foo' } }, 'foreign top-level key kept');
+    // …while install's own hooks and permissions are removed.
+    assert.ok(!after.hooks.PreToolUse, 'install PreToolUse removed');
+    assert.ok(!after.permissions.allow.includes('Bash(*)'), 'install permission removed');
   } finally { rmTmp(dir); }
 });
 
@@ -136,22 +165,23 @@ test('install preserves user defaultMode when repo settings has none', () => {
   } finally { rmTmp(dir); }
 });
 
-test('reinstall does not double-backup', () => {
+test('reinstall records settings additions once and uninstall reverts them', () => {
   const dir = mkTmp();
   try {
     const settingsPath = path.join(dir, 'settings.json');
-    const original = JSON.stringify({ permissions: { allow: ['Bash(echo)'] } }, null, 2);
-    fs.writeFileSync(settingsPath, original);
+    const original = { permissions: { allow: ['Bash(echo)'] } };
+    fs.writeFileSync(settingsPath, JSON.stringify(original, null, 2));
 
     runInstall(dir);
     runInstall(dir);
 
     const manifest = JSON.parse(fs.readFileSync(path.join(dir, '.claude-config-manifest.json'), 'utf8'));
-    const settingsBackups = manifest.backups.filter(b => b.dest === settingsPath);
-    assert.strictEqual(settingsBackups.length, 1, 'only one backup for settings.json across reinstalls');
+    assert.ok(manifest.settings, 'settings additions recorded');
+    assert.strictEqual(manifest.settings.preexisted, true, 'earliest preexisted flag kept');
+    assert.ok(!manifest.backups.some(b => b.dest === settingsPath), 'settings.json is not snapshot-backed-up');
 
     runUninstall(dir);
-    assert.strictEqual(fs.readFileSync(settingsPath, 'utf8'), original, 'restored original after double install');
+    assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), original, 'reverted to original after double install');
   } finally { rmTmp(dir); }
 });
 

--- a/uninstall.js
+++ b/uninstall.js
@@ -29,6 +29,52 @@ for (const f of manifest.createdFiles) {
   log(`  ${DRY_RUN ? '[dry]' : '    '} removed ${f}`);
 }
 
+// Revert the merge install performed on settings.json by subtracting exactly the
+// items it added (recorded in manifest.settings). Unlike a snapshot restore, this
+// preserves any settings other tools or the user added after install.
+function revertSettings(record) {
+  const { dest, preexisted, additions } = record;
+  if (!fs.existsSync(dest)) { log(`  ${DRY_RUN ? '[dry]' : '    '} ${dest} already absent`); return; }
+
+  let cur;
+  try { cur = JSON.parse(fs.readFileSync(dest, 'utf8')); }
+  catch { warn(`${dest} is not valid JSON — leaving as-is`); return; }
+
+  for (const [ev, cmds] of Object.entries(additions.hooks || {})) {
+    if (!cur.hooks?.[ev]) continue;
+    const rm = new Set(cmds);
+    cur.hooks[ev] = cur.hooks[ev]
+      .map(entry => ({ ...entry, hooks: (entry.hooks || []).filter(h => !rm.has(h.command)) }))
+      .filter(entry => (entry.hooks || []).length > 0);
+    if (cur.hooks[ev].length === 0) delete cur.hooks[ev];
+  }
+  if (cur.hooks && Object.keys(cur.hooks).length === 0) delete cur.hooks;
+
+  for (const [key, vals] of Object.entries(additions.permissions || {})) {
+    if (!cur.permissions?.[key]) continue;
+    const rm = new Set(vals);
+    cur.permissions[key] = cur.permissions[key].filter(p => !rm.has(p));
+    if (cur.permissions[key].length === 0) delete cur.permissions[key];
+  }
+  if (cur.permissions && Object.keys(cur.permissions).length === 0) delete cur.permissions;
+
+  // Delete only a file install itself created that has nothing left but $schema;
+  // a preexisting file (or one carrying foreign keys) is always rewritten, never removed.
+  const meaningful = Object.keys(cur).filter(k => k !== '$schema');
+  if (meaningful.length === 0 && !preexisted) {
+    if (!DRY_RUN) fs.unlinkSync(dest);
+    log(`  ${DRY_RUN ? '[dry]' : '    '} removed ${dest}`);
+  } else {
+    if (!DRY_RUN) fs.writeFileSync(dest, JSON.stringify(cur, null, 2) + '\n');
+    log(`  ${DRY_RUN ? '[dry]' : '    '} reverted additions in ${dest}`);
+  }
+}
+
+if (manifest.settings) {
+  log('\nreverting settings.json additions:');
+  revertSettings(manifest.settings);
+}
+
 log('\nrestoring backups:');
 let restoreFailed = false;
 for (const { dest, backup } of manifest.backups) {


### PR DESCRIPTION
## Summary
- `uninstall` no longer wipes out `settings.json` changes made after install. It used to restore a whole-file snapshot taken at install time, discarding hooks/permissions added afterwards by other installers, `/config`, or by hand.
- `uninstall` now reverses the merge install performed, removing only the entries install itself added and leaving everything else intact.

## Implementation
- `install.js` records, per item, exactly what it merged into `settings.json` (`manifest.settings` = `{ dest, preexisted, additions: { hooks: {event: [commands]}, permissions: {key: [entries]} } }`). `mergeSettings`/`mergeHookEvent` now return the added items; `additionsFromRepo` covers the created-from-scratch case; `recordSettings` unions additions across reinstalls and keeps the earliest `preexisted` flag.
- The `settings.json` snapshot backup is removed — it was the source of the data loss and is no longer needed.
- `uninstall.js` `revertSettings()` reads the current file and subtracts the recorded hook commands and permission entries, pruning emptied entries/events/objects. A file install created from scratch is deleted only when nothing but `$schema` remains; a preexisting file (or one carrying foreign keys) is always rewritten, never removed.
- `CLAUDE.md` and `.git/hooks/pre-commit` keep snapshot restore on purpose — install overwrites them wholesale rather than merging, so a snapshot is the correct inverse there.

## Test plan
- `node --test` — full suite green (110 tests).
- `test/install-uninstall.test.js`:
  - rewrote the byte-for-byte restore test to assert merge reversal (original content returns after uninstall);
  - rewrote the no-double-backup test to assert additions are recorded once and not snapshot-backed-up;
  - **added** a test proving settings added by another tool after install (a foreign hook event, a foreign permission, a foreign top-level key) survive uninstall while install''s own entries are removed.
- Reviewer verification: `node --test test/install-uninstall.test.js`.

> Scope note: this addresses the uninstall data-loss only. Known upgrade-path gaps (orphaned files not pruned when a file is removed/renamed across versions; duplicate hooks if a launcher command string drifts) are out of scope and tracked for a follow-up.