### PR TITLE
GH-9: Add issue-rules skill and naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@
 - `commit-trailer-guard` tool: blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
 - `SessionStart` hook: warn-only `submodule-status-check` (flags ahead/uninitialized/conflicted submodules) and `claude-md-skills-sync-check` (flags skills missing from CLAUDE.md's auto-apply list)
 - `bg-agent-counter` tool: tracks pending background agents; `Stop` notification deferred until all `run_in_background` agents complete, preventing premature "Task complete" toasts
+- `issue-rules` skill: title format (`Type(scope): Subject`), description templates for features and bugs (Goal, Acceptance criteria, Test plan), labels, priority levels (P0–P3), and lifecycle states
 
 ### Changed
 
+- `commit-rules` skill: added Branch Naming section — `<user>/<type>/<TRACKER-N>/<subject>` format, TRACKER-N omitted when no issue exists
+- `pr-rules` skill: added Workflow section (issue → branch → commits → PR → merge); PR title now uses tracker ID in place of `Type(scope)` when a tracked issue exists; subject starts with uppercase in all variants
 - `api-design` skill: added rationale behind structure rules and a new wrong/right example for the "no void*" rule
 - `skills-reminder` now generates its prompt from `skills/*/SKILL.md` frontmatter at runtime instead of a hardcoded list, so new skills appear automatically
 - `secret-guard` now scans `MultiEdit` and `NotebookEdit` content, not just `Edit`/`Write`

--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | `api-design` | C++ public API structure and hygiene |
 | `architecture` | System/module architecture design, ADRs, tradeoffs |
 | `changelog` | Keep a Changelog format |
-| `commit-rules` | Conventional Commits format |
+| `commit-rules` | Conventional Commits format and branch naming |
 | `cpp-coding` | C++ implementation conventions |
 | `cpp-testing` | Unit test structure (AAA, naming, coverage) |
 | `ddd` | Domain-Driven Design patterns in C++ |
 | `doxygen` | Doxygen tag coverage for public headers |
 | `editing` | File editing workflow (re-read before edit) |
 | `hook-scripts` | Writing Claude Code hooks and tools |
+| `issue-rules` | Tracker issue title, description, labels, priority, lifecycle |
 | `node-testing` | Conventions for this repo's `test/*.test.js` (node:test) |
 | `pr-rules` | PR title, description, merge strategy |
 | `project-planning` | Scoping, estimation, milestones, risk, status updates |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -16,7 +16,8 @@ When writing or reviewing C++ implementation code → apply `cpp-coding` skill.
 When designing public API, adding public headers, or reviewing public interface → apply `api-design` skill.
 When adding or modifying Doxygen comments on public headers → apply `doxygen` skill.
 When modelling domain objects, aggregates, or bounded contexts → apply `ddd` skill.
-When writing commit messages → apply `commit-rules` skill.
+When writing commit messages or naming branches → apply `commit-rules` skill.
+When creating or reviewing tracker issues → apply `issue-rules` skill.
 When opening, reviewing, or preparing a PR → apply `pr-rules` skill.
 When updating CHANGELOG.md → apply `changelog` skill.
 When preparing a release, bumping version, or tagging → apply `release` skill.

--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-rules
 version: "1.0.0"
-description: Apply when writing or reviewing commit messages
+description: Apply when writing or reviewing commit messages or naming branches
 license: Unlicense
 metadata:
   author: ssoft
@@ -78,6 +78,24 @@ feat(hash): add SipHash-2-4 keyed 64-bit hash
 SipHash provides hash-flooding resistance missing in fnv1a/djb2.
 Implements the reference SipHash-2-4 algorithm with a 128-bit key.
 Key is passed as two uint64_t values to avoid struct padding issues.
+```
+
+---
+
+## Branch Naming
+
+```
+<user>/<type>/<TRACKER-N>/<subject>
+```
+
+- **user** — git username (always; marks personal branches).
+- **type** — same values as commit types (`feat`, `fix`, `chore`, …).
+- **TRACKER-N** — issue identifier from the tracker (`PROJ-42`, `GH-7`, …). Omit the segment entirely when there is no tracked issue.
+- **subject** — kebab-case, imperative, concise.
+
+```
+<user>/feat/PROJ-42/add-siphash
+<user>/chore/update-submodule-refs
 ```
 
 ---

--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: issue-rules
+version: "1.0.0"
+description: Apply when creating or reviewing tracker issues
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - git
+    - issues
+    - tracker
+---
+
+# Skill: Issue Rules
+
+Apply when creating or reviewing tracker issues (GitHub Issues, Jira, Linear, …).
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own issue conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## Title
+
+```
+Type(scope): Subject description
+```
+
+- **Type** — capitalized (see Types table below).
+- **Scope** — optional; component or module the issue targets.
+- **Subject** — imperative mood, uppercase first letter after the colon, no trailing period, ≤ 80 characters total.
+
+```
+Feat(hash): Add SipHash-2-4 keyed 64-bit hash
+Fix(auth): Token expiry check uses < instead of <=
+Chore: Update CI runner to Ubuntu 24.04
+```
+
+---
+
+## Types
+
+| Type | When |
+|------|------|
+| `Feat` | New user-visible functionality |
+| `Fix` | Bug or regression |
+| `Refactor` | Code change with no behaviour change |
+| `Perf` | Performance improvement |
+| `Docs` | Documentation only |
+| `Test` | Test additions or changes |
+| `Chore` | Build, tooling, dependency updates |
+| `Ci` | CI/CD workflow changes |
+| `Style` | Formatting only (no logic change) |
+
+---
+
+## Description Template
+
+### Feature / improvement
+
+```markdown
+## Goal
+What problem does this solve and why now.
+
+## Acceptance criteria
+- [ ] Criterion one
+- [ ] Criterion two
+
+## Test plan
+- [ ] How to verify criterion one (manual steps or automated test name)
+- [ ] Edge cases to cover
+
+## Out of scope
+What is explicitly not part of this issue.
+```
+
+### Bug
+
+```markdown
+## Problem
+What is broken and what is the impact.
+
+## Steps to reproduce
+1. Step one
+2. Step two
+
+## Expected behaviour
+What should happen.
+
+## Actual behaviour
+What happens instead.
+
+## Test plan
+- [ ] Regression test that would have caught this bug
+- [ ] Steps a reviewer can run to confirm the fix
+
+## Environment
+OS, version, relevant config.
+```
+
+---
+
+## Labels
+
+Apply at most one type label (matches the title Type). Additional labels are orthogonal:
+
+| Label | When |
+|-------|------|
+| `breaking` | Public API change |
+| `blocked` | Cannot proceed — link the blocker |
+| `good first issue` | Self-contained, low risk |
+| `needs-design` | Requires ADR or design doc before implementation |
+
+---
+
+## Priority
+
+| Level | Meaning |
+|-------|---------|
+| P0 | Blocker — production broken or security issue |
+| P1 | High — significant user impact, next sprint |
+| P2 | Medium — normal backlog |
+| P3 | Low — nice to have, no deadline |
+
+Default when unset: **P2**.
+
+---
+
+## Milestone
+
+Assign to a milestone when the issue must ship in a specific release. Leave unset for backlog items with no committed date.
+
+---
+
+## Lifecycle
+
+```
+Open → In Progress → In Review → Done
+                              ↘ Closed (won't fix / duplicate)
+```
+
+- **Open** — triaged, not started.
+- **In Progress** — branch exists (see `commit-rules` Branch Naming).
+- **In Review** — PR open.
+- **Done** — merged and deployed.
+- **Closed** — explicitly not going to be fixed; add a comment explaining why.
+
+---
+
+## Cross-References
+
+- `commit-rules` — branch naming convention references the issue identifier (`TRACKER-N`).
+- `pr-rules` — PR title and description mirror the issue being resolved.

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -20,13 +20,54 @@ Project-local rules win. If the repository's `AGENTS.md` or a project skill defi
 
 ---
 
+## Workflow
+
+End-to-end flow from issue to merged PR.
+
+**1. Issue** — create in tracker (`issue-rules`):
+```
+Feat(hash): Add SipHash-2-4 keyed 64-bit hash   ← title
+PROJ-42                                           ← assigned ID
+```
+
+**2. Branch** — name before first commit (`commit-rules` → Branch Naming):
+```
+<user>/feat/PROJ-42/add-siphash
+```
+
+**3. Commits** — on the branch (`commit-rules`):
+```
+feat(hash): add SipHash-2-4 keyed 64-bit hash
+
+SipHash provides hash-flooding resistance missing in fnv1a/djb2.
+Implements SipHash-2-4 with a 128-bit key passed as two uint64_t.
+```
+
+**4. PR** — open when branch is ready (this skill):
+```
+PROJ-42: Add SipHash-2-4 keyed 64-bit hash
+```
+Description: `## Summary` + `## Implementation` + `## Test plan`.
+
+**5. Merge commit** — after review passes (this skill → Merge Strategy):
+`Merge PR #<n>: <pr title>` with a body. See Merge Strategy for the full rule.
+
+---
+
 ## PR Title
 
-Conventional Commits format, uppercase first letter, ≤ 120 characters:
+Type and subject both start with uppercase, ≤ 120 characters. Format depends on whether the PR resolves a tracked issue:
 
+**With issue** — tracker ID replaces `Type(scope)`:
 ```
-Feat(hash): add SipHash-2-4 keyed 64-bit hash
-Fix(wrapper): correct noexcept propagation through executor chain
+PROJ-42: Add SipHash-2-4 keyed 64-bit hash
+GH-7: Correct noexcept propagation through executor chain
+```
+
+**Without issue** — Conventional Commits format:
+```
+Feat(hash): Add SipHash-2-4 keyed 64-bit hash
+Fix(wrapper): Correct noexcept propagation through executor chain
 ```
 
 ---
@@ -71,7 +112,7 @@ All three sections are required. A PR with no test plan is not ready to review.
 
 1. **Rebase before merge.** `git rebase <target>` first; merge only when the branch sits on the current target tip.
 2. **`--no-ff` only.** No fast-forward merge. No squash merge.
-3. **Merge subject:** `Merge PR #<pr-number>: <pr subject>` — copy the PR subject verbatim. Do not re-prefix with `type(scope):` (the PR title already carries it; re-prefixing duplicates the type in the merged log).
+3. **Merge subject:** `Merge PR #<pr-number>: <pr subject>` — copy the PR subject verbatim. Do not re-prefix with `type(scope):` (the PR title already carries it; re-prefixing duplicates the type in the merged log). When the PR title starts with a tracker ID, `#<pr-number>` and `TRACKER-N` are distinct identifiers — both appear and that is correct (`Merge PR #7: PROJ-42: Add SipHash…`).
 4. **Merge subject length:** ≤ 120 characters (same limit as PR title; supersedes the 72-char rule in `commit-rules` for merge commits only).
 5. **Merge body required** — same rule as ordinary commits (`commit-rules`). Body explains what was integrated and why; never empty.
 6. **Trailers:** same ban as `commit-rules` — no AI-attribution. `Co-authored-by` injected by GitHub when committer differs from author is allowed.


### PR DESCRIPTION
## Summary
- New `issue-rules` skill: title format, description templates, labels, priority, lifecycle
- `commit-rules`: branch naming section (`<user>/<type>/<TRACKER-N>/<subject>`)
- `pr-rules`: workflow section (issue → branch → commits → PR), aligned PR title format (uppercase subject, tracker ID replaces Type(scope) when issue exists)
- `config/CLAUDE.md` and `README.md` updated to register `issue-rules`

## Implementation
- `issue-rules` follows the same project-overrides pattern as other skills
- Branch naming encodes username, commit type, tracker ID, and kebab subject; TRACKER-N segment omitted when no issue exists
- PR title has two forms: `TRACKER-N: Subject` (with issue) and `Feat(scope): Subject` (without); merge commit copies verbatim per existing rule
- Workflow section in `pr-rules` serves as a single-place reference for the full artifact chain

## Test plan
- [x] `node install.js` — no errors, `skills/issue-rules/` present in `~/.claude/skills/`
- [x] Read deployed `pr-rules` — Workflow section and updated PR Title examples visible
- [x] Read deployed `commit-rules` — Branch Naming section present
- [x] Read deployed `issue-rules` — both templates (feature/bug) and lifecycle present