### PR TITLE
GH-11: Gate PR merge on issue checklist completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Re-running `install` now performs a clean upgrade: files a previous install created but the current repo no longer ships are pruned, and the `settings.json` merge is re-synced so a hook whose launcher command changed is replaced instead of duplicated. The manifest now also records `updatedAt`. Shared merge/subtract logic extracted to `lib/settings.js` with direct unit tests
 - `pr-rules` skill: Workflow section now spells out the full order of actions (locate repo → find-or-create issue with a test plan and, for features, acceptance criteria → branch → commits → PR → pre-merge issue check → merge → conditional issue close); added a Pre-Merge Checklist that gates merge on the linked issue's checkbox state
 - `issue-rules` skill: `Done` lifecycle state now requires every checklist checkbox in the issue to be checked before closing; added a Progress Comments section requiring issue comments that record which PR/MR resolves which item
+- `pr-rules` Workflow now requires labels on the issue before implementation starts, and Pre-Open Checklist requires the PR to carry the issue's type label (+ `breaking` if applicable); `issue-rules` Labels section states when to set/revisit labels
 
 ### CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - C++ lint tools (`clang-format`, `clang-tidy`, `cppcheck`) now run only when their config file (`.clang-format` / `.clang-tidy` / `.cppcheck`) is present in the edited file's repository, never inheriting one from a parent repo — eliminates lint noise in unconfigured projects. `.cppcheck` is passed to cppcheck as `--suppressions-list`
 - `uninstall` now reverts `settings.json` by subtracting only the hooks and permissions `install` added, instead of restoring a snapshot taken at install time. Settings written to the file afterwards by other tools or by hand are preserved; `install` records the exact additions in the manifest (no more `settings.json` backup)
 - Re-running `install` now performs a clean upgrade: files a previous install created but the current repo no longer ships are pruned, and the `settings.json` merge is re-synced so a hook whose launcher command changed is replaced instead of duplicated. The manifest now also records `updatedAt`. Shared merge/subtract logic extracted to `lib/settings.js` with direct unit tests
+- `pr-rules` skill: Workflow section now spells out the full order of actions (locate repo → find-or-create issue with a test plan and, for features, acceptance criteria → branch → commits → PR → pre-merge issue check → merge → conditional issue close); added a Pre-Merge Checklist that gates merge on the linked issue's checkbox state
+- `issue-rules` skill: `Done` lifecycle state now requires every checklist checkbox in the issue to be checked before closing; added a Progress Comments section requiring issue comments that record which PR/MR resolves which item
 
 ### CI
 

--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -143,12 +143,24 @@ Open → In Progress → In Review → Done
 - **Open** — triaged, not started.
 - **In Progress** — branch exists (see `commit-rules` Branch Naming).
 - **In Review** — PR open.
-- **Done** — merged and deployed.
+- **Done** — merged and deployed, with every checklist checkbox in the issue checked (see `pr-rules` → Pre-Merge Checklist). If checkboxes remain after merge, stay **In Review** with a follow-up PR/MR linked — do not mark Done.
 - **Closed** — explicitly not going to be fixed; add a comment explaining why.
+
+---
+
+## Progress Comments
+
+Track implementation progress in comments, not only checkboxes:
+
+- When a PR/MR is opened against this issue, comment which checklist items it addresses.
+- When a PR/MR merges, comment which items it resolved and update the corresponding checkboxes to match.
+- When items remain open after a merge, comment that a follow-up PR/MR is needed, and link it once it exists.
+
+A reader should be able to reconstruct, from comments alone, which PR/MR implemented which requirement.
 
 ---
 
 ## Cross-References
 
 - `commit-rules` — branch naming convention references the issue identifier (`TRACKER-N`).
-- `pr-rules` — PR title and description mirror the issue being resolved.
+- `pr-rules` — PR title and description mirror the issue being resolved; Pre-Merge Checklist gates merge on this issue's checkbox state.

--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -112,6 +112,8 @@ Apply at most one type label (matches the title Type). Additional labels are ort
 | `good first issue` | Self-contained, low risk |
 | `needs-design` | Requires ADR or design doc before implementation |
 
+Set labels when the issue is created, not after. Revisit them when scope changes — add `blocked` once a dependency appears, remove it once resolved. The PR carries the same type label (+ `breaking` if applicable) — see `pr-rules` → Pre-Open Checklist.
+
 ---
 
 ## Priority

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -22,13 +22,17 @@ Project-local rules win. If the repository's `AGENTS.md` or a project skill defi
 
 ## Workflow
 
-End-to-end flow from issue to merged PR.
+End-to-end order of actions from a new task to a merged, closed issue. Steps run in order — do not open a PR before step 1 is satisfied, do not merge before step 5 is satisfied.
 
-**1. Issue** — create in tracker (`issue-rules`):
+**1. Scope and issue** — before any code change:
+- Identify the repository the change belongs to (root repo or a submodule); the issue is created and tracked there, not in the root repo.
+- Search the tracker for an existing issue covering the task. If found, check it has a test plan and, for features, acceptance criteria (`issue-rules` → Description Template); if incomplete for this task, update the issue before writing code.
+- If no issue exists, create one in that repository (`issue-rules`):
 ```
 Feat(hash): Add SipHash-2-4 keyed 64-bit hash   ← title
 PROJ-42                                           ← assigned ID
 ```
+An issue without a test plan (and, for features, acceptance criteria) is not ready to implement against.
 
 **2. Branch** — name before first commit (`commit-rules` → Branch Naming):
 ```
@@ -49,8 +53,12 @@ PROJ-42: Add SipHash-2-4 keyed 64-bit hash
 ```
 Description: `## Summary` + `## Implementation` + `## Test plan`.
 
-**5. Merge commit** — after review passes (this skill → Merge Strategy):
+**5. Pre-merge issue check** — before merging (this skill → Pre-Merge Checklist): reconcile every checkbox in the linked issue against what the PR actually delivers, and comment on the issue which items it resolves.
+
+**6. Merge commit** — after review passes and step 5 clears (this skill → Merge Strategy):
 `Merge PR #<n>: <pr title>` with a body. See Merge Strategy for the full rule.
+
+**7. Close issue** — only when every checklist checkbox in the issue is checked (`issue-rules` → Lifecycle). If items remain, leave the issue open and note the follow-up PR/MR in a comment instead of closing.
 
 ---
 
@@ -104,20 +112,34 @@ All three sections are required. A PR with no test plan is not ready to review.
 
 ---
 
+## Pre-Merge Checklist
+
+Gates the merge itself — distinct from the Pre-Open Checklist above, which gates opening the PR. Run this against the issue linked in the PR title, not just the PR description.
+
+- [ ] Every checklist checkbox in the issue reflects actual current state, not the state at issue-creation time
+- [ ] Each checkbox now checked is verifiable from what shipped in this PR or an earlier merged PR
+- [ ] Every unchecked item either is out of scope for this PR or has a linked follow-up PR/MR
+- [ ] A comment is added to the issue recording which PR/MR resolves which item (`issue-rules` → Progress Comments)
+
+**Merge gate:** merge only if every item in the issue is checked, or the remaining unchecked items already have a follow-up PR/MR linked in an issue comment. An issue with unchecked items and no plan to address them blocks the merge.
+
+---
+
 ## Merge Strategy
 
 **Rebase, then merge with `--no-ff`** — explicit merge commit per topic; linear first-parent history on protected branches.
 
 ### Rules
 
-1. **Rebase before merge.** `git rebase <target>` first; merge only when the branch sits on the current target tip.
-2. **`--no-ff` only.** No fast-forward merge. No squash merge.
-3. **Merge subject:** `Merge PR #<pr-number>: <pr subject>` — copy the PR subject verbatim. Do not re-prefix with `type(scope):` (the PR title already carries it; re-prefixing duplicates the type in the merged log). When the PR title starts with a tracker ID, `#<pr-number>` and `TRACKER-N` are distinct identifiers — both appear and that is correct (`Merge PR #7: PROJ-42: Add SipHash…`).
-4. **Merge subject length:** ≤ 120 characters (same limit as PR title; supersedes the 72-char rule in `commit-rules` for merge commits only).
-5. **Merge body required** — same rule as ordinary commits (`commit-rules`). Body explains what was integrated and why; never empty.
-6. **Trailers:** same ban as `commit-rules` — no AI-attribution. `Co-authored-by` injected by GitHub when committer differs from author is allowed.
-7. **Cleanup before opening the PR.** Squash fixups via `git commit --fixup=<hash>` + `git rebase -i --autosquash` (per `commit-rules`). Never at merge time.
-8. **Rewrite squashed commit bodies** to reflect the final state (see `commit-rules`).
+1. **Issue gate.** Merge only after the Pre-Merge Checklist above passes.
+2. **Rebase before merge.** `git rebase <target>` first; merge only when the branch sits on the current target tip.
+3. **`--no-ff` only.** No fast-forward merge. No squash merge.
+4. **Merge subject:** `Merge PR #<pr-number>: <pr subject>` — copy the PR subject verbatim. Do not re-prefix with `type(scope):` (the PR title already carries it; re-prefixing duplicates the type in the merged log). When the PR title starts with a tracker ID, `#<pr-number>` and `TRACKER-N` are distinct identifiers — both appear and that is correct (`Merge PR #7: PROJ-42: Add SipHash…`).
+5. **Merge subject length:** ≤ 120 characters (same limit as PR title; supersedes the 72-char rule in `commit-rules` for merge commits only).
+6. **Merge body required** — same rule as ordinary commits (`commit-rules`). Body explains what was integrated and why; never empty.
+7. **Trailers:** same ban as `commit-rules` — no AI-attribution. `Co-authored-by` injected by GitHub when committer differs from author is allowed.
+8. **Cleanup before opening the PR.** Squash fixups via `git commit --fixup=<hash>` + `git rebase -i --autosquash` (per `commit-rules`). Never at merge time.
+9. **Rewrite squashed commit bodies** to reflect the final state (see `commit-rules`).
 
 ### Rationale
 

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -27,6 +27,7 @@ End-to-end order of actions from a new task to a merged, closed issue. Steps run
 **1. Scope and issue** — before any code change:
 - Identify the repository the change belongs to (root repo or a submodule); the issue is created and tracked there, not in the root repo.
 - Search the tracker for an existing issue covering the task. If found, check it has a test plan and, for features, acceptance criteria (`issue-rules` → Description Template); if incomplete for this task, update the issue before writing code.
+- Apply labels — type label matches the title Type, plus any orthogonal labels that apply (`issue-rules` → Labels).
 - If no issue exists, create one in that repository (`issue-rules`):
 ```
 Feat(hash): Add SipHash-2-4 keyed 64-bit hash   ← title
@@ -104,6 +105,7 @@ All three sections are required. A PR with no test plan is not ready to review.
 ## Pre-Open Checklist
 
 - [ ] CI green on all targets declared in the project
+- [ ] PR carries the issue's type label (+ `breaking` if applicable) — see `issue-rules` → Labels
 - [ ] `CHANGELOG.md` updated — every user-visible change documented
 - [ ] `git submodule status` — no `+` prefix on any module
 - [ ] Every commit in the branch builds independently (no broken intermediate state)


### PR DESCRIPTION
## Summary
- `pr-rules` Workflow now spells out the full ordered sequence from a new task to a merged, closed issue, instead of a loose 5-step summary
- Merge is now gated on the linked issue's checklist state via a new Pre-Merge Checklist
- `issue-rules` `Done` state and a new Progress Comments section keep the issue as the source of truth for what's actually resolved
- Label assignment is now tied to the workflow: issue labels are required before implementation starts, and the PR must carry the issue's type label (+ `breaking` if applicable)

## Implementation
- `pr-rules`: Workflow expanded from 5 to 7 steps (scope/issue → branch → commits → PR → pre-merge issue check → merge → conditional close), with a labels bullet in step 1; added `Pre-Merge Checklist` section before `Merge Strategy`; `Merge Strategy` rule 1 now points at that gate; `Pre-Open Checklist` gained a PR-labels item
- `issue-rules`: `Done` lifecycle bullet requires every checklist checkbox checked (generalized wording so it doesn't assume Acceptance Criteria exists on bug-template issues, which only have a Test plan); added `Progress Comments` section; `Labels` section now states labels are set at issue creation and revisited on scope change
- Cross-references between the two skills updated; dropped an inaccurate pointer to `submodule-sync` for issue/repo scoping
- `CHANGELOG.md` documents all skill changes

## Test plan
- Read both deployed `SKILL.md` files end to end for internal consistency (step numbering, cross-references, checklist wording against both the Feature and Bug description templates)
- Verified no remaining "acceptance-criteria/test-plan checkbox" phrasing that would be unsatisfiable for bug-type issues
- No code/build changes — documentation only, `npm test` unaffected

Refs #11