### PR TITLE
GH-27: Add ci-cd-and-automation, deprecation-and-migration, shipping-and-launch skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Skills: `comments` (non-Doxygen comment style — brief, general, no fix narration), `encapsulation` (public/protected/private access-specifier discipline)
 - Skills: `debugging` (root-cause investigation before proposing a fix), `code-review-and-quality` (review substance — correctness, readability, architecture, security, performance), `test-driven-development` (red-green-refactor workflow)
 - Skills: `security-and-hardening` (trust boundaries, input validation, secrets, least privilege), `performance-optimization` (profile-measure-optimize workflow), `observability-and-instrumentation` (logging, metrics, tracing)
+- Skills: `ci-cd-and-automation` (pipeline design and quality gates), `deprecation-and-migration` (retiring a public API, migration guides), `shipping-and-launch` (release readiness, staged rollout, rollback planning)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | `api-design` | C++ public API structure and hygiene |
 | `architecture` | System/module architecture design, ADRs, tradeoffs |
 | `changelog` | Keep a Changelog format |
+| `ci-cd-and-automation` | CI/CD pipeline design and quality gates |
 | `code-review-and-quality` | Review substance — correctness, readability, architecture, security, performance |
 | `comments` | Non-Doxygen code comment style (brief, general, no fix narration) |
 | `commit-rules` | Conventional Commits format and branch naming |
@@ -49,6 +50,7 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | `cpp-testing` | Unit test structure (AAA, naming, coverage) |
 | `ddd` | Domain-Driven Design patterns in C++ |
 | `debugging` | Root-cause investigation before proposing a fix |
+| `deprecation-and-migration` | Retiring a public API and writing a migration guide |
 | `doxygen` | Doxygen tag coverage for public headers |
 | `editing` | File editing workflow (re-read before edit) |
 | `encapsulation` | Access-specifier discipline (public/protected/private) |
@@ -62,6 +64,7 @@ Personal Claude Code configuration — hooks, tools, and skills.
 | `release` | Semver release workflow |
 | `requirements` | Requirements gathering, user stories, acceptance criteria |
 | `security-and-hardening` | Trust boundaries, input validation, secrets, least privilege |
+| `shipping-and-launch` | Release readiness, staged rollout, rollback planning |
 | `submodule-sync` | Git submodule sync discipline |
 | `test-driven-development` | Red-green-refactor workflow, before writing implementation code |
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -37,3 +37,6 @@ When implementing a feature or bug fix, before writing implementation code → a
 When code accepts external input, crosses a trust boundary, or handles secrets/credentials → apply `security-and-hardening` skill.
 When diagnosing or fixing a reported performance problem → apply `performance-optimization` skill.
 When adding logging, metrics, or tracing, or reviewing how a running system reports its own behaviour → apply `observability-and-instrumentation` skill.
+When designing or reviewing a CI/CD pipeline, build automation, or a quality gate → apply `ci-cd-and-automation` skill.
+When retiring a public API, planning a breaking change, or writing a migration guide → apply `deprecation-and-migration` skill.
+When preparing to ship a release to users, beyond version-bump mechanics → apply `shipping-and-launch` skill.

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: ci-cd-and-automation
+version: "1.0.0"
+description: Apply when designing or reviewing a CI/CD pipeline, build automation, or a quality gate
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - ci
+    - automation
+---
+
+# Skill: CI/CD and Automation
+
+Apply when designing or reviewing a CI/CD pipeline, build automation, or a quality gate
+that decides whether a change can merge or ship.
+
+- The specific checks a gate should run (lint, format, static analysis) are project- and
+  language-specific → `cpp-coding`/`hook-scripts` and the project's `AGENTS.md`.
+- Merge itself is still gated on the Pre-Open/Pre-Merge Checklists → `pr-rules` skill;
+  this skill is about the pipeline that produces the "CI green" signal those checklists
+  require.
+- Release tagging and version bump automation → `release` skill.
+- Secrets used by pipeline jobs (deploy keys, tokens) → `security-and-hardening` skill.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own CI/CD stack and gates, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## What a Pipeline Should Gate
+
+Every change that can merge or ship should pass, at minimum: build, test suite,
+lint/format, and any static analysis the project declares. A gate that's easy to bypass
+(a flag, a manual override used routinely) is not a gate — it's documentation of intent.
+
+## Reproducible Locally
+
+A developer should be able to run the same checks the pipeline runs, locally, and get
+the same result — a check that only exists in CI and can't be reproduced locally forces
+a slow push-and-wait debugging loop for anything that fails there. Prefer a single script
+or command both the pipeline and a developer invoke (see this repo's own
+`npm test` / `hooks/git/pre-commit` as an example of the pattern).
+
+## Fast Feedback First
+
+Order pipeline stages from fastest/cheapest to slowest/most expensive (lint before
+build, unit tests before integration tests, single-platform build before the full
+matrix) so a broken change fails in seconds, not after a 20-minute matrix build.
+
+## Matrix Coverage
+
+Run the test matrix across every combination the project actually ships to (compiler
+versions, OS, architecture) — see this repo's own workflow (`.github/workflows/`) running
+`npm test` on multiple Node versions as a minimal example. A matrix entry that's
+perpetually red and ignored is worse than not having it — either fix it or remove it.
+
+## What Blocks vs What Warns
+
+Distinguish a hard gate (build failure, test failure, lint error) from a warning
+(coverage dipped slightly, a non-critical static-analysis note) explicitly in the
+pipeline configuration. A pipeline where warnings and failures look the same in the UI
+trains contributors to ignore both.
+
+## Secrets in Pipelines
+
+Pipeline credentials (deploy keys, registry tokens, signing keys) follow
+`security-and-hardening`'s least-privilege rule: scope each credential to exactly the
+job that needs it, never share one broad credential across every job in the pipeline.
+
+## Flaky Checks
+
+A check that fails intermittently without a code change is a defect in the check, not
+noise to route around with retries-until-green. Quarantine it (mark known-flaky,
+tracked with an issue) rather than letting an intermittent red build normalize ignoring
+CI failures generally.
+
+## Feeding a Pipeline Failure Back to an Agent
+
+When CI fails under an agent-driven workflow, feed the agent the specific failure
+output — not just "CI failed" — and let it apply `debugging` to root-cause it before
+pushing again: a lint failure gets auto-fixed and re-run, a type/compile error gets
+traced to its cited location, a test failure goes through the full debugging skill, not
+a guess. Re-pushing without first reproducing the failure locally just moves the same
+guess-and-check loop into the pipeline, which is slower per iteration than reproducing
+it locally first.
+
+## Keeping the Pipeline Fast
+
+Once a pipeline exceeds a comfortable wait (rule of thumb: ~10 minutes), apply these in
+order of impact before adding more hardware: cache dependencies between runs; split
+independent checks (lint, build, test) into parallel jobs instead of one long sequential
+job; skip jobs a change can't affect (e.g. skip a full matrix build for a docs-only
+change); shard a large test suite across runners; move slow, non-blocking checks to a
+scheduled run instead of every push. Reach for a larger/faster runner last — it hides
+the cost instead of removing it.
+
+## Someone Owns a Red Build
+
+When the pipeline breaks on the shared branch, whoever is responsible for keeping it
+green (not necessarily whoever caused it) fixes or reverts immediately — waiting for the
+original author, or assuming someone else will handle it, lets a broken baseline
+accumulate further broken changes on top of it.
+
+## Automation Beyond CI
+
+The same "reproducible, fast-feedback, explicit gate" principles apply to any automated
+check that gates a workflow — this repo's own `PreToolUse`/`PostToolUse` hooks (see
+`hook-scripts` skill) are automation in this same sense, just running locally instead of
+in a remote pipeline.

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: deprecation-and-migration
+version: "1.0.0"
+description: Apply when retiring a public API, planning a breaking change, or writing a migration guide
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - api
+    - migration
+---
+
+# Skill: Deprecation and Migration
+
+Apply when retiring a public API, planning a breaking change, or writing a migration
+guide for consumers moving off one.
+
+- What counts as a breaking change and the version bump it requires → `api-design`
+  skill (Breaking Changes section) — this skill covers the deprecation-to-removal
+  process around that change, not the definition of "breaking" itself.
+- The version bump and changelog mechanics of shipping the removal →
+  `release`/`changelog` skills.
+- A security vulnerability that forces retiring an unsafe API path →
+  `security-and-hardening` skill for diagnosing the vulnerability; this skill for
+  retiring the path itself.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own deprecation policy, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## Why Announcing Isn't Enough
+
+With enough consumers, every observable behavior of a public symbol becomes depended
+on — including behavior never documented as a guarantee (this is Hyrum's Law). That is
+why deprecation needs active migration support, not just an announcement: a consumer
+can't "just switch" to a replacement that doesn't reproduce a behavior they happened to
+rely on, even one this repo never promised.
+
+## Deprecate Before Removing
+
+Do not remove a public symbol in the same release that first marks it deprecated,
+except when forced by an active security vulnerability. Consumers need a release where
+the deprecation is visible (`[[deprecated("use X instead")]]`, a changelog entry) before
+the removal release actually breaks their build.
+
+## Compulsory vs Advisory
+
+Default to **advisory**: consumers migrate on their own timeline, the deprecated path
+keeps working with no fixed removal date. Reserve **compulsory** deprecation — a hard
+removal date — for cases where leaving the old path in place carries its own cost that
+justifies forcing the migration (an active security vulnerability, a maintenance burden
+that has become unsustainable). Compulsory deprecation still requires providing a
+migration guide and tooling; a deadline with no migration path is not a deprecation
+policy, it's an ultimatum.
+
+## State the Replacement, Not Just the Removal
+
+A deprecation notice that says what's going away without saying what to use instead
+forces every consumer to independently rediscover the replacement. Every deprecation
+message and changelog entry names the replacement API or explicitly states there isn't
+one and why.
+
+```cpp
+// Wrong: says what's gone, not what to do
+[[deprecated]] void open(bool read_only);
+
+// Correct: names the replacement
+[[deprecated("use open(OpenMode) instead")]] void open(bool read_only);
+```
+
+## Grace Period
+
+State how long the deprecated path will keep working (a number of minor releases, or a
+calendar date) at the time it's deprecated, not decided ad hoc when someone asks. A
+grace period announced late is functionally no grace period for anyone who already read
+the original notice and didn't act on a vague "eventually."
+
+## Migration Guide
+
+For any deprecation likely to require more than a mechanical find-replace, write a
+migration guide covering: what changed and why, a before/after example for the common
+case, and what silently changes behavior (not just signature) if anything does. A
+migration guide that only shows the new signature, without a behavior diff, misses the
+cases that compile after migration but behave differently.
+
+## Coexistence During the Grace Period
+
+The deprecated and replacement paths must both work correctly during the grace period —
+a "deprecated" path that's already subtly broken to encourage migration is a support
+burden disguised as an incentive; consumers who haven't migrated yet still depend on it
+working.
+
+## Internal vs Public Deprecation
+
+Deprecating an internal-only symbol (not part of the public API per `api-design`) does
+not need a grace period or migration guide — update every internal call site in the
+same change. This skill's ceremony is proportional to how many consumers outside this
+repo are affected.
+
+## Migrating a Persisted Format (Expand/Contract)
+
+A change to a persisted schema — a config file format, a serialized data layout, a
+database table — is riskier than an API deprecation: data cannot be rolled back by
+reverting a deploy the way code can. The failure mode is coupling the format change to
+the code change that starts relying on it — during the rollout window, old and new code
+run against the same data, and whichever one expects the other's shape breaks. Never
+change a persisted field in place; migrate in additive phases so both old and new code
+stay valid at every step:
+
+```
+EXPAND ──────────→ MIGRATE ──────────→ CONTRACT
+add the new field,  backfill existing    once nothing reads the
+optional, beside    records to carry     old field, drop it in a
+the old one          both                later, separate change
+```
+
+Each phase ships and bakes independently before the next begins; a rename is an add
+(expand) followed by a drop (contract) in a later change, never a single in-place edit.
+Every migration needs a tested path backward, and a large backfill runs in batches
+rather than as one operation that locks everything else out.
+
+## Tracking Removal
+
+Open an issue for the actual removal at the same time the deprecation ships, targeted
+at the release where the grace period ends (`issue-rules` → Milestone), so the removal
+isn't forgotten and doesn't slip indefinitely once the deprecation notice stops being
+visible in day-to-day work.

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -21,6 +21,8 @@ skill is what to design for before those hooks would ever fire.
 - Memory-safety idioms that also happen to prevent whole classes of vulnerability
   (RAII, no naked `new`, no `void*`) → `cpp-coding` skill.
 - Security depth during review → `code-review-and-quality` skill (Security axis).
+- A vulnerability found in already-shipped code → `deprecation-and-migration` skill for
+  how to retire the unsafe path.
 
 ## Project Overrides
 

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: shipping-and-launch
+version: "1.0.0"
+description: Apply when preparing to ship a release to users, beyond the version-bump mechanics
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - release
+    - operations
+---
+
+# Skill: Shipping and Launch
+
+Apply when preparing to ship a release to users — the readiness, rollout, and rollback
+concerns around a release, beyond the version-bump/changelog/tag mechanics already
+covered by `release` skill. Use both together: `release` for the mechanical steps,
+this skill for whether the release is actually safe to expose to users and how widely.
+
+- Monitoring/alerting that must be in place before launch → `observability-and-instrumentation` skill.
+- A breaking change being shipped → `deprecation-and-migration` skill for how it was
+  telegraphed to consumers before this release.
+
+## Project Overrides
+
+Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own launch process, follow those instead. This skill is the fallback for projects that do not specify their own.
+
+---
+
+## Readiness Checklist
+
+Before a release goes out, confirm:
+
+- [ ] `release` skill's Pre-Release Checklist passes (version, changelog, CI green)
+- [ ] Monitoring/alerting for the new or changed behavior is in place, not planned for
+      after launch (`observability-and-instrumentation`)
+- [ ] A rollback plan exists and has been exercised at least once (not just theorized)
+- [ ] Any breaking change was already telegraphed per `deprecation-and-migration` — a
+      launch is not the first time consumers hear about a break
+- [ ] Whoever is on call during the launch window knows a release is happening
+
+A release failing any of these is not blocked from being *built* — it's blocked from
+being *exposed to users* until the gap is closed.
+
+## Staged Rollout
+
+Prefer exposing a risky change to a subset of traffic/users before full rollout —
+percentage-based rollout, a canary environment, or an internal-only release first —
+over an all-at-once release, when the blast radius of being wrong is large. Match the
+rollout strategy to the actual risk: a low-risk documentation-only release doesn't need
+a staged rollout; a change to a payment path does.
+
+## Rollout Decision Thresholds
+
+Decide the advance/hold/roll-back thresholds before the rollout starts, not by feel
+once traffic is flowing — set them relative to a measured baseline, not an absolute
+guess:
+
+| Signal | Advance | Hold and investigate | Roll back |
+|---|---|---|---|
+| Error rate | within 10% of baseline | 10-100% above baseline | more than 2x baseline |
+| p95 latency | within 20% of baseline | 20-50% above baseline | more than 50% above baseline |
+| New error types | none | rare, low volume | appearing at meaningful volume |
+| Business/behavior metric | neutral or better | small decline (may be noise) | clear decline |
+
+Roll back immediately, without waiting for the next scheduled check-in, on: an error
+rate more than 2x baseline, a severe latency regression, a data-integrity problem, or a
+newly discovered security issue — these don't wait for the hold-and-investigate step.
+
+## Rollback Plan
+
+Before shipping, know how to undo it — which previous version to roll back to, whether
+a data migration in this release is reversible, and how long rollback takes. A rollback
+plan discovered under incident pressure is not a plan; if reverting is not
+straightforward (irreversible migration, external side effects), say so explicitly
+before launch, not after something goes wrong.
+
+## Feature Flags
+
+For a change too risky to expose to everyone at once but also not practical to hold in
+a long-lived branch, ship it behind a flag defaulted off, enable it gradually, and
+remove the flag once the change is fully rolled out and stable — a flag left in
+indefinitely after full rollout is dead configuration surface, not a safety net anymore.
+
+## Communication
+
+Tell whoever needs to know before it happens, not after: consumers affected by a
+breaking change (`deprecation-and-migration`), on-call/support if user-facing behavior
+changes, and anyone depending on a deprecated path reaching its removal release. A
+launch that surprises the people who have to support it is a process failure even if
+the code itself is correct.
+
+## Post-Launch Verification
+
+After a release goes out, confirm — using the monitoring set up in the readiness
+checklist, not by assuming — that it behaves as expected under real traffic for a
+defined window before considering the launch complete. "It built and deployed" is not
+the same claim as "it works in production."


### PR DESCRIPTION
## Summary
- Adds the last cluster of full-life-cycle skills: `ci-cd-and-automation`, `deprecation-and-migration`, `shipping-and-launch`.
- Restores the `security-and-hardening` cross-reference deferred in #26. This completes the 9-skill gap-filling effort (GH-23/GH-25/GH-27).

## Implementation
- `ci-cd-and-automation` — pipeline quality gates, reproducibility, fast-feedback ordering, flaky-check handling. Cross-references `pr-rules` (merge gating) rather than restating it.
- `deprecation-and-migration` — deprecate-before-remove, grace periods, migration guides. Cross-references `api-design`'s Breaking Changes section rather than restating it.
- `shipping-and-launch` — readiness checklist, staged rollout, rollback planning, feature flags. Cross-references `release`'s Pre-Release Checklist rather than restating it.
- Stacked on #26 (base branch is GH-25's branch) because `security-and-hardening` needed its deferred cross-reference restored here.
- CHANGELOG.md updated under `Added`.

## Test plan
- `npm test` — 134/134 passing.
- `node install.js` (dry-run and real, into a temp `CLAUDE_CONFIG_DIR`) — 28 skill files present total.
- `tools/claude-md-skills-sync-check.js` against the installed temp dir — no drift reported.
- Verified no skill in this repo cross-references one that doesn't exist yet (`grep` over all backtick-quoted identifiers in the three new files against the full skill list).