### PR TITLE
GH-45: Add review comment style rules and keyboard-reachable characters

### DIFF
--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -102,6 +102,73 @@ All three sections are required. A PR with no test plan is not ready to review.
 
 ---
 
+## Review Comments
+
+Applies to inline review comments and their replies — a different artifact from the
+Description above: shorter-lived, one point at a time.
+
+### Findings
+
+Order:
+1. **The fact** — what the code does, naming the exact symbol. Not an impression
+   ("this looks fragile") — the concrete behaviour.
+2. **The consequence** — the scenario where it breaks, or the invariant it violates.
+   Skip only when the fact alone is self-evidently wrong.
+3. **The fix** — a specific change, or a couple of named alternatives ("either X or
+   Y"). A finding with no proposed direction is not actionable.
+
+Prefix with a bold, lowercase, colon-terminated severity label — `**blocking:**`,
+`**must-fix:**`, `**question:**`, `**note:**`, or whatever label set the project's
+existing review threads already use. Omit the label only when every finding in the
+review is the same severity and there's nothing to disambiguate.
+
+```markdown
+**must-fix:** `hashBytes()` reads `key[0..15]` unconditionally; a key shorter than
+16 bytes is undefined behaviour, and nothing on the call path checks the length
+before this point.
+
+Any caller passing a key from configuration can trigger it silently on a truncated
+value. Validate the length where the key is constructed and return an error, rather
+than trusting every call site to check it first.
+```
+
+Address the code, not the author — state what the code does and what follows from it
+("the division by 2 encodes a fixed switch topology" — not "you hardcoded the
+topology"). Recommend rather than command, even for a blocking finding — "worth
+validating", "better to return an error here" — severity is carried by the label, not
+by imperative phrasing.
+
+### Replies
+
+Open with a verb naming the resolution: fixed / reworked / done / agreed / removed /
+replaced. State the result first, explanation after — then, in one to a few
+sentences, what changed (naming the actual symbol) and, when one exists, the test
+that now covers it.
+
+```markdown
+Fixed: `SipHashKey` now validates its length in the constructor and returns
+`InvalidKeyLength` for anything but 16 bytes; call sites no longer need to check it
+themselves. Covered by `key_shorter_than_16_bytes_is_rejected`.
+```
+
+When disagreeing or clarifying instead of agreeing, give the actual reasoning
+specifically enough that the reviewer can check it — never dismiss a finding without
+an explanation. When the fix belongs to a separate task, say so and name it, or offer
+to file one; don't let a valid finding go unaddressed just because it's out of scope
+for this PR.
+
+### Register
+
+Full sentences, exact identifiers in backticks, no filler or hedging, no slang or
+unnecessary borrowed words — `writing-style` covers these general prose rules for
+every artifact, review comments included. Recommend-not-command and address-the-code
+tone (above) are specific to review feedback and live only in this section, not in
+`writing-style`. Use whichever severity-label vocabulary and language the project's
+existing review threads already use (`AGENTS.md` / project convention wins, per
+Project Overrides above).
+
+---
+
 ## Pre-Open Checklist
 
 - [ ] CI green on all targets declared in the project

--- a/skills/writing-style/SKILL.md
+++ b/skills/writing-style/SKILL.md
@@ -67,6 +67,32 @@ established technical vocabulary rather than reaching for a borrowed shortcut. T
 applies equally to documentation, issue/PR bodies, commit message bodies, review
 comments and replies, and conversational responses.
 
+## Prefer Keyboard-Reachable Characters
+
+Typographic dashes, arrows, ellipses, and curly quotes are one of the tells that mark
+prose as machine-generated, and they are harder to type correctly than the plain
+character every keyboard produces directly. Use the plain form:
+
+| Avoid | Prefer |
+|---|---|
+| — em dash | `-` hyphen, or split the sentence at that point instead |
+| – en dash in a range | `-` hyphen: `1-5`, not `1–5` |
+| → | `->` |
+| … | `...` |
+| “ ” ‘ ’ curly quotes | `"` `"` `'` `'` straight quotes |
+
+Applies regardless of language, to text written for a human reader — documentation,
+issue/PR/commit text, review comments, conversational responses. Does not apply to
+agent-facing instruction files (`skills/`, `agents/`, `commands/`, `hooks/`, `AGENTS.md`) —
+those keep the em dash / arrow convention already established across that corpus, since
+nobody is being asked to type it back and the structural notation (`X → Y skill`) is
+more scannable than the ASCII form.
+
+Exception, regardless of audience: leave a quotation, a code identifier, or a character
+the target language's own orthography requires (e.g. `«` `»` in French) exactly as it
+appears in the source — this governs characters chosen when writing new prose, not
+characters copied from elsewhere.
+
 ## What This Does Not Cover
 
 - Code identifiers, API names, and their required language (see project `AGENTS.md`) —
@@ -74,6 +100,9 @@ comments and replies, and conversational responses.
 - A loanword that is itself the field's standard, dictionary/glossary-recognized term
   in that language (there is no requirement to invent an awkward native neologism where
   none is actually used in professional writing).
+- Keyboard-reachable-character preference on agent-facing instruction files (`skills/`,
+  `agents/`, `commands/`, `hooks/`, `AGENTS.md`) — see Prefer Keyboard-Reachable
+  Characters above for that carve-out.
 
 ## Self-Check Before Sending
 
@@ -81,3 +110,7 @@ Re-read non-English prose before sending it and flag any word that is a direct p
 transliteration of an English verb or slang term used only in spoken/informal
 developer jargon. Replace it with the native phrase, or with the properly assimilated
 term if one already exists — see the table above for the pattern to apply.
+
+In human-facing text, re-read every language's prose, including English, for a
+dash/arrow/quote character a plain keyboard cannot produce directly, and replace it
+per the table above.

--- a/skills/writing-style/SKILL.md
+++ b/skills/writing-style/SKILL.md
@@ -20,7 +20,7 @@ written in, not its shape:
 - Code comment structure and when to write one → `comments` skill.
 - Public API documentation structure → `doxygen` skill.
 - Issue title/description structure → `issue-rules` skill.
-- PR title/description structure → `pr-rules` skill.
+- PR title/description structure, review comment/reply structure → `pr-rules` skill.
 - Commit message structure → `commit-rules` skill.
 
 ## Project Overrides
@@ -64,8 +64,8 @@ same defect, just facing the other way.
 
 The rule is symmetric: whichever language is being written, use that language's own
 established technical vocabulary rather than reaching for a borrowed shortcut. This
-applies equally to documentation, issue/PR bodies, commit message bodies, and
-conversational responses.
+applies equally to documentation, issue/PR bodies, commit message bodies, review
+comments and replies, and conversational responses.
 
 ## What This Does Not Cover
 


### PR DESCRIPTION
## Summary
- No skill governed the register/shape of inline PR review comments and replies
- Added a `pr-rules` "Review Comments" section: findings as fact/consequence/fix with
  a bold severity label, replies as resolution-verb-first with detail and covering test
- While drafting example findings/replies, noticed em dashes and arrows read as
  machine-generated and are harder to type back in a real review thread — added a
  related `writing-style` rule preferring keyboard-reachable characters

## Implementation
- `skills/pr-rules/SKILL.md`: new "Review Comments" section (Findings / Replies /
  Register); Register subsection states precisely which rules it inherits from
  `writing-style` versus which stay local to review feedback (recommend-not-command,
  address-the-code)
- `skills/writing-style/SKILL.md`:
  - artifact-pointer list and language-enumeration now name review comments/replies
  - new "Prefer Keyboard-Reachable Characters" section (hyphen for em/en dash, `->`
    for `→`, straight quotes) for human-facing text — documentation, issue/PR/commit
    text, review comments, conversational responses
  - explicitly excludes agent-facing instruction files (`skills/`, `agents/`,
    `commands/`, `hooks/`, `AGENTS.md`), which keep the existing em dash/arrow
    convention already used throughout that corpus
  - "What This Does Not Cover" and Self-Check sections updated to match

## Test plan
- Manual read-through against real review comments (reference: a prior PR the
  requester authored) confirming the documented finding/reply pattern
- Reviewed via `/caveman-review` across three passes; findings fixed each round
  (message-drift wording, git-version requirement, curly-quote table glyphs,
  agent-facing carve-out visibility)

Closes #45