### PR TITLE
GH-13: Add comments and encapsulation skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `SessionStart` hook: warn-only `submodule-status-check` (flags ahead/uninitialized/conflicted submodules) and `claude-md-skills-sync-check` (flags skills missing from CLAUDE.md's auto-apply list)
 - `bg-agent-counter` tool: tracks pending background agents; `Stop` notification deferred until all `run_in_background` agents complete, preventing premature "Task complete" toasts
 - `issue-rules` skill: title format (`Type(scope): Subject`), description templates for features and bugs (Goal, Acceptance criteria, Test plan), labels, priority levels (P0–P3), and lifecycle states
+- Skills: `comments` (non-Doxygen comment style — brief, general, no fix narration), `encapsulation` (public/protected/private access-specifier discipline)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | `api-design` | C++ public API structure and hygiene |
 | `architecture` | System/module architecture design, ADRs, tradeoffs |
 | `changelog` | Keep a Changelog format |
+| `comments` | Non-Doxygen code comment style (brief, general, no fix narration) |
 | `commit-rules` | Conventional Commits format and branch naming |
 | `cpp-coding` | C++ implementation conventions |
 | `cpp-testing` | Unit test structure (AAA, naming, coverage) |
 | `ddd` | Domain-Driven Design patterns in C++ |
 | `doxygen` | Doxygen tag coverage for public headers |
 | `editing` | File editing workflow (re-read before edit) |
+| `encapsulation` | Access-specifier discipline (public/protected/private) |
 | `hook-scripts` | Writing Claude Code hooks and tools |
 | `issue-rules` | Tracker issue title, description, labels, priority, lifecycle |
 | `node-testing` | Conventions for this repo's `test/*.test.js` (node:test) |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -13,8 +13,11 @@ Local commits, local file edits within a git repo, and read operations do not re
 ## Skills — auto-apply
 
 When writing or reviewing C++ implementation code → apply `cpp-coding` skill.
+When writing, reviewing, or adding tests to C++ code → apply `cpp-testing` skill.
 When designing public API, adding public headers, or reviewing public interface → apply `api-design` skill.
+When choosing access specifiers or reviewing member visibility → apply `encapsulation` skill.
 When adding or modifying Doxygen comments on public headers → apply `doxygen` skill.
+When writing or reviewing non-Doxygen code comments → apply `comments` skill.
 When modelling domain objects, aggregates, or bounded contexts → apply `ddd` skill.
 When writing commit messages or naming branches → apply `commit-rules` skill.
 When creating or reviewing tracker issues → apply `issue-rules` skill.

--- a/skills/comments/SKILL.md
+++ b/skills/comments/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: comments
+version: "1.0.0"
+description: Apply when writing or reviewing non-Doxygen code comments (inline notes, implementation comments)
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - cpp
+    - comments
+    - style
+---
+
+# Skill: Code Comments
+
+Apply when writing or reviewing non-Doxygen code comments (inline notes, implementation comments).
+
+Doc comments on public headers → `doxygen` skill. This skill covers everything else: comments inside function bodies, `.cpp` files, private implementation.
+
+---
+
+## Philosophy
+
+Code documents itself. A comment is a fallback for what naming, structure, and types cannot express — not a first resort.
+
+- **Write a comment only when actually required** — first try to make the code self-explanatory (better names, extracted function, clearer types). If that succeeds, no comment is needed.
+- **Keep it short** — one line. No multi-line prose blocks outside Doxygen.
+- **General character, not case history** — state a timeless fact about the code (an invariant, a constraint, a non-obvious reason), not the story of how it got that way.
+
+## When a Comment Is Justified
+
+Only for something the code cannot say itself:
+- A hidden constraint or external requirement (e.g., a protocol quirk, a platform limitation)
+- A subtle invariant the reader could otherwise break by "simplifying"
+- A workaround, stated in general terms (what breaks and why), not as a changelog entry
+- Behavior that would genuinely surprise a careful reader
+
+## What Never Belongs in a Comment
+
+- **References to the current task, ticket, bug ID, or "just fixed"** — that belongs in the commit message, not the code. A comment describing the fix for an error introduced moments ago is a diary entry, not documentation, and it rots the moment the surrounding code changes again.
+- **What the code already says** — if removing the comment loses no information, delete it.
+- **Narration of a specific decision's private context** ("we chose X because the other team asked", "temporary until Y ships") — write the general constraint instead, or put case-specific context in the commit message / PR description.
+- **Multi-paragraph explanations** — a sign the design needs fixing: extract the invariant into a named function or type instead of writing a wall of prose around it.
+
+```cpp
+// Wrong — narrates a private fix history, will rot, belongs in commit message
+// Fixed crash reported in issue #482: connection was null after close.
+if (connection == nullptr) return;
+
+// Correct — general, timeless fact about the code
+// Upstream API returns null once the connection is closed.
+if (connection == nullptr) return;
+```
+
+## Cross-References
+
+- `commit-rules` — where task/fix/ticket context actually belongs

--- a/skills/encapsulation/SKILL.md
+++ b/skills/encapsulation/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: encapsulation
+version: "1.0.0"
+description: Apply when choosing access specifiers, designing a class's public/protected/private surface, or reviewing member visibility
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - cpp
+    - encapsulation
+    - api
+---
+
+# Skill: Encapsulation
+
+Apply when choosing access specifiers, designing a class's public/protected/private surface, or reviewing member visibility.
+
+Public API structure across headers/modules → `api-design`. This skill covers access-level choice within a single type.
+
+---
+
+## Default Rule
+
+**Private by default.** Every member starts `private`. Widen only when a real caller outside the class needs it.
+
+- **`public`** — only members actually used from outside the class: the genuine external contract.
+- **`protected`** — only members actually used by derived classes (extension points, never a substitute for `public` "just in case"). Prefer `protected` virtual methods over `protected` data members — derived classes should go through behavior, not touch raw state.
+- **`private`** — everything else, including implementation helpers and internals derived classes don't need.
+- **Reviewing existing code** — a `public` method with no external caller demotes to `private`; one only called by derived classes demotes to `protected`.
+- **`friend`** — only for tightly-coupled pairs (e.g. a builder and its product), never as a shortcut to avoid picking the right access level.
+
+**Why:** every `public` member is a promise to every caller — widening later is free, narrowing is a breaking change. Defaulting to `private` keeps that promise as small as possible until proven otherwise.
+
+```cpp
+class Shape {
+public:
+    // Used by callers outside the hierarchy — genuine external contract
+    [[nodiscard]] double area() const { return compute_area(); }
+
+protected:
+    // Extension point — only derived classes override this
+    virtual double compute_area() const = 0;
+
+private:
+    // Implementation detail — no external or derived-class caller
+    void normalize_cache() const;
+};
+```
+
+## Cross-References
+
+- `ddd` — aggregate roots and internal-entity exposure


### PR DESCRIPTION
## Summary
- Add `comments` skill: non-Doxygen comment style (brief, only when required, general/timeless — never a diary of a just-fixed bug or ticket)
- Add `encapsulation` skill: private-by-default access-specifier discipline (public only for real external callers, protected only for derived-class extension points)
- Register both in README.md's skill table and config/CLAUDE.md's auto-apply trigger list
- Document both in CHANGELOG.md

## Implementation
- Each new SKILL.md follows the existing template (frontmatter, "Apply when" scope line, cross-references) and defers to sibling skills (`doxygen`, `api-design`, `ddd`) rather than restating their rules, avoiding duplication across the skill set
- Went through two review passes (`/simplify`) that collapsed duplicate tables/sections, trimmed a cross-reference that had drifted into paraphrasing `ddd`'s own rule text, fixed a `comments` rule that pointed at a Doxygen destination excluded by `doxygen`'s own scope, and tightened the `config/CLAUDE.md` trigger wording

## Test plan
- [x] `npm test` — 128/128 pass, including `claude-md-skills-sync-check` (confirms no skill is missing from CLAUDE.md's auto-apply list)
- [x] Manual read-through of both `SKILL.md` files against sibling skills for structural and stylistic consistency

Closes #13