### PR TITLE
Feat(install): make reinstall a clean upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `secret-guard` now scans `MultiEdit` and `NotebookEdit` content, not just `Edit`/`Write`
 - C++ lint tools (`clang-format`, `clang-tidy`, `cppcheck`) now run only when their config file (`.clang-format` / `.clang-tidy` / `.cppcheck`) is present in the edited file's repository, never inheriting one from a parent repo — eliminates lint noise in unconfigured projects. `.cppcheck` is passed to cppcheck as `--suppressions-list`
 - `uninstall` now reverts `settings.json` by subtracting only the hooks and permissions `install` added, instead of restoring a snapshot taken at install time. Settings written to the file afterwards by other tools or by hand are preserved; `install` records the exact additions in the manifest (no more `settings.json` backup)
+- Re-running `install` now performs a clean upgrade: files a previous install created but the current repo no longer ships are pruned, and the `settings.json` merge is re-synced so a hook whose launcher command changed is replaced instead of duplicated. The manifest now also records `updatedAt`. Shared merge/subtract logic extracted to `lib/settings.js` with direct unit tests
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ removed, backed-up files (`CLAUDE.md`, `pre-commit`) are restored, and `settings
 reverted by **subtracting only the entries install added** — so hooks or permissions added
 to it afterwards by other tools or by hand are kept intact.
 
+Re-running `install.js` performs an in-place **upgrade**: files are refreshed, files a
+previous install created but the current repo no longer ships are pruned, and the
+`settings.json` merge is re-synced — a hook whose launcher command changed is replaced
+rather than duplicated. The manifest tracks `installedAt` and `updatedAt`.
+
 ```
 node install.js --dry-run      # preview without writing
 node install.js --no-git-hook  # skip .git/hooks/pre-commit copy

--- a/install.js
+++ b/install.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { mergeSettings, additionsFromRepo, subtractAdditions } = require('./lib/settings');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const SKIP_GIT = process.argv.includes('--no-git-hook');
@@ -20,8 +21,29 @@ if (fs.existsSync(manifestPath)) {
   catch { warn(`existing manifest unreadable — overwriting: ${manifestPath}`); }
 }
 
+// Every dest path written this run, so upgrade can prune files a previous
+// install created but the current repo no longer ships.
+const written = new Set();
+
 function isTracked(dest) {
   return manifest.createdFiles.includes(dest) || manifest.backups.some(b => b.dest === dest);
+}
+
+function isInside(p, stopAt) {
+  const rel = path.relative(stopAt, p);
+  return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+function pruneEmptyDirs(start, stopAt) {
+  if (DRY_RUN) return;
+  let dir = start;
+  while (isInside(dir, stopAt) && fs.existsSync(dir)) {
+    try {
+      if (fs.readdirSync(dir).length) break;
+      fs.rmdirSync(dir);
+    } catch { break; }
+    dir = path.dirname(dir);
+  }
 }
 
 function backupPathFor(dest) {
@@ -50,6 +72,7 @@ function copyFile(src, dest) {
     fs.copyFileSync(src, dest);
   }
   if (wasMissing && !isTracked(dest)) manifest.createdFiles.push(dest);
+  written.add(dest);
   log(`  ${logPrefix} ${path.relative(repoDir, src)} → ${dest}`);
 }
 
@@ -64,88 +87,11 @@ function copyDir(srcDir, destDir, exclude = new Set()) {
   }
 }
 
-function mergeUnique(existing, incoming) {
-  return [...new Set([...existing, ...incoming])];
-}
-
-function mergeHookEvent(existing, incoming) {
-  const existingCmds = new Set();
-  for (const entry of existing)
-    for (const h of (entry.hooks || []))
-      if (h.command) existingCmds.add(h.command);
-
-  const result = [...existing];
-  const addedCommands = [];
-  for (const entry of incoming) {
-    const newHooks = (entry.hooks || []).filter(h => !existingCmds.has(h.command));
-    if (newHooks.length) {
-      result.push({ ...entry, hooks: newHooks });
-      for (const h of newHooks) if (h.command) addedCommands.push(h.command);
-    }
-  }
-  return { result, addedCommands };
-}
-
-// Merge repo hooks/permissions into existing, recording the exact items added
-// (hook command strings per event, permission entries per key). Uninstall later
-// subtracts precisely these, so post-install changes by other tools survive.
-function mergeSettings(existing, repo) {
-  const out = structuredClone(existing);
-  const additions = { hooks: {}, permissions: {} };
-
-  if (repo.hooks) {
-    out.hooks = out.hooks || {};
-    for (const [ev, entries] of Object.entries(repo.hooks)) {
-      const { result, addedCommands } = mergeHookEvent(out.hooks[ev] || [], entries);
-      out.hooks[ev] = result;
-      if (addedCommands.length) additions.hooks[ev] = addedCommands;
-    }
-  }
-
-  if (repo.permissions) {
-    out.permissions = out.permissions || {};
-    for (const key of ['allow', 'ask', 'deny']) {
-      if (!repo.permissions[key]) continue;
-      const existingArr = out.permissions[key] || [];
-      const existingSet = new Set(existingArr);
-      const addedPerms = repo.permissions[key].filter(p => !existingSet.has(p));
-      out.permissions[key] = mergeUnique(existingArr, repo.permissions[key]);
-      if (addedPerms.length) additions.permissions[key] = addedPerms;
-    }
-  }
-
-  return { out, additions };
-}
-
-// Additions when settings.json is created from scratch: everything the repo
-// settings contribute (the whole file is install-owned).
-function additionsFromRepo(repo) {
-  const additions = { hooks: {}, permissions: {} };
-  for (const [ev, entries] of Object.entries(repo.hooks || {})) {
-    const cmds = [];
-    for (const entry of entries)
-      for (const h of (entry.hooks || []))
-        if (h.command) cmds.push(h.command);
-    if (cmds.length) additions.hooks[ev] = cmds;
-  }
-  for (const key of ['allow', 'ask', 'deny'])
-    if (repo.permissions?.[key]?.length) additions.permissions[key] = [...repo.permissions[key]];
-  return additions;
-}
-
-// Record (or accumulate across reinstalls) what install added to settings.json.
-// The earliest `preexisted` flag wins; additions are unioned so a reinstall with
-// a newer repo settings still registers any extra items for removal.
+// Record what install currently owns in settings.json. Because installSettings
+// strips the previous install's additions before re-merging, `additions` always
+// describes current ownership exactly — so this replaces, never accumulates.
 function recordSettings(dest, preexisted, additions) {
-  if (!manifest.settings || manifest.settings.dest !== dest) {
-    manifest.settings = { dest, preexisted, additions };
-    return;
-  }
-  const s = manifest.settings;
-  for (const [ev, cmds] of Object.entries(additions.hooks || {}))
-    s.additions.hooks[ev] = [...new Set([...(s.additions.hooks[ev] || []), ...cmds])];
-  for (const [key, vals] of Object.entries(additions.permissions || {}))
-    s.additions.permissions[key] = [...new Set([...(s.additions.permissions[key] || []), ...vals])];
+  manifest.settings = { dest, preexisted, additions };
 }
 
 function installSettings() {
@@ -153,24 +99,33 @@ function installSettings() {
   if (!fs.existsSync(src)) { warn(`source not found: ${src}`); return; }
   const dest = path.join(claudeDir, 'settings.json');
   const repo = JSON.parse(fs.readFileSync(src, 'utf8'));
+  written.add(dest);
 
   // settings.json is merged, not snapshot-replaced: uninstall reverts by
   // subtracting exactly what was added, so no backup is taken here.
+  const prior = manifest.settings?.dest === dest ? manifest.settings : null;
+
   if (!fs.existsSync(dest)) {
     if (!DRY_RUN) {
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       fs.copyFileSync(src, dest);
     }
-    recordSettings(dest, false, additionsFromRepo(repo));
+    recordSettings(dest, prior ? prior.preexisted : false, additionsFromRepo(repo));
     log(`  ${logPrefix} config/settings.json → ${dest} (created)`);
     return;
   }
+
   let existing;
   try { existing = JSON.parse(fs.readFileSync(dest, 'utf8')); }
   catch { warn(`${dest} is not valid JSON — skipping merge`); return; }
-  const { out: merged, additions } = mergeSettings(existing, repo);
+
+  // On upgrade, strip what the previous install added before re-merging the
+  // current repo settings. This drops entries that drifted (e.g. a changed hook
+  // command) or were removed upstream, instead of leaving stale duplicates.
+  const base = prior ? subtractAdditions(existing, prior.additions) : existing;
+  const { out: merged, additions } = mergeSettings(base, repo);
   if (!DRY_RUN) fs.writeFileSync(dest, JSON.stringify(merged, null, 2) + '\n');
-  recordSettings(dest, true, additions);
+  recordSettings(dest, prior ? prior.preexisted : true, additions);
   log(`  ${logPrefix} config/settings.json → ${dest} (merged)`);
   for (const [ev, cmds] of Object.entries(additions.hooks))
     log(`      added ${cmds.length} hook${cmds.length === 1 ? '' : 's'} to ${ev}`);
@@ -185,6 +140,7 @@ function installCLAUDEmd() {
     fs.mkdirSync(path.dirname(dest), { recursive: true });
     fs.copyFileSync(src, dest);
   }
+  written.add(dest);
   log(`  ${logPrefix} config/CLAUDE.md → ${dest}`);
 }
 
@@ -236,6 +192,26 @@ if (!SKIP_GIT) {
   installGitHook();
 }
 
+// Upgrade hygiene: remove files a previous install created under claudeDir that
+// the current repo no longer ships (renamed/deleted hooks, tools, skills).
+// Scoped to claudeDir so the git pre-commit hook (outside it) is never touched.
+log('\npruning files no longer shipped:');
+const orphans = manifest.createdFiles.filter(
+  f => isInside(f, claudeDir) && !written.has(f) && fs.existsSync(f),
+);
+for (const f of orphans) {
+  if (!DRY_RUN) fs.unlinkSync(f);
+  log(`  ${logPrefix} removed ${f}`);
+}
+if (orphans.length) {
+  const orphanSet = new Set(orphans);
+  manifest.createdFiles = manifest.createdFiles.filter(f => !orphanSet.has(f));
+  for (const dir of new Set(orphans.map(f => path.dirname(f)))) pruneEmptyDirs(dir, claudeDir);
+} else {
+  log(`  ${logPrefix} (none)`);
+}
+
+manifest.updatedAt = new Date().toISOString();
 if (!DRY_RUN) fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
 log(`\nManifest: ${manifestPath}`);
 log('Done.');

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// Pure helpers for the additive settings.json merge shared by install.js and
+// uninstall.js. install merges the repo's hooks/permissions in and records the
+// exact items added; uninstall (and a reinstall) subtract precisely those, so a
+// user's or another tool's settings are never clobbered.
+
+function mergeUnique(existing, incoming) {
+  return [...new Set([...existing, ...incoming])];
+}
+
+// Append the incoming hook entries whose command is not already present, and
+// report which command strings were actually added.
+function mergeHookEvent(existing, incoming) {
+  const existingCmds = new Set();
+  for (const entry of existing)
+    for (const h of (entry.hooks || []))
+      if (h.command) existingCmds.add(h.command);
+
+  const result = [...existing];
+  const addedCommands = [];
+  for (const entry of incoming) {
+    const newHooks = (entry.hooks || []).filter(h => !existingCmds.has(h.command));
+    if (newHooks.length) {
+      result.push({ ...entry, hooks: newHooks });
+      for (const h of newHooks) if (h.command) addedCommands.push(h.command);
+    }
+  }
+  return { result, addedCommands };
+}
+
+// Merge repo hooks/permissions into existing, returning the merged object and a
+// record of the exact additions (hook commands per event, permission entries per
+// key) for later subtraction.
+function mergeSettings(existing, repo) {
+  const out = structuredClone(existing);
+  const additions = { hooks: {}, permissions: {} };
+
+  if (repo.hooks) {
+    out.hooks = out.hooks || {};
+    for (const [ev, entries] of Object.entries(repo.hooks)) {
+      const { result, addedCommands } = mergeHookEvent(out.hooks[ev] || [], entries);
+      out.hooks[ev] = result;
+      if (addedCommands.length) additions.hooks[ev] = addedCommands;
+    }
+  }
+
+  if (repo.permissions) {
+    out.permissions = out.permissions || {};
+    for (const key of ['allow', 'ask', 'deny']) {
+      if (!repo.permissions[key]) continue;
+      const existingArr = out.permissions[key] || [];
+      const existingSet = new Set(existingArr);
+      const addedPerms = repo.permissions[key].filter(p => !existingSet.has(p));
+      out.permissions[key] = mergeUnique(existingArr, repo.permissions[key]);
+      if (addedPerms.length) additions.permissions[key] = addedPerms;
+    }
+  }
+
+  return { out, additions };
+}
+
+// Additions when settings.json is created from scratch — everything the repo
+// settings contribute (the whole managed surface is install-owned).
+function additionsFromRepo(repo) {
+  const additions = { hooks: {}, permissions: {} };
+  for (const [ev, entries] of Object.entries(repo.hooks || {})) {
+    const cmds = [];
+    for (const entry of entries)
+      for (const h of (entry.hooks || []))
+        if (h.command) cmds.push(h.command);
+    if (cmds.length) additions.hooks[ev] = cmds;
+  }
+  for (const key of ['allow', 'ask', 'deny'])
+    if (repo.permissions?.[key]?.length) additions.permissions[key] = [...repo.permissions[key]];
+  return additions;
+}
+
+// Remove exactly the recorded additions from a settings object, pruning emptied
+// hook entries/events and permission keys. Mutates and returns `settings`.
+function subtractAdditions(settings, additions = {}) {
+  for (const [ev, cmds] of Object.entries(additions.hooks || {})) {
+    if (!settings.hooks?.[ev]) continue;
+    const rm = new Set(cmds);
+    settings.hooks[ev] = settings.hooks[ev]
+      .map(entry => ({ ...entry, hooks: (entry.hooks || []).filter(h => !rm.has(h.command)) }))
+      .filter(entry => (entry.hooks || []).length > 0);
+    if (settings.hooks[ev].length === 0) delete settings.hooks[ev];
+  }
+  if (settings.hooks && Object.keys(settings.hooks).length === 0) delete settings.hooks;
+
+  for (const [key, vals] of Object.entries(additions.permissions || {})) {
+    if (!settings.permissions?.[key]) continue;
+    const rm = new Set(vals);
+    settings.permissions[key] = settings.permissions[key].filter(p => !rm.has(p));
+    if (settings.permissions[key].length === 0) delete settings.permissions[key];
+  }
+  if (settings.permissions && Object.keys(settings.permissions).length === 0) delete settings.permissions;
+
+  return settings;
+}
+
+// True when nothing but an optional $schema key remains.
+function isEffectivelyEmpty(settings) {
+  return Object.keys(settings).filter(k => k !== '$schema').length === 0;
+}
+
+module.exports = {
+  mergeUnique,
+  mergeHookEvent,
+  mergeSettings,
+  additionsFromRepo,
+  subtractAdditions,
+  isEffectivelyEmpty,
+};

--- a/test/install-uninstall.test.js
+++ b/test/install-uninstall.test.js
@@ -203,3 +203,71 @@ test('uninstall on dir with no manifest is a no-op', () => {
     assert.deepStrictEqual(fs.readdirSync(dir), []);
   } finally { rmTmp(dir); }
 });
+
+test('upgrade prunes a file a previous install created but no longer ships', () => {
+  const dir = mkTmp();
+  try {
+    runInstall(dir);
+    // A file shipped by an earlier version, still tracked in the manifest.
+    const stale = path.join(dir, 'tools', 'obsolete.js');
+    fs.writeFileSync(stale, '// removed upstream');
+    const mpath = path.join(dir, '.claude-config-manifest.json');
+    const m = JSON.parse(fs.readFileSync(mpath, 'utf8'));
+    m.createdFiles.push(stale);
+    fs.writeFileSync(mpath, JSON.stringify(m, null, 2) + '\n');
+
+    const r = runInstall(dir);
+    assert.strictEqual(r.status, 0, r.stderr);
+    assert.ok(!fs.existsSync(stale), 'stale file removed on upgrade');
+    const m2 = JSON.parse(fs.readFileSync(mpath, 'utf8'));
+    assert.ok(!m2.createdFiles.includes(stale), 'stale file dropped from manifest');
+    assert.ok(fs.existsSync(path.join(dir, 'tools', 'bash-safety.js')), 'still-shipped file kept');
+  } finally { rmTmp(dir); }
+});
+
+test('upgrade replaces a drifted hook command instead of duplicating it', () => {
+  const dir = mkTmp();
+  try {
+    runInstall(dir);
+    const settingsPath = path.join(dir, 'settings.json');
+    const mpath = path.join(dir, '.claude-config-manifest.json');
+
+    const s = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const currentCmd = s.hooks.PreToolUse[0].hooks[0].command;
+    const oldCmd = 'node -e "OLD_LAUNCHER"';
+    // Rewrite both the file and the manifest as if the previous install used oldCmd.
+    s.hooks.PreToolUse = [{ hooks: [{ type: 'command', command: oldCmd }] }];
+    fs.writeFileSync(settingsPath, JSON.stringify(s, null, 2) + '\n');
+    const m = JSON.parse(fs.readFileSync(mpath, 'utf8'));
+    m.settings.additions.hooks.PreToolUse = [oldCmd];
+    fs.writeFileSync(mpath, JSON.stringify(m, null, 2) + '\n');
+
+    const r = runInstall(dir);
+    assert.strictEqual(r.status, 0, r.stderr);
+
+    const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const cmds = after.hooks.PreToolUse.flatMap(e => e.hooks.map(h => h.command));
+    assert.deepStrictEqual(cmds, [currentCmd], 'drifted command replaced, not duplicated');
+  } finally { rmTmp(dir); }
+});
+
+test('reinstall does not duplicate hook entries', () => {
+  const dir = mkTmp();
+  try {
+    runInstall(dir);
+    runInstall(dir);
+    const s = JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'));
+    for (const [ev, entries] of Object.entries(s.hooks))
+      assert.strictEqual(entries.length, 1, `${ev} has a single entry after reinstall`);
+  } finally { rmTmp(dir); }
+});
+
+test('manifest records installedAt and updatedAt', () => {
+  const dir = mkTmp();
+  try {
+    runInstall(dir);
+    const m = JSON.parse(fs.readFileSync(path.join(dir, '.claude-config-manifest.json'), 'utf8'));
+    assert.ok(m.installedAt, 'installedAt recorded');
+    assert.ok(m.updatedAt, 'updatedAt recorded');
+  } finally { rmTmp(dir); }
+});

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,0 +1,77 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  mergeSettings,
+  additionsFromRepo,
+  subtractAdditions,
+  isEffectivelyEmpty,
+} = require('../lib/settings');
+
+const hookEntry = cmd => ({ hooks: [{ type: 'command', command: cmd }] });
+const repo = cmds => ({ hooks: { PreToolUse: [hookEntry(cmds)] } });
+
+test('mergeSettings adds repo hooks into an empty object', () => {
+  const { out, additions } = mergeSettings({}, repo('CMD'));
+  assert.strictEqual(out.hooks.PreToolUse.length, 1);
+  assert.deepStrictEqual(additions.hooks.PreToolUse, ['CMD']);
+});
+
+test('mergeSettings does not re-add an existing command', () => {
+  const existing = { hooks: { PreToolUse: [hookEntry('CMD')] } };
+  const { out, additions } = mergeSettings(existing, repo('CMD'));
+  assert.strictEqual(out.hooks.PreToolUse.length, 1, 'no duplicate entry');
+  assert.deepStrictEqual(additions.hooks, {}, 'nothing recorded as added');
+});
+
+test('mergeSettings preserves foreign keys and permissions', () => {
+  const existing = { customField: 1, permissions: { allow: ['Bash(ls)'] } };
+  const { out } = mergeSettings(existing, { permissions: { allow: ['Read'] } });
+  assert.strictEqual(out.customField, 1);
+  assert.deepStrictEqual(out.permissions.allow, ['Bash(ls)', 'Read']);
+});
+
+test('mergeSettings records only newly added permission entries', () => {
+  const existing = { permissions: { allow: ['Read'] } };
+  const { additions } = mergeSettings(existing, { permissions: { allow: ['Read', 'Edit'] } });
+  assert.deepStrictEqual(additions.permissions.allow, ['Edit']);
+});
+
+test('additionsFromRepo lists every repo command and permission', () => {
+  const a = additionsFromRepo({ hooks: { PreToolUse: [hookEntry('CMD')] }, permissions: { ask: ['Bash(git push *)'] } });
+  assert.deepStrictEqual(a.hooks.PreToolUse, ['CMD']);
+  assert.deepStrictEqual(a.permissions.ask, ['Bash(git push *)']);
+});
+
+test('subtractAdditions removes recorded items and prunes empties', () => {
+  const settings = { hooks: { PreToolUse: [hookEntry('CMD')] }, permissions: { allow: ['Read'] } };
+  subtractAdditions(settings, { hooks: { PreToolUse: ['CMD'] }, permissions: { allow: ['Read'] } });
+  assert.ok(!settings.hooks, 'emptied hooks object pruned');
+  assert.ok(!settings.permissions, 'emptied permissions object pruned');
+});
+
+test('subtractAdditions keeps foreign entries alongside removed ones', () => {
+  const settings = { hooks: { PreToolUse: [hookEntry('CMD'), hookEntry('USER')] } };
+  subtractAdditions(settings, { hooks: { PreToolUse: ['CMD'] } });
+  const cmds = settings.hooks.PreToolUse.flatMap(e => e.hooks.map(h => h.command));
+  assert.deepStrictEqual(cmds, ['USER']);
+});
+
+test('strip-before-merge replaces a drifted command without duplicating', () => {
+  // First install registers CMD_V1 and records it as an addition.
+  const { out: v1, additions } = mergeSettings({}, repo('CMD_V1'));
+  // Upgrade: the repo command changed to CMD_V2.
+  const base = subtractAdditions(v1, additions);
+  const { out: v2 } = mergeSettings(base, repo('CMD_V2'));
+  const cmds = v2.hooks.PreToolUse.flatMap(e => e.hooks.map(h => h.command));
+  assert.deepStrictEqual(cmds, ['CMD_V2'], 'old command dropped, new one present, no duplicate');
+});
+
+test('isEffectivelyEmpty is true for {} and a $schema-only object', () => {
+  assert.strictEqual(isEffectivelyEmpty({}), true);
+  assert.strictEqual(isEffectivelyEmpty({ $schema: 'x' }), true);
+});
+
+test('isEffectivelyEmpty is false when any real key remains', () => {
+  assert.strictEqual(isEffectivelyEmpty({ $schema: 'x', permissions: {} }), false);
+});

--- a/uninstall.js
+++ b/uninstall.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { subtractAdditions, isEffectivelyEmpty } = require('./lib/settings');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
@@ -40,28 +41,11 @@ function revertSettings(record) {
   try { cur = JSON.parse(fs.readFileSync(dest, 'utf8')); }
   catch { warn(`${dest} is not valid JSON — leaving as-is`); return; }
 
-  for (const [ev, cmds] of Object.entries(additions.hooks || {})) {
-    if (!cur.hooks?.[ev]) continue;
-    const rm = new Set(cmds);
-    cur.hooks[ev] = cur.hooks[ev]
-      .map(entry => ({ ...entry, hooks: (entry.hooks || []).filter(h => !rm.has(h.command)) }))
-      .filter(entry => (entry.hooks || []).length > 0);
-    if (cur.hooks[ev].length === 0) delete cur.hooks[ev];
-  }
-  if (cur.hooks && Object.keys(cur.hooks).length === 0) delete cur.hooks;
-
-  for (const [key, vals] of Object.entries(additions.permissions || {})) {
-    if (!cur.permissions?.[key]) continue;
-    const rm = new Set(vals);
-    cur.permissions[key] = cur.permissions[key].filter(p => !rm.has(p));
-    if (cur.permissions[key].length === 0) delete cur.permissions[key];
-  }
-  if (cur.permissions && Object.keys(cur.permissions).length === 0) delete cur.permissions;
+  subtractAdditions(cur, additions);
 
   // Delete only a file install itself created that has nothing left but $schema;
   // a preexisting file (or one carrying foreign keys) is always rewritten, never removed.
-  const meaningful = Object.keys(cur).filter(k => k !== '$schema');
-  if (meaningful.length === 0 && !preexisted) {
+  if (isEffectivelyEmpty(cur) && !preexisted) {
     if (!DRY_RUN) fs.unlinkSync(dest);
     log(`  ${DRY_RUN ? '[dry]' : '    '} removed ${dest}`);
   } else {


### PR DESCRIPTION
## Summary
- Re-running `install.js` is now a real upgrade instead of an additive copy.
- Files a previous version shipped but the current repo no longer does (renamed/deleted hooks, tools, skills) are pruned instead of lingering and being invoked.
- A hook whose launcher command string changed between versions is now replaced in `settings.json` rather than duplicated.

> **Stacked on #7** (`feature/uninstall-surgical-settings`). Base will retarget to `main` automatically once #7 merges. Review/merge #7 first.

## Implementation
- Orphan pruning: after copying, `install` removes `manifest.createdFiles` entries it created that were not written this run, scoped to `claudeDir` via `isInside` so the external git `pre-commit` hook is never touched; emptied dirs are pruned. Pruned paths are dropped from the manifest.
- `settings.json` re-sync (strip-before-merge): before merging the current repo settings, `install` subtracts the previous install''s recorded additions (`manifest.settings.additions`). A drifted hook command is therefore removed and re-added as the current one (no duplicate), and entries removed upstream propagate. `recordSettings` becomes a replace, since the additions now describe current ownership exactly.
- Shared merge/subtract logic extracted to `lib/settings.js` (`mergeSettings`, `additionsFromRepo`, `subtractAdditions`, `isEffectivelyEmpty`), used by both `install.js` and `uninstall.js`. These scripts run from the repo and are not deployed, so a local `lib/` require is fine.
- Manifest gains an `updatedAt` timestamp (refreshed each run); `installedAt` is preserved from the first install.

## Test plan
- `node --test` — full suite green (124 tests).
- `test/settings.test.js` (new, 10 unit tests): merge add/dedup, additions recording, subtract + prune, foreign-entry preservation, the **drift** case (strip-then-merge yields a single current command), `isEffectivelyEmpty`.
- `test/install-uninstall.test.js` (+4 integration tests): orphan pruned on upgrade and dropped from manifest while still-shipped files are kept; drifted hook command replaced not duplicated; reinstall produces a single entry per event; manifest records `installedAt` + `updatedAt`.
- Manual Node-driven upgrade run confirmed: orphan pruned, manifest updated, `installedAt` preserved.
- Reviewer verification: `node --test test/settings.test.js test/install-uninstall.test.js`.