### PR TITLE
GH-41: Cross-reference comments and cpp-coding skills

### DIFF
--- a/skills/comments/SKILL.md
+++ b/skills/comments/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Apply when writing or reviewing non-Doxygen code comments (inline notes, implementation comments).
 
-Doc comments on public headers → `doxygen` skill. This skill covers everything else: comments inside function bodies, `.cpp` files, private implementation.
+Doc comments on public headers → `doxygen` skill. This skill covers everything else: comments inside function bodies, `.cpp` files, private implementation. Implementation conventions (types, RAII, naming) → `cpp-coding` skill.
 
 ---
 

--- a/skills/cpp-coding/SKILL.md
+++ b/skills/cpp-coding/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 Apply when writing or reviewing C++ implementation code.
 
-Scope: project-level implementation conventions (not the C++ standard). Public API structure → `api-design`. Docs → `doxygen`. Naming, namespaces, file layout → project `AGENTS.md`.
+Scope: project-level implementation conventions (not the C++ standard). Public API structure → `api-design`. Docs → `doxygen`. Inline/implementation comments → `comments`. Naming, namespaces, file layout → project `AGENTS.md`.
 
 Reference: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#s-philosophy
 


### PR DESCRIPTION
## Summary
- `comments` skill was not discoverable from `cpp-coding`'s scope pointers during coding
- Added reciprocal cross-reference pointers between `cpp-coding` and `comments` SKILL.md, matching the existing `doxygen` ↔ `comments` pattern

## Implementation
- `skills/cpp-coding/SKILL.md`: scope line now points "Inline/implementation comments" to `comments`
- `skills/comments/SKILL.md`: scope line now points "Implementation conventions (types, RAII, naming)" back to `cpp-coding`
- No change to `config/CLAUDE.md` auto-apply triggers — each skill's trigger condition stays narrow and non-overlapping per `AGENTS.md`'s no-overlap rule; this is a discoverability pointer within skill scope text only

## Test plan
- Manual read-through of both SKILL.md files: cross-references present, wording consistent with `doxygen`'s existing cross-ref style
- Confirmed `comment-check.js` PostToolUse hook remains a separate, non-redundant layer (runtime nudge on actual C++ comment edits, independent of skill auto-apply)

Closes #41