### PR TITLE
GH-17: Prompt for confirmation before git push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `pr-rules` skill: Workflow section now spells out the full order of actions (locate repo → find-or-create issue with a test plan and, for features, acceptance criteria → branch → commits → PR → pre-merge issue check → merge → conditional issue close); added a Pre-Merge Checklist that gates merge on the linked issue's checkbox state
 - `issue-rules` skill: `Done` lifecycle state now requires every checklist checkbox in the issue to be checked before closing; added a Progress Comments section requiring issue comments that record which PR/MR resolves which item
 - `pr-rules` Workflow now requires labels on the issue before implementation starts, and Pre-Open Checklist requires the PR to carry the issue's type label (+ `breaking` if applicable); `issue-rules` Labels section states when to set/revisit labels
+- `bash-safety` now prompts for confirmation before any `git push` (PreToolUse `permissionDecision: ask`) rather than only warning on `--force`, so no push runs without an explicit yes — even under `bypassPermissions`, which the settings `ask` list cannot cover
 
 ### CI
 

--- a/test/bash-safety.test.js
+++ b/test/bash-safety.test.js
@@ -1,7 +1,11 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
 const { check } = require('../tools/bash-safety');
+
+const TOOL = path.join(__dirname, '..', 'tools', 'bash-safety.js');
 
 test('blocks rm -rf /', () => {
   assert.strictEqual(check('rm -rf /').action, 'block');
@@ -59,14 +63,32 @@ test('warns on rm -fr foo (recursive but not root)', () => {
   assert.strictEqual(check('rm -fr foo').action, 'warn');
 });
 
-test('warns on git push --force', () => {
-  const r = check('git push --force origin main');
-  assert.strictEqual(r.action, 'warn');
-  assert.ok(r.warnings.some(w => /--force/.test(w.msg)));
+test('asks before plain git push', () => {
+  assert.strictEqual(check('git push origin main').action, 'ask');
 });
 
-test('warns on git push -f', () => {
-  assert.strictEqual(check('git push -f origin main').action, 'warn');
+test('asks before git push after a chain operator', () => {
+  assert.strictEqual(check('cd /d/foo && git push origin main').action, 'ask');
+});
+
+test('asks before git push after a newline (cd || cd fallback then push)', () => {
+  assert.strictEqual(check('cd /d/foo || cd "D:/foo"\ngit push origin main').action, 'ask');
+});
+
+test('asks before git push --force', () => {
+  assert.strictEqual(check('git push --force origin main').action, 'ask');
+});
+
+test('asks before git push -f', () => {
+  assert.strictEqual(check('git push -f origin main').action, 'ask');
+});
+
+test('does not prompt on git push named inside a commit message', () => {
+  assert.strictEqual(check('git commit -m "how to git push safely"').action, 'pass');
+});
+
+test('does not prompt on "(git push)" named inside a commit message', () => {
+  assert.strictEqual(check('git commit -m "run (git push) in a subshell"').action, 'pass');
 });
 
 test('warns on git reset --hard', () => {
@@ -95,4 +117,14 @@ test('passes git status', () => {
 
 test('passes ls -la', () => {
   assert.strictEqual(check('ls -la').action, 'pass');
+});
+
+test('emits a PreToolUse ask decision for git push', () => {
+  const r = spawnSync('node', [TOOL], {
+    input: JSON.stringify({ tool_input: { command: 'git push origin main' } }),
+    encoding: 'utf8',
+  });
+  assert.strictEqual(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'ask');
 });

--- a/tools/bash-safety.js
+++ b/tools/bash-safety.js
@@ -6,8 +6,11 @@ const BLOCK = [
   { re: /format\s+[a-zA-Z]:/i, msg: 'disk format command' },
 ];
 
+const ASK = [
+  { re: /(?:^|[\n;&|])\s*git\s+push\b/i, msg: 'git push affects the shared remote — confirm before pushing' },
+];
+
 const WARN = [
-  { re: /git\s+push\b.*(?:--force\b|\s-f\b)/i, msg: 'git push --force/-f — overwrites remote history' },
   { re: /git\s+reset\s+--hard\b/i, msg: 'git reset --hard — discards uncommitted work' },
   { re: /git\s+checkout\s+--\s*\./i, msg: 'git checkout -- . — discards all working tree changes' },
   { re: /git\s+clean\s+-[a-zA-Z]*f/i, msg: 'git clean -f — deletes untracked files' },
@@ -21,6 +24,7 @@ const WARN = [
 
 function check(cmd) {
   for (const { re, msg } of BLOCK) if (re.test(cmd)) return { action: 'block', msg };
+  for (const { re, msg } of ASK) if (re.test(cmd)) return { action: 'ask', msg };
   const warnings = WARN.filter(({ re }) => re.test(cmd));
   return { action: warnings.length ? 'warn' : 'pass', warnings };
 }
@@ -41,6 +45,16 @@ if (require.main === module) {
       process.stderr.write(`Blocked: ${r.msg}\nCommand: ${cmd.slice(0, 200)}\n`);
       process.exit(2);
     }
+    if (r.action === 'ask') {
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          permissionDecisionReason: r.msg,
+        },
+      }));
+      process.exit(0);
+    }
     if (r.action === 'warn') {
       process.stdout.write(
         'bash-safety warning — destructive command detected:\n' +
@@ -52,4 +66,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { BLOCK, WARN, check };
+module.exports = { BLOCK, ASK, WARN, check };


### PR DESCRIPTION
## Summary
- `git push` now always prompts for confirmation before running — not just `git push --force`.

## Implementation
- `tools/bash-safety.js`: `git push` returns a PreToolUse `permissionDecision: ask`, anchored to command start so a `git push` named inside a quoted commit message does not trigger. It prompts even under `bypassPermissions`, which the settings `ask` list cannot cover.
- A hard block (exit 2) was avoided on purpose — it would force pushing by hand instead of prompting.
- The prior `--force`-only warning is subsumed by the prompt.

## Test plan
- `node --test test/bash-safety.test.js` — 29/29.
- `check()` returns `ask` for plain / chained (`&&`) / newline-fallback / `--force` / `-f` pushes; `pass` for `git push` (and `(git push)`) named inside a commit message.
- Integration test asserts the tool emits `permissionDecision: ask` (exit 0, JSON on stdout) for `git push`.

Closes #17
