### PR TITLE
GH-39: Add comment-check PostToolUse reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Commands: `/spec`, `/build`, `/ship` — orchestrate the persona agents into an idea-to-release pipeline; `/ship` fans `code-reviewer` and `security-auditor` out in parallel, merges into a go/no-go, and hands off to `release-manager` on go
 - `templates/AGENT.md` and `templates/COMMAND.md` for consistent agent/command authoring, matching `templates/SKILL.md`'s role for skills
 - `AGENTS.md`: "Idea-to-Release Pipeline" section describing the `/spec` → `/build` → `/ship` flow and when to invoke a persona agent directly instead of via its command
+- `comment-check` tool: `PostToolUse` reminder when an edit adds a new non-Doxygen comment to a C++ file, pointing back at the `comments` skill — runs unconditionally, unlike the lint tools which require a project config file
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ pipeline of persona agents and commands built on top of them.
 - `commit-trailer-guard.js` — blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
 - `secret-guard.js` — blocks writes (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) containing private keys, AWS keys, GitHub PATs; warns on probable credentials
 
-**`PostToolUse`** — runs after `Edit` / `Write` / `MultiEdit` / `NotebookEdit` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`). Each tool runs **only when its config file is present in this repository** (searched from the edited file up to the git root, never into a parent repo); otherwise it is skipped silently:
-- `clang-format.js` — formats in-place; requires `.clang-format` (skips silently if `clang-format` not in PATH)
+**`PostToolUse`** — runs after `Edit` / `Write` / `MultiEdit` / `NotebookEdit` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`):
+- `comment-check.js` — runs unconditionally (no config file needed); reminds to check any newly added non-Doxygen comment against the `comments` skill
+- `clang-format.js` — formats in-place; requires `.clang-format` in this repository (searched from the edited file up to the git root, never into a parent repo) — skips silently if missing, or if `clang-format` isn't in PATH
 - `clang-tidy.js` — runs static analysis; requires `.clang-tidy` (uses `compile_commands.json` when found)
 - `cppcheck.js` — runs `cppcheck --enable=warning,style,performance,portability --std=c++20 --error-exitcode=1 …`; requires `.cppcheck`, passed as `--suppressions-list`
 

--- a/hooks/PostToolUse.js
+++ b/hooks/PostToolUse.js
@@ -61,6 +61,11 @@ process.stdin.on('end', () => {
   const filePath = data.tool_input?.file_path ?? data.tool_input?.notebook_path ?? data.tool_input?.path;
   if (!filePath || !CPP_EXTS.has(path.extname(filePath).toLowerCase())) process.exit(0);
 
+  // Reminder for the `comments` skill, not an external linter — runs unconditionally,
+  // unlike the LINT tools below which require a project config file.
+  const cc = spawnSync('node', [path.join(toolsDir, 'comment-check.js')], { input: raw, encoding: 'utf8', stdio: 'pipe', timeout: 10000 });
+  if (cc.stdout?.trim()) process.stdout.write(cc.stdout.trim() + '\n');
+
   const fileDir = path.dirname(path.resolve(filePath));
   const boundary = repoBoundary(fileDir);
 

--- a/test/comment-check.test.js
+++ b/test/comment-check.test.js
@@ -1,0 +1,92 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { isPlainCommentLine, addedCommentLines, extractEdits, check } = require('../tools/comment-check');
+
+test('detects a leading // comment', () => {
+  assert.strictEqual(isPlainCommentLine('// note'), true);
+});
+
+test('detects a trailing // comment after code', () => {
+  assert.strictEqual(isPlainCommentLine('int x = 5; // meaning of x'), true);
+});
+
+test('ignores a URL containing //', () => {
+  assert.strictEqual(isPlainCommentLine('const std::string url = "https://example.com";'), false);
+});
+
+test('excludes Doxygen /// comments', () => {
+  assert.strictEqual(isPlainCommentLine('/// Brief description.'), false);
+});
+
+test('excludes Doxygen //! comments', () => {
+  assert.strictEqual(isPlainCommentLine('//! Brief description.'), false);
+});
+
+test('excludes Doxygen /** block comments', () => {
+  assert.strictEqual(isPlainCommentLine('/** Brief description.'), false);
+});
+
+test('detects a plain block comment opener', () => {
+  assert.strictEqual(isPlainCommentLine('/* explanation */'), true);
+});
+
+test('detects a plain block comment closer', () => {
+  assert.strictEqual(isPlainCommentLine(' * still explaining */'), true);
+});
+
+test('ignores a line with no comment', () => {
+  assert.strictEqual(isPlainCommentLine('int x = 5;'), false);
+});
+
+test('addedCommentLines finds only lines new to newText', () => {
+  const added = addedCommentLines('int x = 5;', 'int x = 5;\n// why 5\nint y = 6;');
+  assert.deepStrictEqual(added, ['// why 5']);
+});
+
+test('addedCommentLines ignores a comment already present in oldText', () => {
+  const added = addedCommentLines('// why 5\nint x = 5;', '// why 5\nint x = 6;');
+  assert.deepStrictEqual(added, []);
+});
+
+test('extractEdits reads a single Edit old_string/new_string pair', () => {
+  const edits = extractEdits({ old_string: 'a', new_string: 'b' });
+  assert.deepStrictEqual(edits, [{ old: 'a', new: 'b' }]);
+});
+
+test('extractEdits reads MultiEdit edits array', () => {
+  const edits = extractEdits({ edits: [{ old_string: 'a', new_string: 'b' }, { old_string: 'c', new_string: 'd' }] });
+  assert.deepStrictEqual(edits, [{ old: 'a', new: 'b' }, { old: 'c', new: 'd' }]);
+});
+
+test('extractEdits returns empty array for Write (no prior content available)', () => {
+  assert.deepStrictEqual(extractEdits({ content: 'whatever' }), []);
+});
+
+test('extractEdits returns empty array for null tool_input', () => {
+  assert.deepStrictEqual(extractEdits(null), []);
+});
+
+test('check flags a new comment in a .cpp file', () => {
+  const r = check({ old_string: 'int x = 5;', new_string: 'int x = 5; // why 5' }, 'foo.cpp');
+  assert.deepStrictEqual(r.added, ['int x = 5; // why 5']);
+});
+
+test('check skips non-C++ files', () => {
+  const r = check({ old_string: '', new_string: '// note' }, 'foo.js');
+  assert.deepStrictEqual(r.added, []);
+});
+
+test('check skips when file_path is missing', () => {
+  const r = check({ old_string: '', new_string: '// note' }, '');
+  assert.deepStrictEqual(r.added, []);
+});
+
+test('check aggregates across MultiEdit edits', () => {
+  const toolInput = { edits: [
+    { old_string: 'a;', new_string: 'a; // one' },
+    { old_string: 'b;', new_string: 'b; // two' },
+  ] };
+  const r = check(toolInput, 'foo.h');
+  assert.deepStrictEqual(r.added, ['a; // one', 'b; // two']);
+});

--- a/test/lint-gating.test.js
+++ b/test/lint-gating.test.js
@@ -21,6 +21,13 @@ function makeStubConfigDir() {
       `process.stdout.write('INVOKED ${name} ' + (process.argv[3] || '') + '\\n');\n`,
     );
   }
+  // The dispatcher also runs comment-check.js unconditionally (not gated by a config
+  // file like the lint tools above) — copy the real one so its stdin-reading exit
+  // path doesn't fail with "module not found" and pollute these assertions.
+  fs.copyFileSync(
+    path.join(__dirname, '..', 'tools', 'comment-check.js'),
+    path.join(toolsDir, 'comment-check.js'),
+  );
   return cfgDir;
 }
 
@@ -32,9 +39,9 @@ function makeRepo() {
   return repo;
 }
 
-function runDispatcher(cfgDir, filePath) {
+function runDispatcher(cfgDir, filePath, extraToolInput = {}) {
   const r = spawnSync('node', [DISPATCHER], {
-    input: JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: filePath } }),
+    input: JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: filePath, ...extraToolInput } }),
     encoding: 'utf8',
     env: { ...process.env, CLAUDE_CONFIG_DIR: cfgDir },
   });
@@ -99,5 +106,20 @@ test('config above the repo boundary (parent repo) is not used', () => {
     assert.strictEqual(out.trim(), '');
   } finally {
     cleanup(cfgDir, parent);
+  }
+});
+
+test('comment-check reminder surfaces through the dispatcher even with no lint config', () => {
+  const cfgDir = makeStubConfigDir();
+  const repo = makeRepo();
+  try {
+    const out = runDispatcher(cfgDir, path.join(repo, 'x.cpp'), {
+      old_string: 'int x = 5;',
+      new_string: 'int x = 5; // why 5',
+    });
+    assert.match(out, /comment-check reminder/);
+    assert.match(out, /why 5/);
+  } finally {
+    cleanup(cfgDir, repo);
   }
 });

--- a/tools/comment-check.js
+++ b/tools/comment-check.js
@@ -1,0 +1,65 @@
+'use strict';
+const path = require('path');
+
+const CPP_EXTS = new Set(['.h', '.hpp', '.cpp', '.cc', '.cxx']);
+
+// A "plain" comment line the `comments` skill governs. Doxygen markers (///, //!,
+// /**) are excluded — those belong to the separate `doxygen` skill. `//` must sit at
+// line start or after whitespace so a URL literal like "https://x" doesn't match.
+function isPlainCommentLine(line) {
+  if (/\/\/\/|\/\/!|\/\*\*/.test(line)) return false;
+  if (/(^|\s)\/\/(?!\/)/.test(line)) return true;
+  return /\/\*(?!\*)/.test(line) || /\*\/\s*$/.test(line);
+}
+
+// Compares whole lines against the pre-edit set, not just the comment substring, so
+// a comment attached to a changed code line is flagged too — cheaper than a real
+// line-level diff, at the cost of an occasional re-flag of an unchanged comment.
+function addedCommentLines(oldText, newText) {
+  const oldLines = new Set((oldText ?? '').split('\n'));
+  return (newText ?? '').split('\n').filter(line => isPlainCommentLine(line) && !oldLines.has(line));
+}
+
+// Edit -> one {old,new} pair; MultiEdit -> one pair per edits[]. Write has no prior
+// content in the hook payload, so it's intentionally not covered here — flagging
+// every comment in a full overwrite would be noise, not a useful nudge.
+function extractEdits(toolInput) {
+  if (!toolInput) return [];
+  if (Array.isArray(toolInput.edits)) {
+    return toolInput.edits.map(e => ({ old: e?.old_string ?? '', new: e?.new_string ?? '' }));
+  }
+  if (toolInput.old_string !== undefined || toolInput.new_string !== undefined) {
+    return [{ old: toolInput.old_string ?? '', new: toolInput.new_string ?? '' }];
+  }
+  return [];
+}
+
+function check(toolInput, filePath) {
+  if (!filePath || !CPP_EXTS.has(path.extname(filePath).toLowerCase())) return { added: [] };
+  const added = extractEdits(toolInput).flatMap(({ old, new: n }) => addedCommentLines(old, n));
+  return { added };
+}
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+    const filePath = data.tool_input?.file_path ?? '';
+    const { added } = check(data.tool_input, filePath);
+    if (added.length) {
+      process.stdout.write(
+        `comment-check reminder — ${added.length} new comment${added.length === 1 ? '' : 's'} in ${filePath}:\n` +
+        added.map(l => `  ${l.trim()}`).join('\n') + '\n' +
+        'Check each against the `comments` skill: default is no comment; keep only one ' +
+        'that states a fact the code cannot say itself.\n'
+      );
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { isPlainCommentLine, addedCommentLines, extractEdits, check };


### PR DESCRIPTION
## Summary
- Adds `tools/comment-check.js`: a `PostToolUse` reminder when an edit adds a new non-Doxygen comment to a C++ file, pointing back at the `comments` skill.
- Wired into `hooks/PostToolUse.js`, running unconditionally (unlike `clang-format`/`clang-tidy`/`cppcheck`, which require a project config file).

## Implementation
- Detects added comment lines by diffing `old_string`/`new_string` (Edit) or each pair in `edits[]` (MultiEdit) against a per-line regex that excludes Doxygen markers (`///`, `//!`, `/**`).
- `Write` is intentionally not covered — no prior content is available in that hook's payload to diff against, and flagging every comment in a full overwrite would be noise.
- Fixed `test/lint-gating.test.js`'s stub `CLAUDE_CONFIG_DIR`, which didn't include `comment-check.js` — the dispatcher's new unconditional call was silently failing there (module not found) since the tests only assert `stdout`, never stderr/exit status.

## Test plan
- `npm test` — 157/157 passing (19 new tests for the detection logic + one dispatcher-level integration test).
- Manual: piped a real `Edit` payload with an added trailing comment into `hooks/PostToolUse.js` — reminder printed correctly.
- `node install.js --dry-run` — `comment-check.js` shows deployed to `~/.claude/tools/`.
- `tools/claude-md-skills-sync-check.js` — no drift.