### PR TITLE
GH-35: Add /spec, /build, /ship commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `writing-style` skill: technical register and vocabulary for documentation, issue/PR/commit text, and conversation, in any human language — no slang, no unnecessary borrowings from another language
 - `install.js` support for `agents/*.md` → `~/.claude/agents/` and `commands/*.md` → `~/.claude/commands/` (both optional; a checkout without either installs cleanly)
 - Agents: `spec-architect`, `implementer`, `code-reviewer`, `security-auditor`, `release-manager` — persona subagents forming an idea-to-release pipeline, each scoped to one stage and pointed at the skills it applies
+- Commands: `/spec`, `/build`, `/ship` — orchestrate the persona agents into an idea-to-release pipeline; `/ship` fans `code-reviewer` and `security-auditor` out in parallel, merges into a go/no-go, and hands off to `release-manager` on go
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ points at the skills it applies — see `AGENTS.md` → "Adding an agent".
 | `security-auditor` | Security audit | `security-and-hardening` |
 | `release-manager` | Release | `changelog`, `release`, `shipping-and-launch` |
 
+## Commands
+
+Slash commands orchestrating the agents above into the idea-to-release pipeline.
+
+| Command | Orchestrates |
+|---------|---------------|
+| `/spec <idea>` | `spec-architect` — produces a specification (and ADR when warranted) |
+| `/build <task>` | `implementer` — implements one task by TDD from an existing spec |
+| `/ship [scope]` | `code-reviewer` + `security-auditor` in parallel → go/no-go → `release-manager` on go |
+
 ## Installation
 
 Requires Node.js (no npm packages needed).

--- a/commands/build.md
+++ b/commands/build.md
@@ -1,0 +1,13 @@
+---
+description: Implement one task by TDD via the implementer persona, from an existing spec
+argument-hint: <task to implement>
+---
+
+Invoke the `implementer` subagent to implement the following task, by TDD, from the
+spec already produced by `/spec`:
+
+$ARGUMENTS
+
+If no spec exists yet for this task, stop and ask whether to run `/spec` first rather
+than guessing at requirements. Do not review the resulting diff for merge-readiness as
+part of this command — that is `/ship`'s job.

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -1,0 +1,28 @@
+---
+description: Run code-reviewer and security-auditor in parallel on the current change, merge into a go/no-go, then hand off to release-manager
+argument-hint: [optional scope, defaults to the current diff/branch]
+---
+
+Scope: $ARGUMENTS (default to the current diff or branch if not specified).
+
+Run both of the following in parallel, each as its own subagent invocation:
+
+1. `code-reviewer` subagent — review the scope for correctness, readability,
+   architecture fit, security, and performance (Security/Performance axes are a first
+   pass only; the dedicated audit below is authoritative for security).
+2. `security-auditor` subagent — audit the same scope for trust-boundary, input
+   validation, secrets, and least-privilege issues.
+
+Merge both reports into a single verdict:
+
+- **Go** — neither subagent reported a blocking finding.
+- **No-go** — either subagent reported at least one blocking finding.
+
+Report the merged verdict and every finding (with severity) to the user before doing
+anything else.
+
+On **go**, invoke the `release-manager` subagent to prepare the release (changelog
+entry, version bump, shipping-readiness checklist).
+
+On **no-go**, stop. Do not invoke `release-manager`, and do not attempt to fix the
+findings yourself as part of this command — that goes back through `/build`.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -1,0 +1,12 @@
+---
+description: Turn an idea or task into a specification (and ADR when the change touches architecture) via the spec-architect persona
+argument-hint: <idea or task description>
+---
+
+Invoke the `spec-architect` subagent to turn the following into a specification:
+
+$ARGUMENTS
+
+Wait for the spec (and ADR, if the change touches system/module structure) before
+starting implementation. Do not write implementation code as part of this command —
+that is `/build`'s job.

--- a/test/install-uninstall.test.js
+++ b/test/install-uninstall.test.js
@@ -73,6 +73,15 @@ test('install deploys the spec-architect persona agent', () => {
   } finally { rmTmp(dir); }
 });
 
+test('install deploys the ship command', () => {
+  const dir = mkTmp();
+  try {
+    const r = runInstall(dir);
+    assert.strictEqual(r.status, 0, `install failed: ${r.stderr}`);
+    assert.ok(fs.existsSync(path.join(dir, 'commands', 'ship.md')));
+  } finally { rmTmp(dir); }
+});
+
 test('uninstall removes everything when nothing was preexisting', () => {
   const dir = mkTmp();
   try {


### PR DESCRIPTION
## Summary
- Adds `/spec`, `/build`, `/ship` commands orchestrating the 5 persona agents (GH-33) into an idea-to-release pipeline.
- Adds a "Commands" table to `README.md`.

## Implementation
- `/spec` and `/build` are thin — invoke one persona each, with an explicit boundary against doing the next stage's job.
- `/ship` fans `code-reviewer` and `security-auditor` out in parallel, merges into a single go/no-go verdict, and only invokes `release-manager` on go.
- Extended `test/install-uninstall.test.js` with a specific-filename assertion (`commands/ship.md`), same pattern used for the agent files in #34.

## Test plan
- `npm test` — 137/137 passing.
- `node install.js` (dry-run and real, into a temp `CLAUDE_CONFIG_DIR`) — all 3 command files present under `commands/`.
- `tools/claude-md-skills-sync-check.js` against the installed temp dir — no drift reported.
- Verified every backtick-quoted agent reference in the 3 command files resolves to an agent that exists.