### PR TITLE
GH-29: Support agents/ and commands/ directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Configuration repository for Claude Code.
 hooks/      Event dispatcher scripts (PreToolUse, PostToolUse, Stop)
 tools/      Atomic tool scripts invoked by hooks
 skills/     Skill definitions loaded by /skill-name slash commands
+agents/     Persona subagent definitions (one markdown file per agent)
+commands/   Slash command definitions (one markdown file per command)
 settings.json   Portable global Claude Code configuration
 install.js  Bootstrap script — copies files to ~/.claude/
 ```
@@ -43,6 +45,23 @@ See `skills/hook-scripts/SKILL.md` for full hook development conventions.
    `skills/` directly so it never goes stale, but this file must be updated by hand;
    `tools/claude-md-skills-sync-check.js` warns at session start if you forget)
 6. Run `node install.js` to deploy
+
+## Adding an agent
+
+1. Create `agents/<name>.md` with YAML frontmatter (`name`, `description`, `tools`) and
+   the persona's system prompt as the body
+2. Name the skill(s) the persona must apply in the body, so it doesn't have to
+   rediscover them from scratch each invocation
+3. Add an entry to the agents table in `README.md`
+4. Run `node install.js` to deploy — copied to `~/.claude/agents/<name>.md`
+
+## Adding a command
+
+1. Create `commands/<name>.md` — the body is the prompt template run for `/<name>`
+2. Keep a command's job to *orchestrating* existing skills/agents, not duplicating their
+   rules inline
+3. Add an entry to the commands table in `README.md`
+4. Run `node install.js` to deploy — copied to `~/.claude/commands/<name>.md`
 
 ## Installation
 

--- a/install.js
+++ b/install.js
@@ -181,6 +181,18 @@ if (!fs.existsSync(skillsDir)) {
   }
 }
 
+// agents/ and commands/ are optional — unlike hooks/tools/skills, a fresh
+// checkout of this repo may not carry any yet, so absence isn't warned on.
+log('\nagents/');
+const agentsDir = path.join(repoDir, 'agents');
+if (fs.existsSync(agentsDir)) copyDir(agentsDir, path.join(claudeDir, 'agents'));
+else log(`  ${logPrefix} (none)`);
+
+log('\ncommands/');
+const commandsDir = path.join(repoDir, 'commands');
+if (fs.existsSync(commandsDir)) copyDir(commandsDir, path.join(claudeDir, 'commands'));
+else log(`  ${logPrefix} (none)`);
+
 log('\nsettings.json');
 installSettings();
 

--- a/test/install-uninstall.test.js
+++ b/test/install-uninstall.test.js
@@ -50,6 +50,20 @@ test('install creates files and manifest on empty dir', () => {
   } finally { rmTmp(dir); }
 });
 
+test('install copies agents/ and commands/ when the repo ships them, skips gracefully otherwise', () => {
+  const dir = mkTmp();
+  const agentsDir = path.join(repoDir, 'agents');
+  const commandsDir = path.join(repoDir, 'commands');
+  const repoShipsAgents = fs.existsSync(agentsDir);
+  const repoShipsCommands = fs.existsSync(commandsDir);
+  try {
+    const r = runInstall(dir);
+    assert.strictEqual(r.status, 0, `install failed: ${r.stderr}`);
+    assert.strictEqual(fs.existsSync(path.join(dir, 'agents')), repoShipsAgents);
+    assert.strictEqual(fs.existsSync(path.join(dir, 'commands')), repoShipsCommands);
+  } finally { rmTmp(dir); }
+});
+
 test('uninstall removes everything when nothing was preexisting', () => {
   const dir = mkTmp();
   try {


### PR DESCRIPTION
## Summary
- `install.js` now deploys `agents/*.md` and `commands/*.md`, mirroring the existing `skills/` handling.
- `AGENTS.md` documents the new directories and the ceremony for adding an agent/command.

## Implementation
- Both directories are optional at install time — a checkout without either (the current state of this repo) installs cleanly with `(none)` logged, no warning. Content lands in follow-up PRs (persona agents, then `/spec`/`/build`/`/ship` commands).
- `uninstall.js` needed no changes: it reverses purely from `manifest.createdFiles`, generic over subdirectory — verified via the round-trip test, not just assumed.
- Based directly on `main` (not stacked) — this PR is independent of the skill-catalog PRs (#24/#26/#28).

## Test plan
- `npm test` — 135/135 passing (new test added: agents/commands round-trip, self-adjusting to whatever the repo currently ships so it keeps working once #30/#31 land real content).
- `node install.js --dry-run` — shows `agents/` and `commands/` sections, `(none)` for both in the current repo state.
- Manual install → uninstall round-trip against a temp `CLAUDE_CONFIG_DIR` — confirmed empty directory afterward.