### PR TITLE
GH-43: Require --fixup=amend when the commit message must change

### DIFF
--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -118,9 +118,20 @@ Key is passed as two uint64_t values to avoid struct padding issues.
 When correcting an earlier commit on the same branch, use `--fixup` instead of a free-form commit:
 
 ```bash
-git commit --fixup=<hash>          # creates "fixup! <original subject>"
+git commit --fixup=<hash>          # code-only fix; target's message is left untouched
+git commit --fixup=amend:<hash>    # fix also changes what the message must say
+git commit --fixup=reword:<hash>   # message-only correction, no code change
 git rebase -i --autosquash <base>  # squashes fixups automatically before merge
 ```
+
+Plain `--fixup` never opens an editor: `rebase --autosquash` folds the code silently and
+keeps the target commit's original message exactly as it was, even when the fix makes
+that message no longer describe the code. Use `amend:` (or `reword:` for a message-only
+correction) whenever the fixup changes what the commit should say about itself — it
+opens the editor immediately, pre-filled with the target's message, and the edited
+result replaces the target's message during autosquash. `amend:`/`reword:` require
+git ≥ 2.32; on an older git, amend the target commit's message by hand after autosquash
+instead.
 
 Use `--fixup` when the change belongs to a specific earlier commit — reviewer sees the correction attached to its target, not floating. Use a normal commit only when the change is logically independent.
 
@@ -128,7 +139,13 @@ Use `--fixup` when the change belongs to a specific earlier commit — reviewer 
 
 Squash fixup commits before opening the PR — not at merge time.
 
-When squashing, rewrite the body to describe the actual final change — not the fixup history. The merged commit must read as if it was written that way from the start.
+Before running `rebase -i --autosquash`, check whether any fixup changes what its target
+commit's body claims. If so, that fixup must be `--fixup=amend:<hash>`, not plain
+`--fixup` — otherwise the merged commit keeps describing the pre-fix behaviour.
+
+After autosquash completes, re-read each final message (`git log -1 <hash>`) against the
+diff it now covers (`git show <hash>`) and amend anything that drifted. The merged
+commit must read as if it was written that way from the start.
 
 ## No Correction Commits Within a PR
 


### PR DESCRIPTION
## Summary
- `commit-rules`' fixup guidance said to "rewrite the body" when squashing, but the
  prescribed command sequence never opens an editor, so that instruction was
  unenforceable
- Documents `--fixup=amend:<hash>` / `--fixup=reword:<hash>` as the actual mechanism

## Implementation
- `skills/commit-rules/SKILL.md` Fixup Commits: adds `amend:`/`reword:` fixup forms,
  explains why plain `--fixup` silently keeps the target's stale message, notes the
  git ≥ 2.32 requirement and the manual-amend fallback for older git
- Fixup / Squash Merges: replaces the vague "rewrite the body" line with a concrete
  pre-check (use `amend:` when a fixup changes what the message claims) and a
  post-autosquash verification step (`git log -1 <hash>` vs `git show <hash>`)

## Test plan
- Manual read-through: section now names an actual command sequence a reviewer can
  follow instead of an unenforceable intent statement
- Reviewed via `/caveman-review`; two nits raised (missing git version requirement,
  ambiguous `git log`/`git show` pairing) and fixed

Closes #43