### PR TITLE
GH-18: Tighten comment and Doxygen discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `issue-rules` skill: `Done` lifecycle state now requires every checklist checkbox in the issue to be checked before closing; added a Progress Comments section requiring issue comments that record which PR/MR resolves which item
 - `pr-rules` Workflow now requires labels on the issue before implementation starts, and Pre-Open Checklist requires the PR to carry the issue's type label (+ `breaking` if applicable); `issue-rules` Labels section states when to set/revisit labels
 - `bash-safety` now prompts for confirmation before any `git push` (PreToolUse `permissionDecision: ask`) rather than only warning on `--force`, so no push runs without an explicit yes — even under `bypassPermissions`, which the settings `ask` list cannot cover
+- `comments` skill: the default is now no comment — reserve comments for critical, non-obvious facts a reader would otherwise get wrong; added a red-flags self-check for the common "might help" / "let me explain this expression" rationalizations
 
 ### CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `pr-rules` Workflow now requires labels on the issue before implementation starts, and Pre-Open Checklist requires the PR to carry the issue's type label (+ `breaking` if applicable); `issue-rules` Labels section states when to set/revisit labels
 - `bash-safety` now prompts for confirmation before any `git push` (PreToolUse `permissionDecision: ask`) rather than only warning on `--force`, so no push runs without an explicit yes — even under `bypassPermissions`, which the settings `ask` list cannot cover
 - `comments` skill: the default is now no comment — reserve comments for critical, non-obvious facts a reader would otherwise get wrong; added a red-flags self-check for the common "might help" / "let me explain this expression" rationalizations
+- `doxygen` skill: one block documents the type on its declaration (`@brief`/`@ingroup`/`@tparam`) while members carry no Doxygen; longer type prose can move to the `.cpp` via `@class`/`@struct`/`@enum`, and the `#ifdef DOXYGEN` guard is a last resort for a re-exported type (real type in `detail`, public `using` alias) requiring `PREDEFINED = DOXYGEN` in the Doxyfile
 
 ### CI
 

--- a/skills/comments/SKILL.md
+++ b/skills/comments/SKILL.md
@@ -21,9 +21,9 @@ Doc comments on public headers → `doxygen` skill. This skill covers everything
 
 ## Philosophy
 
-Code documents itself. A comment is a fallback for what naming, structure, and types cannot express — not a first resort.
+Code documents itself. **The default is no comment.** Add one only when, without it, a careful reader would get a critical, non-obvious fact wrong — never to restate what the code already shows.
 
-- **Write a comment only when actually required** — first try to make the code self-explanatory (better names, extracted function, clearer types). If that succeeds, no comment is needed.
+- **Default to none** — first make the code self-explanatory (better names, extracted function, clearer types). "Might help the reader" is not enough; the bar is that they get it *wrong* without the line.
 - **Keep it short** — one line. No multi-line prose blocks outside Doxygen.
 - **General character, not case history** — state a timeless fact about the code (an invariant, a constraint, a non-obvious reason), not the story of how it got that way.
 
@@ -51,6 +51,12 @@ if (connection == nullptr) return;
 // Upstream API returns null once the connection is closed.
 if (connection == nullptr) return;
 ```
+
+## Red Flags — delete the comment
+
+- "This might help the next reader" — not enough; the bar is they get it *wrong* without it.
+- "This expression is non-obvious, I'll explain it" — if it needs prose, name it (extract a constant or function) instead.
+- "I'll note why I chose this approach" — that is commit-message material, not a code comment.
 
 ## Cross-References
 

--- a/skills/doxygen/SKILL.md
+++ b/skills/doxygen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: doxygen
 version: "1.0.0"
-description: Apply when adding or modifying Doxygen comments on public C++ headers
+description: Apply when adding or modifying Doxygen comments for public C++ headers
 license: Unlicense
 metadata:
   author: ssoft
@@ -13,87 +13,88 @@ metadata:
 
 # Skill: Doxygen
 
-Apply when adding or modifying public C++ headers.
+Apply when documenting public C++ headers.
 
 Header structure, namespace rules, `#pragma once` → `api-design` / `cpp-coding` skills.
+Non-Doxygen implementation comments → `comments` skill.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own documentation conventions (language, placement, required tags), follow those instead. This skill is the fallback for projects that do not specify their own.
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own documentation conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
 
-## Documentation Placement
+## Core Rule — document the type, not its members
 
-The declaration must stay readable at a glance. Extensive documentation lives away from the declaration.
+One Doxygen block sits **on the type declaration** — the class, struct, or enum. Its **members** (methods, fields, enum values) carry **no** Doxygen: clear names and types speak for them. "Clean" means a clean body, not an undocumented type.
 
-- **Header declarations** — `@brief` only, plus the structural tags (`@tparam`, `@param`, `@return`, `@ingroup`). One short line per tag, no prose paragraphs.
-- **`.cpp` definitions** — full descriptions, invariants, complexity notes, algorithm rationale, examples, `@note` / `@warning` / `@see` blocks.
-- **Free functions and templates that have no `.cpp`** — keep the header block to `@brief` + structural tags; put extended prose into a separate companion file (`foo_doc.h` or a `@page` in the module's docs header) referenced via `@see`.
+- **The type block** — `@brief`, `@ingroup`, and `@tparam` for templates — sits directly above the declaration.
+- **Members get nothing.** No `///` on any method, field, or enumerator.
+- Keep the header block short. Longer type-level prose (invariants, algorithm, examples, `@note` / `@warning`) can move to the `.cpp` to keep the header lean — see Placement.
 
-A reader scanning a public header must see the signature and one-line intent without scrolling past a wall of comments.
+## Placement
 
-## Coverage
+- **Type block → on the declaration** in the header:
+   ```cpp
+   /// @brief Fixed-capacity single-producer/single-consumer ring buffer
+   /// @ingroup mylib_containers
+   /// @tparam T element type
+   template <class T>
+   class RingBuffer { /* members: no Doxygen */ };
+   ```
+- **Longer type-level prose → the `.cpp`.** Attach it to the type from another file with an explicit `@class` / `@struct` / `@enum`, so the header keeps only `@brief` + tags:
+   ```cpp
+   // ring_buffer.cpp — @brief/@ingroup stay on the declaration; add prose only
+   /**
+    * @class mylib::RingBuffer
+    *
+    * Lock-free for one producer and one consumer. push/pop return false
+    * when full/empty instead of blocking.
+    */
+   ```
+- **Special case — no public declaration to hang the block on.** The real type lives in `detail` and the public API is a `using` alias. Document the alias with a `#ifdef DOXYGEN` guard (or the `@class` form above):
+   ```cpp
+   namespace mylib::detail { template <class T> class WidgetImpl; }
+   namespace mylib { using Widget = detail::WidgetImpl<int>; }
 
-Every public entity must have a Doxygen block:
-classes, structs, functions, type aliases, variables, enums, enum values.
+   #ifdef DOXYGEN
+   /// @class mylib::Widget
+   /// @brief Owning handle to a rendered widget
+   /// @ingroup mylib_core
+   #endif
+   ```
+   The guard needs Doxyfile support so only Doxygen sees the block:
+   `ENABLE_PREPROCESSING = YES` (default) plus `PREDEFINED = DOXYGEN`. The compiler and cppcheck run with `DOXYGEN` undefined (cppcheck via `-UDOXYGEN`) and skip it.
 
-## Required Tags
+## Required tags
+
+On the type block:
 
 | Tag | When |
 |-----|------|
-| `@brief` | Always — one-line description |
-| `@tparam Name` | Each template parameter |
-| `@param name` | Each function parameter |
-| `@return` | Return value; omit for `void` |
-| `@ingroup GroupId` | Every entity — links to its group |
+| `@brief` | Always — one line, no trailing period |
+| `@ingroup GroupId` | Always — links the type to its group |
+| `@tparam Name` | Each template parameter of a class template |
+| `@class` / `@struct` / `@enum` `Qualified::Name` | Only when the block is detached from the declaration (`.cpp` or guarded) — it must name its target |
 
-Optional: `@note`, `@warning`, `@throws`, `@pre`, `@post`, `@see`.
+Free functions are documented on their own declaration and add `@param` / `@return`; omit `@return` for `void`. Optional: `@note`, `@warning`, `@pre`, `@post`, `@see`.
 
 ## Group System
 
-Define groups in the top-level module header or a dedicated group header:
+Define groups in the module header:
 ```cpp
-/// @defgroup MyLib_Hash Hash utilities
-/// @ingroup MyLib
+/// @defgroup mylib_containers Containers
+/// @ingroup mylib
 ```
-
-Wrap group members:
-```cpp
-/// @{
-// ... entities with @ingroup MyLib_Hash ...
-/// @}
-```
-
-Every entity must declare `@ingroup` even when wrapped in `@{` / `@}`.
+Every documented type declares `@ingroup`.
 
 ## Style Rules
 
 - Language: follow the project's `AGENTS.md`
-- Document the CONTRACT, not the implementation
-- `@brief` is one line — no period at end
-- `@param` and `@tparam` descriptions: lowercase start, no period
-- Align tag columns for readability when there are multiple params
-
-## Example
-
-```cpp
-/// @defgroup MyLib_Hash Hash utilities
-/// @ingroup MyLib
-/// @{
-
-/// @brief Computes FNV-1a 64-bit hash over a byte range
-/// @ingroup MyLib_Hash
-/// @tparam Iter  input iterator over byte-sized elements
-/// @param  first begin of range
-/// @param  last  end of range
-/// @return 64-bit FNV-1a digest
-template <typename Iter>
-constexpr uint64_t fnv1a(Iter first, Iter last) noexcept;
-
-/// @}
-```
+- Document the CONTRACT of the type, not its implementation
+- `@brief` is one line, no period at the end
+- Never document a member — if you are writing `///` on a method or field, delete it
 
 ## What to Skip
 
-- Private / implementation-detail entities (inside `detail/` or `namespace detail`)
+- Private / `detail` entities (inside `detail/` or `namespace detail`)
 - Internal macros not part of the public API
-- Trivial getters/setters that are self-explanatory — still document, keep `@brief` minimal
+- Per-member documentation — never write it


### PR DESCRIPTION
## Summary
- `comments` skill: the default is now **no comment** — reserve comments for critical, non-obvious facts a reader would otherwise get wrong.
- `doxygen` skill: the **type** is documented on its declaration; **members** carry no Doxygen; the `#ifdef DOXYGEN` guard is a last resort for re-exported `detail` types.

## Implementation
- `comments`: strengthened the philosophy to a hard default and added a red-flags self-check for the common "might help" / "let me explain this expression" rationalizations.
- `doxygen`: one block per type (`@brief` / `@ingroup` / `@tparam`) on the declaration; longer type prose can move to the `.cpp` via an explicit `@class` / `@struct` / `@enum`; the guard requires `PREDEFINED = DOXYGEN` in the Doxyfile (the compiler and cppcheck skip the block via `-UDOXYGEN`).

## Test plan
- Docs-only change; no code paths affected. `node --test` unaffected.
- Verified frontmatter and skill triggers/descriptions intact; examples render as valid Doxygen.

Closes #18
