### PR TITLE
GH-15: Reduce label scheme to type + topic labels

### DIFF
--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -103,16 +103,31 @@ OS, version, relevant config.
 
 ## Labels
 
-Apply at most one type label (matches the title Type). Additional labels are orthogonal:
+Every issue gets at most one **type** label, matching the title Type, when one applies:
 
-| Label | When |
-|-------|------|
-| `breaking` | Public API change |
-| `blocked` | Cannot proceed — link the blocker |
-| `good first issue` | Self-contained, low risk |
-| `needs-design` | Requires ADR or design doc before implementation |
+| Label | Title Types it covers |
+|-------|------------------------|
+| `Feature` | `Feat` |
+| `BUG` | `Fix` |
+| `Refactor` | `Refactor` |
 
-Set labels when the issue is created, not after. Revisit them when scope changes — add `blocked` once a dependency appears, remove it once resolved. The PR carries the same type label (+ `breaking` if applicable) — see `pr-rules` → Pre-Open Checklist.
+Title types other than these three (see the Types table above) carry no label — the title prefix alone is enough.
+
+Every issue also gets a few **topic** labels (2-4, not a tag cloud) — named after the
+actual subject matter (component, subsystem, domain concept), not drawn from a fixed
+list. Before creating one, check the tracker's existing labels (e.g. `gh label list`
+on GitHub) for one covering the same topic and reuse it; create a new topic label
+only the first time a topic has no match. Topic labels grow organically with the
+project.
+
+```
+Feat(threat-analysis): Add short-term conflict alert algorithm
+→ Feature, STCA, Safety Nets, Algorithm, ATCS
+```
+
+Set labels when the issue is created, not after. The PR carries the same labels — the
+type label if the issue has one, plus its topic labels — see `pr-rules` → Pre-Open
+Checklist.
 
 ---
 

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -27,7 +27,7 @@ End-to-end order of actions from a new task to a merged, closed issue. Steps run
 **1. Scope and issue** — before any code change:
 - Identify the repository the change belongs to (root repo or a submodule); the issue is created and tracked there, not in the root repo.
 - Search the tracker for an existing issue covering the task. If found, check it has a test plan and, for features, acceptance criteria (`issue-rules` → Description Template); if incomplete for this task, update the issue before writing code.
-- Apply labels — type label matches the title Type, plus any orthogonal labels that apply (`issue-rules` → Labels).
+- Apply the type label matching the title Type, if one exists, plus topic labels for the issue's subject matter (`issue-rules` → Labels).
 - If no issue exists, create one in that repository (`issue-rules`):
 ```
 Feat(hash): Add SipHash-2-4 keyed 64-bit hash   ← title
@@ -105,7 +105,7 @@ All three sections are required. A PR with no test plan is not ready to review.
 ## Pre-Open Checklist
 
 - [ ] CI green on all targets declared in the project
-- [ ] PR carries the issue's type label (+ `breaking` if applicable) — see `issue-rules` → Labels
+- [ ] PR carries the issue's labels — type label if any, plus topic labels — see `issue-rules` → Labels
 - [ ] `CHANGELOG.md` updated — every user-visible change documented
 - [ ] `git submodule status` — no `+` prefix on any module
 - [ ] Every commit in the branch builds independently (no broken intermediate state)


### PR DESCRIPTION
## Summary
- Reduce GitHub labels from 21 to 3 fixed type labels (`Feature`, `BUG`, `Refactor`) — already applied directly against the repo (renamed `Feat`→`Feature`, `Fix`→`BUG`, deleted the other 18 unused labels)
- Introduce a second, orthogonal axis: topic labels — free-form, created ad-hoc from an issue's actual subject matter, reused when a topic recurs, never pre-enumerated (this skill ships to every project, so a fixed repo-specific taxonomy would be the wrong scope)
- Sync `skills/issue-rules/SKILL.md` and `skills/pr-rules/SKILL.md` to describe the new scheme instead of the old 13-label one

## Implementation
- `issue-rules` Labels section: type-label table (3 rows, down from 9+4), plus a new topic-label rule with a worked example
- `pr-rules`: Workflow step 1 and Pre-Open Checklist updated to reference both type and topic labels instead of "type label + orthogonal labels"
- Dogfooded immediately: created the `labels` topic label ad-hoc for this issue/PR's own subject matter, per the rule just written

## Test plan
- [x] `npm test` — 128/128 pass
- [x] Grepped both files for `breaking`/`blocked`/`good first issue`/`needs-design` — no leftover references
- [x] `gh label list --repo ssoft-hub/ai` — exactly `Feature`, `BUG`, `Refactor` (+ `labels`, created by this PR)
- [x] Confirmed the `Feat`→`Feature` rename preserved existing assignments on issues #11/#13 and PRs #12/#14 rather than stripping them

Closes #15