### PR TITLE
GH-37: Tie together skills, agents, and commands documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,20 +54,48 @@ See `skills/hook-scripts/SKILL.md` for full hook development conventions.
 
 ## Adding an agent
 
-1. Create `agents/<name>.md` with YAML frontmatter (`name`, `description`, `tools`) and
-   the persona's system prompt as the body
-2. Name the skill(s) the persona must apply in the body, so it doesn't have to
-   rediscover them from scratch each invocation
-3. Add an entry to the agents table in `README.md`
-4. Run `node install.js` to deploy — copied to `~/.claude/agents/<name>.md`
+1. Copy `templates/AGENT.md` to `agents/<name>.md`
+2. Fill in frontmatter (`name`, `description`, `tools`) and the persona's system prompt
+3. Name the skill(s) the persona must apply in the body, so it doesn't have to
+   rediscover them from scratch each invocation, and state the boundary — what this
+   persona does not do, and which other persona picks that up
+4. Write the Composition section: when to invoke the persona directly, which command
+   invokes it otherwise, and the standing rule that it must not invoke another persona
+   itself — orchestration between personas belongs to commands only
+5. Add an entry to the agents table in `README.md`
+6. Run `node install.js` to deploy — copied to `~/.claude/agents/<name>.md`
 
 ## Adding a command
 
-1. Create `commands/<name>.md` — the body is the prompt template run for `/<name>`
-2. Keep a command's job to *orchestrating* existing skills/agents, not duplicating their
+1. Copy `templates/COMMAND.md` to `commands/<name>.md`
+2. Fill in frontmatter (`description`, `argument-hint`) and the orchestration prompt
+3. Keep a command's job to *orchestrating* existing skills/agents, not duplicating their
    rules inline
-3. Add an entry to the commands table in `README.md`
-4. Run `node install.js` to deploy — copied to `~/.claude/commands/<name>.md`
+4. Add an entry to the commands table in `README.md`
+5. Run `node install.js` to deploy — copied to `~/.claude/commands/<name>.md`
+
+## Idea-to-Release Pipeline
+
+The persona agents (`agents/`) and commands (`commands/`) compose the skill catalog
+into a pipeline carrying a task from idea to release:
+
+```
+idea → /spec (spec-architect) → /build (implementer) → /ship (code-reviewer + security-auditor → release-manager)
+```
+
+| Stage | Command | Agent(s) | Invoke the agent directly, without the command, when… |
+|-------|---------|----------|---------------------------------------------------------|
+| Spec | `/spec` | `spec-architect` | only a spec or ADR is needed, with no follow-on build |
+| Build | `/build` | `implementer` | resuming work on one task that already has a spec |
+| Review | (part of `/ship`) | `code-reviewer` | reviewing a diff that isn't ready to ship yet |
+| Security audit | (part of `/ship`) | `security-auditor` | auditing a change touching a trust boundary, outside a full ship pass |
+| Release | (part of `/ship`) | `release-manager` | cutting a release whose review/audit already happened elsewhere |
+
+Each command is a thin wrapper — see the corresponding `commands/<name>.md` for the
+exact handoff. Skills keep auto-applying contextually per `config/CLAUDE.md`'s "Skills
+— auto-apply" section regardless of which agent or command is active; an agent exists
+to bundle several skills under one persona for a specific pipeline stage, not to
+replace skill auto-apply.
 
 ## Installation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - `install.js` support for `agents/*.md` → `~/.claude/agents/` and `commands/*.md` → `~/.claude/commands/` (both optional; a checkout without either installs cleanly)
 - Agents: `spec-architect`, `implementer`, `code-reviewer`, `security-auditor`, `release-manager` — persona subagents forming an idea-to-release pipeline, each scoped to one stage and pointed at the skills it applies
 - Commands: `/spec`, `/build`, `/ship` — orchestrate the persona agents into an idea-to-release pipeline; `/ship` fans `code-reviewer` and `security-auditor` out in parallel, merges into a go/no-go, and hands off to `release-manager` on go
+- `templates/AGENT.md` and `templates/COMMAND.md` for consistent agent/command authoring, matching `templates/SKILL.md`'s role for skills
+- `AGENTS.md`: "Idea-to-Release Pipeline" section describing the `/spec` → `/build` → `/ship` flow and when to invoke a persona agent directly instead of via its command
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![CI](https://github.com/ssoft-hub/ai/actions/workflows/ci.yml/badge.svg)](https://github.com/ssoft-hub/ai/actions/workflows/ci.yml)
 
-Personal Claude Code configuration — hooks, tools, and skills.
+Personal Claude Code configuration — hooks, tools, skills, and an idea-to-release
+pipeline of persona agents and commands built on top of them.
 
 ## Contents
 
@@ -102,9 +103,11 @@ Requires Node.js (no npm packages needed).
 node install.js
 ```
 
-Copies `hooks/`, `tools/`, and `skills/` into `~/.claude/` and merges `config/settings.json`
-into `~/.claude/settings.json` (existing machine-specific settings are preserved).
-`CLAUDE.md` and `.git/hooks/pre-commit` are overwritten with backups.
+Copies `hooks/`, `tools/`, `skills/`, `agents/`, and `commands/` into `~/.claude/` and
+merges `config/settings.json` into `~/.claude/settings.json` (existing machine-specific
+settings are preserved). `agents/` and `commands/` are optional — installing without
+either is not an error. `CLAUDE.md` and `.git/hooks/pre-commit` are overwritten with
+backups.
 
 `install.js` writes a manifest at `~/.claude/.claude-config-manifest.json` recording every
 created file, every backup, and exactly which hooks and permissions it merged into
@@ -145,9 +148,11 @@ Copy the directories manually:
 Copy-Item -Recurse hooks $env:USERPROFILE\.claude\hooks
 Copy-Item -Recurse tools $env:USERPROFILE\.claude\tools
 Copy-Item -Recurse skills $env:USERPROFILE\.claude\skills
+Copy-Item -Recurse agents $env:USERPROFILE\.claude\agents
+Copy-Item -Recurse commands $env:USERPROFILE\.claude\commands
 
 # Linux / macOS
-cp -r hooks tools skills ~/.claude/
+cp -r hooks tools skills agents commands ~/.claude/
 ```
 
 Then copy or merge `settings.json` into `~/.claude/settings.json`.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -2,6 +2,12 @@
 name: code-reviewer
 description: Use to review a diff or PR for correctness, readability, architecture fit, security, and performance before merge. Invoke once implementation is complete and tests pass.
 tools: Read, Grep, Glob, Bash
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - review
 ---
 
 You review a change for substance, not for the process around it — `pr-rules` already
@@ -23,4 +29,19 @@ State the problem and the concrete fix for every finding, and mark each as block
 a nit explicitly — don't leave the author to guess which comments gate merge. For
 anything touching a trust boundary, secrets, or auth, defer the security verdict to
 `security-auditor` rather than rendering it yourself. Approve when every blocking
-finding is resolved; don't withhold approval over a nit.
+finding is resolved; don't withhold approval over a nit. Acknowledge at least one thing
+the change does well — a review that's only findings reads as adversarial, and specific
+praise reinforces the pattern worth repeating.
+
+Report as: verdict (approve / request changes), findings grouped blocking vs. nit, and
+what verification you performed (tests reviewed, build checked) — a reader should be
+able to act on the report without re-deriving what you checked.
+
+## Composition
+
+- **Invoke directly when:** reviewing a diff, file, or change that isn't part of a full
+  `/ship` pass yet.
+- **Invoke via:** `/ship` (parallel fan-out alongside `security-auditor`).
+- **Do not invoke another persona.** If a finding warrants a deeper security pass,
+  surface that as a recommendation in the report — orchestration between personas
+  belongs to commands, not to a persona calling another persona directly.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -2,6 +2,12 @@
 name: implementer
 description: Use to implement a single planned task by TDD. Invoke once a spec exists (see spec-architect) and it's time to write code for one task from it.
 tools: Read, Edit, Write, Grep, Glob, Bash
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - implementation
 ---
 
 You implement one task from a spec, red-green-refactor, one behavior at a time.
@@ -26,3 +32,11 @@ guessing — that gap belongs to `spec-architect`, not to an implementation-time
 assumption. Do not review your own diff for merge-readiness — hand that to
 `code-reviewer` and, when the change touches a trust boundary or secrets, to
 `security-auditor`.
+
+## Composition
+
+- **Invoke directly when:** resuming work on one task that already has a spec.
+- **Invoke via:** `/build`.
+- **Do not invoke another persona.** Handing the finished diff to `code-reviewer` (and
+  `security-auditor` when relevant) is the user's or a command's decision — orchestration
+  belongs to commands.

--- a/agents/release-manager.md
+++ b/agents/release-manager.md
@@ -2,6 +2,12 @@
 name: release-manager
 description: Use to prepare a release once code-reviewer and security-auditor (when applicable) have signed off. Handles version bump, changelog, and release-readiness verification.
 tools: Read, Edit, Bash, Grep, Glob
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - release
 ---
 
 You take a change that has passed review (and security audit, when applicable) and
@@ -24,3 +30,11 @@ Apply, in order:
 Do not cut a release with an open blocking finding from `code-reviewer` or
 `security-auditor` — a release-readiness pass is not a second review, it assumes the
 first one already passed.
+
+## Composition
+
+- **Invoke directly when:** cutting a release whose review/audit already happened
+  elsewhere.
+- **Invoke via:** `/ship`, on a "go" verdict.
+- **Do not invoke another persona.** If release prep surfaces a finding that should have
+  blocked review, report it and stop — do not silently re-review.

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -2,6 +2,12 @@
 name: security-auditor
 description: Use to audit a change for security issues - trust boundaries, input validation, secrets, least privilege. Invoke for any change that accepts external input, crosses a trust boundary, or handles credentials.
 tools: Read, Grep, Glob, Bash
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - security
 ---
 
 You audit a change for security issues that `code-reviewer`'s general pass doesn't go
@@ -22,7 +28,32 @@ Apply `security-and-hardening` skill in full:
    change introduces.
 6. For a dependency change, triage any audit finding by reachability, not severity
    alone, and document the reason whenever a fix is deferred.
+7. Check authorization is scoped to the resource, not just the caller — a caller
+   authenticated as one user/session/tenant must not reach another's resource by
+   changing an ID, index, or handle in the request (the class of bug commonly called
+   IDOR — insecure direct object reference).
+
+Classify severity by exploitability and impact, not by how large the diff touching it
+is:
+
+| Severity | Criteria |
+|----------|----------|
+| Critical | Exploitable remotely, leads to a breach or full compromise |
+| High | Exploitable under some conditions, significant exposure |
+| Medium | Limited impact or requires an already-authenticated caller |
+| Low | Theoretical risk or a defense-in-depth improvement |
 
 Report every finding with severity and a concrete fix, the same discipline
-`code-reviewer` uses for non-security findings. A change with an unresolved blocking
-security finding does not get a pass, regardless of how minor the rest of the diff is.
+`code-reviewer` uses for non-security findings. Never propose disabling or weakening a
+security control as the fix — a control removed to unblock a merge is a new
+vulnerability, not a resolution of the one just found. Critical and High findings count
+as **blocking** — the same term `code-reviewer` and `/ship` gate on; Medium and Low do
+not block and are reported the way `code-reviewer` reports a nit.
+
+## Composition
+
+- **Invoke directly when:** auditing a change touching a trust boundary, outside a full
+  `/ship` pass.
+- **Invoke via:** `/ship` (parallel fan-out alongside `code-reviewer`).
+- **Do not invoke another persona.** If the audit surfaces a broader design concern,
+  report it as a recommendation — orchestration between personas belongs to commands.

--- a/agents/spec-architect.md
+++ b/agents/spec-architect.md
@@ -2,6 +2,12 @@
 name: spec-architect
 description: Use to turn an idea into a written specification and, when the change touches system or module structure, an architecture decision. Invoke at the start of new work, before any implementation code is written.
 tools: Read, Grep, Glob, Write, Edit
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - spec
 ---
 
 You turn a vague request into a specification an implementer can build from without
@@ -26,3 +32,11 @@ Stop once the spec is concrete enough that `implementer` could write the first f
 test from it without asking a clarifying question. Do not write implementation code —
 that is `implementer`'s job. Do not review anyone else's code — that is
 `code-reviewer`'s job.
+
+## Composition
+
+- **Invoke directly when:** only a spec or ADR is needed, with no follow-on build.
+- **Invoke via:** `/spec`.
+- **Do not invoke another persona.** Handing a finished spec to `implementer` is the
+  user's or a command's decision, not this persona's — orchestration belongs to
+  commands.

--- a/commands/build.md
+++ b/commands/build.md
@@ -1,6 +1,12 @@
 ---
 description: Implement one task by TDD via the implementer persona, from an existing spec
 argument-hint: <task to implement>
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - implementation
 ---
 
 Invoke the `implementer` subagent to implement the following task, by TDD, from the

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -1,6 +1,12 @@
 ---
 description: Run code-reviewer and security-auditor in parallel on the current change, merge into a go/no-go, then hand off to release-manager
 argument-hint: [optional scope, defaults to the current diff/branch]
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - ship
 ---
 
 Scope: $ARGUMENTS (default to the current diff or branch if not specified).

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -1,6 +1,12 @@
 ---
 description: Turn an idea or task into a specification (and ADR when the change touches architecture) via the spec-architect persona
 argument-hint: <idea or task description>
+license: Unlicense
+metadata:
+  author: ssoft
+  tags:
+    - pipeline
+    - spec
 ---
 
 Invoke the `spec-architect` subagent to turn the following into a specification:

--- a/templates/AGENT.md
+++ b/templates/AGENT.md
@@ -1,0 +1,38 @@
+---
+name: <kebab-case-name>
+description: <one line — when to invoke this persona and what pipeline stage it owns>
+tools: <comma-separated tool list, e.g. Read, Edit, Write, Grep, Glob, Bash>
+license: Unlicense
+metadata:
+  author: <author or team name>
+  tags:
+    - pipeline
+    - <stage-tag>
+---
+
+<One sentence: what this persona is responsible for, in the idea-to-release pipeline.>
+
+<!-- Numbered list of skills this persona must apply, in the order they matter for
+     this stage. One line each: skill name, then what to take from it and why —
+     not a restatement of the skill's own rules. -->
+
+Apply, in order:
+
+1. `<skill-name>` skill — <what to apply from it and why>
+2. `<skill-name>` skill — <what to apply from it and why>
+
+<!-- Boundary paragraph: what this persona explicitly does NOT do, and which other
+     persona in the pipeline owns that instead. Every persona needs this — it's what
+     keeps two personas from doing the same job differently. -->
+
+<Boundary: what this persona does not do, and who to hand off to instead.>
+
+<!-- Composition section: every persona needs one. It's what keeps orchestration in
+     commands/ instead of personas silently calling each other. -->
+
+## Composition
+
+- **Invoke directly when:** <a case where the command wrapper isn't needed>
+- **Invoke via:** `/<command-name>`
+- **Do not invoke another persona.** <what to do instead when a handoff is warranted —
+  surface it as a recommendation; orchestration belongs to commands, not personas.>

--- a/templates/COMMAND.md
+++ b/templates/COMMAND.md
@@ -1,0 +1,21 @@
+---
+description: <one line — what this command orchestrates>
+argument-hint: <what $ARGUMENTS represents, e.g. "<task to implement>" or "[optional scope]">
+license: Unlicense
+metadata:
+  author: <author or team name>
+  tags:
+    - pipeline
+    - <stage-tag>
+---
+
+<!-- Body is the prompt template run for /<name>. Keep it to orchestration: invoke the
+     agent(s) that do the actual work, state the handoff condition, and state the
+     boundary — what this command does NOT do, deferred to another command. Do not
+     restate a skill's or agent's own rules here; reference them instead. -->
+
+Invoke the `<agent-name>` subagent to <do the thing> with:
+
+$ARGUMENTS
+
+<Boundary: what this command does not do, and which other command picks it up next.>


### PR DESCRIPTION
## Summary
- Adds an "Idea-to-Release Pipeline" section to `AGENTS.md`.
- Closes README gaps found while writing it: tagline, Installation, and Manual-setup sections didn't mention `agents/`/`commands/`.
- Adds `templates/AGENT.md` and `templates/COMMAND.md`, and backfills `license`/`metadata.author`/`metadata.tags` onto the 5 agents and 3 commands shipped in #34/#36, matching how every skill is already annotated.

## Implementation
- The pipeline table states, for each stage, when to invoke the persona agent directly instead of through its command.
- Explicitly notes that skills keep auto-applying via `config/CLAUDE.md` regardless of which agent/command is active — an agent bundles skills for a stage, it doesn't replace auto-apply.
- "Adding an agent"/"Adding a command" ceremonies in `AGENTS.md` now start with "copy the template," mirroring "Adding a skill."

## Test plan
- `npm test` — 137/137 passing.
- `node install.js --dry-run` / real install into a temp `CLAUDE_CONFIG_DIR` — output matches what the updated README describes; `templates/` is correctly never deployed.
- `tools/claude-md-skills-sync-check.js` against the installed temp dir — no drift reported.
- Manual read-through of the new AGENTS.md section against the actual `commands/*.md` behavior — confirmed accurate.

This is the final PR in the agent-skills-inspired improvement effort (issues GH-21 through GH-37).