### PR TITLE
GH-25: Add security-and-hardening, performance-optimization, observability skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `issue-rules` skill: title format (`Type(scope): Subject`), description templates for features and bugs (Goal, Acceptance criteria, Test plan), labels, priority levels (P0–P3), and lifecycle states
 - Skills: `comments` (non-Doxygen comment style — brief, general, no fix narration), `encapsulation` (public/protected/private access-specifier discipline)
 - Skills: `debugging` (root-cause investigation before proposing a fix), `code-review-and-quality` (review substance — correctness, readability, architecture, security, performance), `test-driven-development` (red-green-refactor workflow)
+- Skills: `security-and-hardening` (trust boundaries, input validation, secrets, least privilege), `performance-optimization` (profile-measure-optimize workflow), `observability-and-instrumentation` (logging, metrics, tracing)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | `hook-scripts` | Writing Claude Code hooks and tools |
 | `issue-rules` | Tracker issue title, description, labels, priority, lifecycle |
 | `node-testing` | Conventions for this repo's `test/*.test.js` (node:test) |
+| `observability-and-instrumentation` | Logging, metrics, tracing for production visibility |
+| `performance-optimization` | Profile-measure-optimize workflow for a reported performance problem |
 | `pr-rules` | PR title, description, merge strategy |
 | `project-planning` | Scoping, estimation, milestones, risk, status updates |
 | `release` | Semver release workflow |
 | `requirements` | Requirements gathering, user stories, acceptance criteria |
+| `security-and-hardening` | Trust boundaries, input validation, secrets, least privilege |
 | `submodule-sync` | Git submodule sync discipline |
 | `test-driven-development` | Red-green-refactor workflow, before writing implementation code |
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -34,3 +34,6 @@ When scoping work, estimating, sequencing milestones, or writing a project plan/
 When investigating a bug, test failure, or unexpected behavior, before proposing a fix → apply `debugging` skill.
 When reviewing code changes for correctness, readability, architecture, security, or performance → apply `code-review-and-quality` skill.
 When implementing a feature or bug fix, before writing implementation code → apply `test-driven-development` skill.
+When code accepts external input, crosses a trust boundary, or handles secrets/credentials → apply `security-and-hardening` skill.
+When diagnosing or fixing a reported performance problem → apply `performance-optimization` skill.
+When adding logging, metrics, or tracing, or reviewing how a running system reports its own behaviour → apply `observability-and-instrumentation` skill.

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -18,6 +18,8 @@ around opening/merging the PR the review attaches to → `pr-rules` skill.
 
 - Public API shape and breaking-change review → `api-design` skill.
 - Access-specifier and encapsulation review → `encapsulation` skill.
+- Security-specific review depth (auth, input validation, secrets) → `security-and-hardening` skill.
+- Performance-specific review depth (complexity, allocations) → `performance-optimization` skill.
 
 ## Project Overrides
 
@@ -69,7 +71,7 @@ wrong):
 ## Security
 
 - Any input crossing a trust boundary (user input, network, file, subprocess argument)
-  gets checked before anything else in the diff.
+  gets checked against `security-and-hardening` before anything else in the diff.
 - Secrets, credentials, or tokens appearing in code, logs, or test fixtures block the
   review regardless of how minor the rest of the change is.
 
@@ -104,7 +106,7 @@ change that leaves dead code behind isn't finished, even if what it added is cor
 ## Performance
 
 - A change on a hot path (per-request, per-frame, per-iteration of a large loop) gets
-  checked for unnecessary allocation/copy before merge.
+  checked for unnecessary allocation/copy before merge — see `performance-optimization`.
 - Do not request a performance change on a cold path without measurement — an
   unmeasured "this could be faster" comment is a nitpick, not a blocker.
 

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: observability-and-instrumentation
+version: "1.0.0"
+description: Apply when adding logging, metrics, or tracing, or reviewing how a running system reports its own behaviour
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - observability
+    - quality
+---
+
+# Skill: Observability and Instrumentation
+
+Apply when adding logging, metrics, or tracing, or reviewing how a running system
+reports its own behaviour. This skill governs instrumentation added *for* production
+visibility, not test assertions or debug-session-only tracing.
+
+- Temporary instrumentation added to chase a specific bug → `debugging` skill
+  (Instrumentation Before Speculation); remove it once the bug is understood unless it's
+  worth keeping permanently under this skill's rules.
+- Never logging a secret, even at debug level → `security-and-hardening` skill.
+- A metric showing a performance regression → `performance-optimization` skill for the
+  follow-up investigation.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own logging/metrics stack and conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## Define "Working" Before Instrumenting
+
+Telemetry added without a question behind it is noise. Before instrumenting a feature,
+write down the 2-4 questions an on-call engineer will actually ask about it ("what
+fraction of requests succeed on the first attempt?", "when it fails, why?"). Every
+signal added should answer one of those questions — if the questions can't be named yet,
+instrumenting now produces volume, not visibility.
+
+## The Three Signals
+
+- **Logs** — discrete events with context, for reconstructing what happened in one
+  specific case ("this request failed, here's why").
+- **Metrics** — aggregated numeric measurements over time, for spotting trends and
+  triggering alerts ("error rate is up 5x since the last deploy").
+- **Traces** — the path a single request/operation took across components, for
+  understanding where time or an error was introduced in a multi-step flow.
+
+Pick the signal that answers the question being asked. Logging every request to answer
+a question metrics would answer better produces volume without insight.
+
+## Log Levels
+
+| Level | When |
+|-------|------|
+| Error | The operation failed and needs attention; includes enough context to act on it |
+| Warn | Unexpected but recovered-from condition; worth noticing, not urgent |
+| Info | Significant lifecycle events (started, stopped, config loaded) — low volume |
+| Debug | Detailed internal state, off by default in production |
+
+Do not log routine success at `Error` or `Warn` level, and do not log a real failure at
+`Info` — an operator triaging by severity depends on the level being accurate.
+
+## Structured, Not Just Formatted
+
+Prefer structured fields (key/value pairs, a structured logging library) over a
+free-form interpolated string — a log line an operator can query by field
+(`request_id`, `user_id`, `status`) is far more useful under incident pressure than one
+that has to be grepped and parsed by hand.
+
+```cpp
+// Harder to query later
+log.error("failed to process request " + id + " for user " + user + ": " + err);
+
+// Structured — queryable by field
+log.error("request processing failed", {{"request_id", id}, {"user_id", user}, {"error", err}});
+```
+
+## Context Propagation
+
+Attach a correlation/request ID at the entry point of an operation and propagate it
+through every log line and downstream call that operation makes. Without it,
+reconstructing one request's path through a system with concurrent traffic means
+guessing which log lines belong together.
+
+## What Not to Log
+
+- Secrets, credentials, tokens, full payloads containing personal data — see
+  `security-and-hardening`.
+- High-frequency events inside a tight loop at a level enabled in production — this
+  degrades performance and buries the signal that matters in noise.
+- The same failure repeatedly without rate-limiting or deduplication when it's expected
+  to recur (e.g. a retry loop) — log the first occurrence and a periodic summary, not
+  every attempt.
+
+## Metrics
+
+- Prefer the three standard shapes — counter (monotonically increasing, e.g. requests
+  served), gauge (current value, e.g. queue depth), histogram (distribution, e.g.
+  latency) — over inventing a bespoke aggregation.
+- Name metrics for what they measure, not for the code path that emits them — a metric
+  name should survive a refactor of the code that produces it.
+- A metric with no consumer (no dashboard, no alert) is dead weight — add it with the
+  dashboard/alert that will use it, not speculatively.
+- For a request-driven component, cover **RED** — rate, error rate, duration — on every
+  endpoint and every external dependency it calls. For a resource (a queue, a pool, a
+  worker), cover **USE** — utilization, saturation, errors — instead.
+- Track percentiles, never a bare average — an average of latency hides the fraction of
+  callers having a bad time. Read p50/p95/p99 from a histogram, not a mean.
+- **Cardinality is the failure mode of metrics.** Every unique label value combination
+  becomes its own time series. Labels must come from small, fixed sets (a route
+  template, a status class, a provider name) — never a user ID, a raw identifier, or
+  free-form error text, which belongs in logs, not in a metric label.
+
+## Alerting
+
+An alert should be actionable — if firing it does not lead to a specific action, it's
+noise that trains the on-call to ignore alerts, including the next one that matters.
+Alert on symptoms a user would notice (error rate, latency) more than on internal
+implementation details, unless the internal detail reliably predicts user-facing impact.
+Use two severities, not more: one that pages a human now, one that becomes a ticket for
+this week's work — a third tier of "informational" alerts becomes noise that trains
+people to skim past all of them, including the two that matter.
+
+## Traces
+
+Instrument boundaries (service calls, database queries, external API calls) rather than
+every internal function call — a trace with too many spans is as hard to read as a log
+with too much noise. Each span should represent a decision-relevant unit of work.
+
+## Verify the Telemetry Itself
+
+Instrumentation is code and can be wrong — don't call the work done without checking
+the actual output. Force the path in a non-production environment and confirm: the log
+line is structured and carries the correlation ID, not `[object Object]`-style noise;
+the metric series appears with the expected labels; a single request can be followed
+end-to-end without a broken span; and a newly added alert, fired once at a lowered
+threshold, reaches the right channel.

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: performance-optimization
+version: "1.0.0"
+description: Apply when diagnosing or fixing a reported performance problem, or evaluating whether a change is worth its performance cost
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - performance
+    - quality
+---
+
+# Skill: Performance Optimization
+
+Apply when diagnosing or fixing a reported performance problem, or evaluating whether a
+change is worth its performance cost. This skill covers the *process* of finding and
+validating a performance fix. The default C++ idioms to write by (avoiding copies,
+preferring views, hot-path allocation discipline) are always in effect regardless of a
+specific problem → `cpp-coding` skill (Performance section) — do not restate them here.
+
+- Performance depth during review → `code-review-and-quality` skill (Performance axis).
+- Production performance regressions surfaced via metrics → `observability-and-instrumentation` skill.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own performance budget or tooling, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## Measure Before Optimizing
+
+Do not change code for performance based on intuition about what "should" be slow.
+Profile first (e.g. `perf`, VTune, Tracy, a targeted micro-benchmark) and identify the
+actual hot path — intuition about hot paths is wrong often enough that skipping this
+step routinely produces effort spent on code that wasn't the bottleneck.
+
+Two complementary measurements matter, not one: a controlled micro-benchmark or
+profiler run isolates a specific function under reproducible conditions, while
+telemetry from real usage (`observability-and-instrumentation`) confirms the fix
+actually helped under real workloads and hardware. A benchmark improvement that doesn't
+show up in production telemetry means the benchmark measured the wrong thing.
+
+## State the Budget
+
+Before optimizing, state what "fast enough" means for this specific case (a latency
+target, a throughput target, a memory ceiling) — see `requirements` for non-functional
+requirements. Optimizing past the stated budget trades engineering time and code clarity
+for a gain nobody asked for.
+
+## Algorithmic Complexity First
+
+Check the algorithmic complexity (Big-O) of the hot path before micro-optimizing its
+constant factor — an O(n²) algorithm processing a large `n` will not be fixed by
+inlining or removing a copy. Fix the algorithm before tuning the implementation.
+
+## Measure the Fix
+
+Re-run the same profiling/benchmark after the change, on the same workload, and compare
+against the baseline captured before the change. A performance fix without a before/after
+number is a guess about whether it helped — see `test-driven-development`'s "measure,
+don't assume" spirit applied to performance instead of correctness.
+
+- Bad: "this should be faster because it avoids a copy" (no measurement)
+- Good: "p99 latency for a 10k-row export dropped from 480ms to 95ms (benchmark: `export_bench`, 20 runs)"
+
+## Common Sources, in Order of Likely Impact
+
+| Source | What to check |
+|--------|----------------|
+| Algorithm | Big-O of the hot path relative to the actual input size |
+| I/O | Network/disk calls inside a loop that could be batched |
+| Allocation | Allocations per iteration of a hot loop (see `cpp-coding` → Performance) |
+| Copies | Values copied where a reference/view/move would do |
+| Synchronization | Lock contention or false sharing under concurrent load |
+| Cache locality | Data layout causing avoidable cache misses on a hot path |
+
+## Do Not Trade Away Correctness or Clarity Silently
+
+A performance change that removes a bounds check, a validation step, or makes the code
+meaningfully harder to follow needs to say so explicitly and justify the trade with the
+measured gain — see `code-review-and-quality`. An unstated correctness-for-speed trade
+is a defect, not an optimization.
+
+## When Not to Optimize
+
+A cold path (rarely executed, not on any measured budget) does not get optimized on
+suspicion alone. Time spent there is better spent elsewhere unless a specific report or
+measurement says otherwise.

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: security-and-hardening
+version: "1.0.0"
+description: Apply when code accepts external input, crosses a trust boundary, or handles secrets/credentials
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - security
+    - quality
+---
+
+# Skill: Security and Hardening
+
+Apply when code accepts external input, crosses a trust boundary (network, file,
+subprocess, IPC, config), or handles secrets/credentials. This skill covers design-time
+decisions; mechanical, write-time enforcement of some of the same concerns is handled by
+the `secret-guard` and `bash-safety` hooks (see `AGENTS.md` → Hook architecture) — this
+skill is what to design for before those hooks would ever fire.
+
+- Memory-safety idioms that also happen to prevent whole classes of vulnerability
+  (RAII, no naked `new`, no `void*`) → `cpp-coding` skill.
+- Security depth during review → `code-review-and-quality` skill (Security axis).
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own security requirements (e.g. a specific compliance regime), follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## Trust Boundaries
+
+Identify every point where data crosses from a less-trusted source into code that acts
+on it: network input, file contents, environment variables, command-line arguments,
+subprocess output, IPC/shared memory, config files editable by another process. Data is
+untrusted until validated, regardless of how internal the source looks — a config file
+"nobody else touches" is still an attack surface if anything else can write to it.
+
+## Threat Modeling Before Hardening
+
+Controls added without first asking "how would this be misused" are guesses. Before
+hardening a feature, spend a few minutes naming the trust boundaries and the assets
+worth attacking (credentials, data, availability, elevated actions), then run STRIDE
+over each boundary as a quick lens, not a ceremony:
+
+| Threat | Ask | Typical mitigation |
+|---|---|---|
+| Spoofing | Can someone impersonate a user or service? | Authentication, signature verification |
+| Tampering | Can data be altered in transit or at rest? | Integrity checks, parameterized queries |
+| Repudiation | Can an action be denied afterward? | Audit logging of security-relevant events |
+| Information disclosure | Can data leak? | Encryption, field allowlists, generic errors |
+| Denial of service | Can the system be overwhelmed? | Rate limiting, input size caps, timeouts |
+| Elevation of privilege | Can a caller gain rights it shouldn't have? | Authorization checks, least privilege |
+
+If the trust boundaries for a feature can't be named, it isn't ready to be secured —
+controls added at that point are bolted on, not designed in.
+
+## Input Validation
+
+- Validate at the boundary, not deep inside business logic — reject or normalize bad
+  input as early as possible so invalid data never propagates.
+- Validate shape (type, length, format) and range (bounds, allowed values) separately —
+  a string that's syntactically a number can still be out of the range the code assumes.
+- Treat size/length fields from untrusted input as untrusted too — do not `resize()` or
+  `reserve()` a container to an attacker-controlled value without an upper bound.
+- Never build a shell command, SQL query, file path, or format string by concatenating
+  untrusted input — use parameterized APIs (prepared statements, `std::filesystem` path
+  composition, argv arrays instead of a shell string).
+
+```cpp
+// Wrong: path traversal via unvalidated input
+auto path = base_dir + "/" + user_supplied_name;
+
+// Correct: reject any component that escapes base_dir
+auto candidate = std::filesystem::weakly_canonical(base_dir / user_supplied_name);
+if (!candidate.string().starts_with(base_dir.string()))
+    throw std::invalid_argument("path escapes base directory");
+```
+
+## Integer and Bounds Safety
+
+- Check for overflow before an arithmetic operation on attacker-influenced sizes, not
+  after — `a + b < a` (unsigned wraparound) is a hardening check, not defensive noise.
+- Prefer a bounds-checked accessor (`.at()`) over `operator[]` at a trust boundary; the
+  cost of a checked access is negligible next to the cost of an out-of-bounds read.
+- Reject negative values for anything that becomes a size, count, or index before it
+  reaches the container API, rather than relying on the container to reject it.
+
+## Secrets and Credentials
+
+- Never hardcode a credential, API key, or private key in source, config committed to
+  the repo, logs, or test fixtures — see `secret-guard` for the mechanical check this
+  backs up. Load secrets from environment or a secrets manager at runtime.
+- Do not log a secret even at debug level — a debug log that's rotated to disk or
+  shipped to a log aggregator is a leak, not a diagnostic aid (see
+  `observability-and-instrumentation`).
+- Redact or omit tokens/credentials in error messages surfaced to a user or exception
+  text that a bug tracker will capture verbatim.
+- **If a secret is ever committed, rotate it.** Deleting the line, or rewriting history
+  to remove it, is not enough — treat it as compromised the moment it reaches a remote,
+  since a mirror, fork, or cached view can retain it regardless of what the canonical
+  history says. Revoke and reissue the credential first, then clean up the history.
+
+## Least Privilege
+
+- A process, file, or credential should have exactly the access it needs and no more —
+  default to read-only, narrow-scoped tokens, and drop elevated privileges as soon as
+  the operation requiring them completes.
+- Do not add a broad permission (a wildcard scope, an "admin" flag) to make one specific
+  operation simpler — grant the specific permission the operation needs.
+
+## Dependencies
+
+- Pin dependency versions; an unpinned transitive dependency can introduce a
+  vulnerability between builds without any change to this repo's own code.
+- Prefer well-maintained libraries with a security-disclosure process over
+  unmaintained ones, even at a convenience cost.
+- A package-manager audit reports known advisories — it does not prove the rest of a
+  dependency is trustworthy. Triage by reachability, not severity alone: a critical
+  finding in code that is never called on any path this project exercises is lower
+  priority than a moderate finding on a path that runs on every request. Document the
+  reason and set a review date whenever a fix is deferred rather than applied.
+
+## When a Vulnerability Is Found
+
+Reproduce it, understand the root cause (`debugging` skill), fix the root cause rather
+than the specific exploit string, and add a regression test that would have caught it.
+Do not silently patch a security bug without documenting the class of issue — the next
+similar bug in a different location depends on that being written down.


### PR DESCRIPTION
## Summary
- Adds three skills closing the second cluster of full-life-cycle gaps: `security-and-hardening`, `performance-optimization`, `observability-and-instrumentation`.
- Restores the `code-review-and-quality` cross-references that were deliberately deferred in #24.

## Implementation
- `security-and-hardening` — trust boundaries, input validation, integer/bounds safety, secrets, least privilege. Cross-references (doesn't restate) `cpp-coding`'s memory-safety idioms.
- `performance-optimization` — profile-measure-optimize workflow for a *reported* problem, distinct from `cpp-coding`'s always-on performance idioms.
- `observability-and-instrumentation` — logs/metrics/traces, log levels, structured logging, alerting.
- Stacked on #24 (base branch is GH-23's branch) because `code-review-and-quality` — added in #24 — needed its cross-references restored here.
- `security-and-hardening` intentionally omits a cross-reference to `deprecation-and-migration` — that skill lands in the next PR.
- CHANGELOG.md updated under `Added`.

## Test plan
- `npm test` — 134/134 passing.
- `node install.js` (dry-run and real, into a temp `CLAUDE_CONFIG_DIR`) — all three new skill files present, plus the two from #24.
- `tools/claude-md-skills-sync-check.js` against the installed temp dir — no drift reported.