### PR TITLE
GH-49: Guard gh commands that publish review comments on the spot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `templates/AGENT.md` and `templates/COMMAND.md` for consistent agent/command authoring, matching `templates/SKILL.md`'s role for skills
 - `AGENTS.md`: "Idea-to-Release Pipeline" section describing the `/spec` → `/build` → `/ship` flow and when to invoke a persona agent directly instead of via its command
 - `comment-check` tool: `PostToolUse` reminder when an edit adds a new non-Doxygen comment to a C++ file, pointing back at the `comments` skill — runs unconditionally, unlike the lint tools which require a project config file
+- `review-publish-guard` tool: `PreToolUse` `permissionDecision: ask` before a `gh` command that publishes review feedback the moment it runs — `gh pr review --comment/--approve/--request-changes`, `gh pr comment`, `POST /pulls/{n}/comments` with `in_reply_to`, an `event` field on `POST /pulls/{n}/reviews`, `submitPullRequestReview`, and `addPullRequestReviewThreadReply` without a `pullRequestReviewId`, which belongs to no pending review and therefore publishes. The prompt names the pending-review alternative, and the pending path itself (`addPullRequestReview` with no `event`, `addPullRequestReviewThread`, a reply carrying the review id, `deletePullRequestReview`, `gh api graphql --input`) runs unprompted. Rules read a command as argv rather than as text: each rule anchors to the command word, so a commit message or progress note naming a blocked command does not prompt, and a quoted body arrives as one token, so a delimiter or a flag quoted inside it neither splits the call apart nor changes how it parses. Enforces `pr-rules` → Pending by Default, which until now held only while the agent remembered it
 
 ### Changed
 
@@ -52,6 +53,7 @@
 - `pr-rules` skill: Merge Strategy states that the human authorises each merge, matching the rule that review feedback already follows
 - `code-reviewer` agent: states an approving verdict in its report instead of approving the PR, and points at `pr-rules` → Pending by Default for how findings reach the PR
 - `AGENTS.md` "Adding a skill": states that `install.js` copies only `skills/<name>/SKILL.md`, so a skill stays one file until that copy loop changes
+- `PreToolUse` dispatcher now emits one permission decision per run: the strictest of the decisions returned (`deny` over `ask` over `allow`), carrying every reason behind it and any warning printed alongside. Two tools deciding on one command (`git push && gh pr comment ...`) used to write two JSON objects onto one stdout, which parses as neither, so the decision could be lost together with the prompt it was raised for; the reason is also all the user reads before answering, and one tool's reason alone misstates what is about to run
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pipeline of persona agents and commands built on top of them.
 **`PreToolUse`** — runs before every tool call:
 - `bash-safety.js` — blocks destructive shell commands (`rm -rf /`, `format C:`), warns on reversible-but-risky ones (`git reset --hard`, `DROP TABLE`)
 - `commit-trailer-guard.js` — blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
+- `review-publish-guard.js` — prompts for confirmation before a `gh` command that publishes review feedback on the spot (`gh pr review --comment/--approve/--request-changes`, `gh pr comment`, REST `in_reply_to`, an `event` field on `POST /pulls/{n}/reviews`, `submitPullRequestReview`, and a thread reply carrying no `pullRequestReviewId`); the pending-review path stays unprompted
 - `secret-guard.js` — blocks writes (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) containing private keys, AWS keys, GitHub PATs; warns on probable credentials
 
 **`PostToolUse`** — runs after `Edit` / `Write` / `MultiEdit` / `NotebookEdit` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`):

--- a/hooks/PreToolUse.js
+++ b/hooks/PreToolUse.js
@@ -8,12 +8,31 @@ const toolsDir = path.join(configDir, 'tools');
 
 const DISPATCH = {
   Agent:        ['bg-agent-counter.js'],
-  Bash:         ['bash-safety.js', 'commit-trailer-guard.js'],
+  Bash:         ['bash-safety.js', 'commit-trailer-guard.js', 'review-publish-guard.js'],
   Edit:         ['secret-guard.js'],
   Write:        ['secret-guard.js'],
   MultiEdit:    ['secret-guard.js'],
   NotebookEdit: ['secret-guard.js'],
 };
+
+// Claude Code reads this hook's stdout as a single JSON document when a tool decides
+// on a permission. Several tools can decide on one command, so a run keeps the
+// strictest decision and every reason behind it, plain-text warnings included: the
+// reason is all the user reads before answering.
+const RANK = { allow: 0, ask: 1, deny: 2 };
+
+function toDecision(out) {
+  try {
+    const parsed = JSON.parse(out);
+    return parsed.hookSpecificOutput?.permissionDecision ? parsed : null;
+  } catch { return null; }
+}
+
+function strictest(decisions) {
+  return decisions.reduce((a, b) =>
+    (RANK[b.hookSpecificOutput.permissionDecision] ?? 0) >
+    (RANK[a.hookSpecificOutput.permissionDecision] ?? 0) ? b : a);
+}
 
 let raw = '';
 process.stdin.setEncoding('utf8');
@@ -25,13 +44,34 @@ process.stdin.on('end', () => {
   const tools = DISPATCH[data.tool_name] ?? [];
   if (!tools.length) process.exit(0);
 
+  const notes = [];
+  const decisions = [];
+
   for (const tool of tools) {
     const r = spawnSync('node', [path.join(toolsDir, tool)], {
       input: raw, encoding: 'utf8', stdio: 'pipe', timeout: 30000,
     });
-    if (r.stdout?.trim()) process.stdout.write(r.stdout);
     if (r.stderr?.trim()) process.stderr.write(r.stderr);
-    if (r.status === 2) process.exit(2);
+    if (r.status === 2) {
+      if (notes.length) process.stdout.write(notes.join('\n'));
+      process.exit(2);
+    }
+    const out = r.stdout?.trim() ?? '';
+    if (!out) continue;
+    const decision = toDecision(out);
+    if (decision) decisions.push(decision);
+    else notes.push(out);
+  }
+
+  if (decisions.length) {
+    const decision = strictest(decisions);
+    decision.hookSpecificOutput.permissionDecisionReason = [
+      ...notes,
+      ...decisions.map(d => d.hookSpecificOutput.permissionDecisionReason),
+    ].join('\n');
+    process.stdout.write(JSON.stringify(decision));
+  } else if (notes.length) {
+    process.stdout.write(notes.join('\n'));
   }
   process.exit(0);
 });

--- a/test/PreToolUse.test.js
+++ b/test/PreToolUse.test.js
@@ -1,0 +1,113 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const repoDir = path.join(__dirname, '..');
+const HOOK = path.join(repoDir, 'hooks', 'PreToolUse.js');
+
+function run(command, configDir = repoDir) {
+  return spawnSync('node', [HOOK], {
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command } }),
+    env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+    encoding: 'utf8',
+  });
+}
+
+// The Bash tools the dispatcher spawns, replaced by fixtures that decide on command.
+const BASH_TOOLS = ['bash-safety.js', 'commit-trailer-guard.js', 'review-publish-guard.js'];
+
+function deciding(decision) {
+  return decision
+    ? `'use strict';process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PreToolUse',permissionDecision:'${decision}',permissionDecisionReason:'${decision} fixture'}}));`
+    : "'use strict';";
+}
+
+function mkConfig(decisions) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-config-test-'));
+  fs.mkdirSync(path.join(dir, 'tools'));
+  BASH_TOOLS.forEach((tool, i) => {
+    fs.writeFileSync(path.join(dir, 'tools', tool), deciding(decisions[i]));
+  });
+  return dir;
+}
+
+function rmConfig(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+test('emits one permission decision when two guards fire on one command', () => {
+  const r = run('git push && gh pr comment 49 -b x');
+  assert.strictEqual(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'ask');
+});
+
+test('keeps every reason when two guards decide on one command', () => {
+  const r = run('git push && gh pr comment 49 -b x');
+  const reason = JSON.parse(r.stdout).hookSpecificOutput.permissionDecisionReason;
+  assert.match(reason, /git push/);
+  assert.match(reason, /gh pr comment/);
+});
+
+test('keeps an earlier warning in the reason of the decision that follows it', () => {
+  const r = run('rm -r build && gh pr comment 49 -b x');
+  assert.strictEqual(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'ask');
+  assert.match(out.hookSpecificOutput.permissionDecisionReason, /rm -r/);
+  assert.match(out.hookSpecificOutput.permissionDecisionReason, /gh pr comment/);
+});
+
+test('passes plain warning text through when no tool decides', () => {
+  const r = run('rm -r build');
+  assert.strictEqual(r.status, 0);
+  assert.match(r.stdout, /rm -r/);
+  assert.throws(() => JSON.parse(r.stdout));
+});
+
+test('exits 2 on a blocked command', () => {
+  const r = run('rm -rf /');
+  assert.strictEqual(r.status, 2);
+  assert.match(r.stderr, /Blocked/);
+});
+
+test('stays silent on a command no tool objects to', () => {
+  const r = run('gh pr view 49');
+  assert.strictEqual(r.status, 0);
+  assert.strictEqual(r.stdout, '');
+});
+
+test('keeps deny when a later tool denies what an earlier one only asked about', () => {
+  const dir = mkConfig(['ask', 'deny', null]);
+  try {
+    const out = JSON.parse(run('anything', dir).stdout);
+    assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'deny');
+    assert.match(out.hookSpecificOutput.permissionDecisionReason, /ask fixture/);
+    assert.match(out.hookSpecificOutput.permissionDecisionReason, /deny fixture/);
+  } finally { rmConfig(dir); }
+});
+
+test('keeps deny when an earlier tool denies and a later one asks', () => {
+  const dir = mkConfig(['deny', 'ask', null]);
+  try {
+    const out = JSON.parse(run('anything', dir).stdout);
+    assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'deny');
+  } finally { rmConfig(dir); }
+});
+
+test('keeps ask over allow', () => {
+  const dir = mkConfig(['allow', 'ask', null]);
+  try {
+    const out = JSON.parse(run('anything', dir).stdout);
+    assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'ask');
+  } finally { rmConfig(dir); }
+});
+
+test('exits 0 on malformed stdin JSON', () => {
+  const r = spawnSync('node', [HOOK], { input: 'not json', encoding: 'utf8' });
+  assert.strictEqual(r.status, 0);
+});

--- a/test/review-publish-guard.test.js
+++ b/test/review-publish-guard.test.js
@@ -1,0 +1,294 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const { check } = require('../tools/review-publish-guard');
+
+const TOOL = path.join(__dirname, '..', 'tools', 'review-publish-guard.js');
+
+test('asks before gh pr review --comment', () => {
+  assert.strictEqual(check('gh pr review 49 --comment --body "looks good"').action, 'ask');
+});
+
+test('asks before gh pr review --approve', () => {
+  assert.strictEqual(check('gh pr review 49 --approve').action, 'ask');
+});
+
+test('asks before gh pr review --request-changes', () => {
+  assert.strictEqual(check('gh pr review 49 --request-changes --body "fix this"').action, 'ask');
+});
+
+test('asks before gh pr review -c short flag', () => {
+  assert.strictEqual(check('gh pr review 49 -c -b "looks good"').action, 'ask');
+});
+
+test('asks before gh pr review -a short flag', () => {
+  assert.strictEqual(check('gh pr review 49 -a').action, 'ask');
+});
+
+test('asks before gh pr review after a chain operator', () => {
+  assert.strictEqual(check('git status && gh pr review 49 --approve').action, 'ask');
+});
+
+test('asks before gh pr comment', () => {
+  assert.strictEqual(check('gh pr comment 49 --body "one finding left"').action, 'ask');
+});
+
+test('asks before gh pr comment carrying a help flag inside its body', () => {
+  assert.strictEqual(
+    check('gh pr comment 49 -b "see gh pr review -h for the flag list"').action,
+    'ask'
+  );
+});
+
+test('asks before a thread reply with no pullRequestReviewId', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='mutation($thread:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$thread,body:$body}){comment{id}}}' -f thread=T_1 -f body='reply'").action,
+    'ask'
+  );
+});
+
+test('names the pending alternative in the gh pr review prompt', () => {
+  assert.match(check('gh pr review 49 --approve').msg, /addPullRequestReview/);
+});
+
+test('attributes a reply with no review id to the unattached reply rule', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='mutation{addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}'").name,
+    'unattached reply'
+  );
+});
+
+test('still splits a real command chain into segments', () => {
+  assert.strictEqual(check('gh pr view 49 && git status').action, 'pass');
+  assert.strictEqual(check('git status && gh pr comment 49 -b x').action, 'ask');
+});
+
+test('asks before a REST reply with in_reply_to and an explicit POST', () => {
+  assert.strictEqual(
+    check('gh api -X POST repos/o/r/pulls/49/comments -F in_reply_to=1 -f body=x').action,
+    'ask'
+  );
+});
+
+test('asks before a REST reply with in_reply_to and an implicit POST', () => {
+  assert.strictEqual(
+    check('gh api repos/o/r/pulls/49/comments -F in_reply_to=1 -f body=x').action,
+    'ask'
+  );
+});
+
+test('asks before a REST review carrying an event field', () => {
+  assert.strictEqual(
+    check("gh api -X POST repos/o/r/pulls/49/reviews -f event=APPROVE -f body='ok'").action,
+    'ask'
+  );
+});
+
+test('asks before a REST submit of a pending review', () => {
+  assert.strictEqual(
+    check('gh api -X POST repos/o/r/pulls/49/reviews/12/events -f event=COMMENT').action,
+    'ask'
+  );
+});
+
+test('asks before a REST reply whose body holds a semicolon', () => {
+  assert.strictEqual(
+    check("gh api -X POST repos/o/r/pulls/49/comments -f body='use -f; then rerun' -F in_reply_to=1").action,
+    'ask'
+  );
+});
+
+test('asks before a REST reply whose body holds a chain operator', () => {
+  assert.strictEqual(
+    check("gh api -X POST repos/o/r/pulls/49/comments -f body='build && test' -F in_reply_to=1").action,
+    'ask'
+  );
+});
+
+test('asks before a REST review event whose body holds a semicolon', () => {
+  assert.strictEqual(
+    check("gh api -X POST repos/o/r/pulls/49/reviews -f body='x; y' -f event=APPROVE").action,
+    'ask'
+  );
+});
+
+test('asks before a REST reply whose body quotes a method flag', () => {
+  assert.strictEqual(
+    check("gh api repos/o/r/pulls/49/comments -F in_reply_to=1 -f body='run gh api -X GET first'").action,
+    'ask'
+  );
+});
+
+test('asks before a REST review event whose body quotes a method flag', () => {
+  assert.strictEqual(
+    check("gh api repos/o/r/pulls/49/reviews -f event=APPROVE -f body='was --method GET'").action,
+    'ask'
+  );
+});
+
+test('asks before gh pr comment behind an environment assignment', () => {
+  assert.strictEqual(check('GH_TOKEN=x gh pr comment 49 -b x').action, 'ask');
+});
+
+test('asks before gh pr comment behind the command builtin', () => {
+  assert.strictEqual(check('command gh pr comment 49 -b x').action, 'ask');
+});
+
+test('asks before gh pr comment inside a command substitution', () => {
+  assert.strictEqual(check('out=$(gh pr comment 49 -b x)').action, 'ask');
+});
+
+test('asks before gh pr comment inside a subshell', () => {
+  assert.strictEqual(check('(cd repo && gh pr comment 49 -b x)').action, 'ask');
+});
+
+test('does not prompt on a commit message naming a command in parentheses', () => {
+  assert.strictEqual(check('git commit -m "run (gh pr comment) later"').action, 'pass');
+});
+
+test('asks before a field written in the attached form', () => {
+  assert.strictEqual(
+    check('gh api -X POST repos/o/r/pulls/49/comments -Fin_reply_to=1 -fbody=x').action,
+    'ask'
+  );
+});
+
+test('passes gh pr review whose body quotes an event flag', () => {
+  assert.strictEqual(check('gh pr review 49 -b "--approve"').action, 'pass');
+});
+
+test('asks before the submitPullRequestReview mutation', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='mutation($rev:ID!){submitPullRequestReview(input:{pullRequestReviewId:$rev,event:COMMENT}){clientMutationId}}' -f rev=R_1").action,
+    'ask'
+  );
+});
+
+test('passes addPullRequestReview with no event field', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='mutation($pr:ID!,$body:String!){addPullRequestReview(input:{pullRequestId:$pr,body:$body}){pullRequestReview{id state}}}' -f pr=PR_1 -f body='overall'").action,
+    'pass'
+  );
+});
+
+test('passes addPullRequestReviewThread', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='mutation($rev:ID!,$path:String!,$line:Int!,$body:String!){addPullRequestReviewThread(input:{pullRequestReviewId:$rev,path:$path,line:$line,side:RIGHT,body:$body}){thread{id}}}' -f rev=R_1 -f path=tools/x.js -F line=3 -f body='finding'").action,
+    'pass'
+  );
+});
+
+test('passes addPullRequestReviewThreadReply', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='mutation($rev:ID!,$thread:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewId:$rev,pullRequestReviewThreadId:$thread,body:$body}){comment{id}}}' -f rev=R_1 -f thread=T_1 -f body='reply'").action,
+    'pass'
+  );
+});
+
+test('passes deletePullRequestReview', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='mutation($rev:ID!){deletePullRequestReview(input:{pullRequestReviewId:$rev}){pullRequestReview{state}}}' -f rev=R_1").action,
+    'pass'
+  );
+});
+
+test('passes gh api graphql --input', () => {
+  assert.strictEqual(check('gh api graphql --input review.json').action, 'pass');
+});
+
+test('passes the reviewThreads lookup query', () => {
+  assert.strictEqual(
+    check("gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){id reviews(last:10,states:PENDING){nodes{id}}}}}' -f o=ssoft-hub -f r=ai -F n=49").action,
+    'pass'
+  );
+});
+
+test('passes a REST review without an event field', () => {
+  assert.strictEqual(
+    check("gh api -X POST repos/o/r/pulls/49/reviews -f body='overall comment'").action,
+    'pass'
+  );
+});
+
+test('passes a GET of the review comments', () => {
+  assert.strictEqual(
+    check("gh api repos/o/r/pulls/49/comments --jq '.[].in_reply_to'").action,
+    'pass'
+  );
+});
+
+test('passes gh pr review --help', () => {
+  assert.strictEqual(check('gh pr review --help').action, 'pass');
+});
+
+test('passes gh pr comment --help', () => {
+  assert.strictEqual(check('gh pr comment --help').action, 'pass');
+});
+
+test('passes gh pr review with only -R and -b, which carry no event', () => {
+  assert.strictEqual(check('gh pr review 49 -R ssoft-hub/ai -b "draft"').action, 'pass');
+});
+
+test('passes gh pr view', () => {
+  assert.strictEqual(check('gh pr view 49 --json title,body').action, 'pass');
+});
+
+test('passes gh pr diff', () => {
+  assert.strictEqual(check('gh pr diff 49').action, 'pass');
+});
+
+test('passes gh issue comment', () => {
+  assert.strictEqual(check('gh issue comment 49 --body "PR #50 resolves this"').action, 'pass');
+});
+
+test('passes git status', () => {
+  assert.strictEqual(check('git status').action, 'pass');
+});
+
+test('does not prompt on a commit message naming the banned commands', () => {
+  assert.strictEqual(
+    check('git commit -m "guard gh pr comment and gh pr review --approve"').action,
+    'pass'
+  );
+});
+
+test('does not prompt on a commit message naming a publishing mutation', () => {
+  assert.strictEqual(check('git commit -m "ask on submitPullRequestReview"').action, 'pass');
+});
+
+test('does not prompt on a progress note quoting what the guard blocks', () => {
+  assert.strictEqual(
+    check('gh issue comment 49 -b "PR #50 blocks gh pr comment"').action,
+    'pass'
+  );
+});
+
+test('does not prompt on an echo of a documentation line', () => {
+  assert.strictEqual(check('echo "use gh pr comment for progress notes"').action, 'pass');
+});
+
+test('emits a PreToolUse ask decision for gh pr review --approve', () => {
+  const r = spawnSync('node', [TOOL], {
+    input: JSON.stringify({ tool_input: { command: 'gh pr review 49 --approve' } }),
+    encoding: 'utf8',
+  });
+  assert.strictEqual(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'ask');
+});
+
+test('exits 0 without output on a passing command', () => {
+  const r = spawnSync('node', [TOOL], {
+    input: JSON.stringify({ tool_input: { command: 'gh pr view 49' } }),
+    encoding: 'utf8',
+  });
+  assert.strictEqual(r.status, 0);
+  assert.strictEqual(r.stdout, '');
+});
+
+test('exits 0 on malformed stdin JSON', () => {
+  const r = spawnSync('node', [TOOL], { input: 'not json', encoding: 'utf8' });
+  assert.strictEqual(r.status, 0);
+});

--- a/tools/review-publish-guard.js
+++ b/tools/review-publish-guard.js
@@ -1,0 +1,197 @@
+'use strict';
+
+const VALUE_FLAGS = [
+  '-f', '-F', '--field', '--raw-field', '--input',
+  '-X', '--method', '-b', '--body', '--body-file',
+  '-q', '--jq', '-H', '--header', '-R', '--repo', '--template',
+];
+const SHORT_VALUE_FLAGS = ['-f', '-F', '-X', '-b', '-q', '-H', '-R'];
+const FIELD_FLAGS = ['-f', '-F', '--field', '--raw-field'];
+const WRAPPERS = new Set(['command', 'sudo', 'env', 'nohup', 'time']);
+
+// gh flags are case-sensitive: -R (--repo) must not read as -r (--request-changes).
+const REVIEW_EVENT = /^-(?:-(?:comment|approve|request-changes)|[abcrFR]*[acr][abcrFR]*)$/;
+const REPLY_PATH = /(?:^|\/)pulls\/[^/]+\/comments\b/;
+const REVIEW_PATH = /(?:^|\/)pulls\/[^/]+\/reviews\b/;
+
+const DELIMITERS = new Set([';', '&', '|', '\n', '(', ')', '`']);
+
+// A quoted body holds prose, so it starts no command and supplies no flag. One pass
+// splits on unquoted delimiters and strips the quotes, leaving each command an argv
+// whose body is a single token no rule looks inside. A substitution or a subshell
+// starts a command too, so its parentheses and backticks delimit as well.
+function commands(cmd) {
+  const found = [];
+  let argv = [];
+  let token = '';
+  let started = false;
+  let quote = null;
+
+  const endToken = () => { if (started) { argv.push(token); token = ''; started = false; } };
+  const endCommand = () => { endToken(); if (argv.length) found.push(argv); argv = []; };
+
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i];
+    if (quote) {
+      if (c === '\\' && quote === '"' && i + 1 < cmd.length) token += cmd[++i];
+      else if (c === quote) quote = null;
+      else token += c;
+      started = true;
+    } else if (c === "'" || c === '"') {
+      quote = c;
+      started = true;
+    } else if (c === '\\' && i + 1 < cmd.length) {
+      token += cmd[++i];
+      started = true;
+    } else if (DELIMITERS.has(c)) {
+      endCommand();
+    } else if (c === ' ' || c === '\t') {
+      endToken();
+    } else {
+      token += c;
+      started = true;
+    }
+  }
+  endCommand();
+  return found;
+}
+
+// Options are the tokens in flag position, values the tokens their flags consume, so
+// `-f body=...` never reaches the option list and its prose never reaches a flag test.
+function parse(argv) {
+  let start = 0;
+  while (start < argv.length
+    && (/^[A-Za-z_]\w*=/.test(argv[start]) || WRAPPERS.has(argv[start]))) start++;
+
+  const words = argv.slice(start);
+  const options = [];
+  const values = [];
+
+  for (let i = 0; i < words.length; i++) {
+    const t = words[i];
+    options.push(t);
+    const eq = t.indexOf('=');
+    const attached = SHORT_VALUE_FLAGS.find(f => t.startsWith(f) && t.length > f.length);
+    if (VALUE_FLAGS.includes(t)) {
+      values.push([t, words[i + 1] ?? '']);
+      i++;
+    } else if (eq > 0 && VALUE_FLAGS.includes(t.slice(0, eq))) {
+      values.push([t.slice(0, eq), t.slice(eq + 1)]);
+    } else if (attached) {
+      values.push([attached, t.slice(attached.length)]);
+    }
+  }
+  return { words, options, values };
+}
+
+function isGh(ctx, ...sub) {
+  return ctx.words[0] === 'gh' && sub.every((word, i) => ctx.words[i + 1] === word);
+}
+
+function fieldValue(ctx, name) {
+  const prefix = `${name}=`;
+  const hit = ctx.values.find(([flag, v]) => FIELD_FLAGS.includes(flag) && v.startsWith(prefix));
+  return hit ? hit[1].slice(prefix.length) : null;
+}
+
+// gh api sends GET unless a method is given or the call carries fields.
+function isPost(ctx) {
+  const method = ctx.values.find(([flag]) => flag === '-X' || flag === '--method');
+  if (method) return method[1].toUpperCase() === 'POST';
+  return ctx.values.some(([flag]) => FIELD_FLAGS.includes(flag) || flag === '--input');
+}
+
+function query(ctx) {
+  return fieldValue(ctx, 'query') ?? '';
+}
+
+const ASK = [
+  {
+    // A bare gh pr review publishes too, but only from a terminal: without an event
+    // flag gh refuses to run non-interactively, which is how a hooked command runs.
+    name: 'gh pr review',
+    test: ctx => isGh(ctx, 'pr', 'review') && ctx.options.some(t => REVIEW_EVENT.test(t)),
+    msg: 'gh pr review --comment/--approve/--request-changes submits the review on the spot. '
+      + 'Leave the feedback in a pending review instead: addPullRequestReview with no event '
+      + 'field, then addPullRequestReviewThread per finding, and a human submits it. '
+      + 'See pr-rules, Pending by Default.',
+  },
+  {
+    name: 'gh pr comment',
+    test: ctx => isGh(ctx, 'pr', 'comment')
+      && ctx.words[3] !== '--help' && ctx.words[3] !== '-h',
+    msg: 'gh pr comment publishes on the spot and notifies every watcher. Review feedback '
+      + 'belongs in the body of a pending addPullRequestReview instead. Progress notes belong '
+      + 'on the issue, which gh issue comment reaches without this prompt. '
+      + 'See pr-rules, Pending by Default.',
+  },
+  {
+    name: 'REST reply',
+    test: ctx => isGh(ctx, 'api') && ctx.options.some(t => REPLY_PATH.test(t))
+      && fieldValue(ctx, 'in_reply_to') !== null && isPost(ctx),
+    msg: 'POST /pulls/{n}/comments with in_reply_to has no pending form and publishes the '
+      + 'reply. Use addPullRequestReviewThreadReply with the pullRequestReviewId of a pending '
+      + 'review instead. See pr-rules, Pending by Default.',
+  },
+  {
+    name: 'REST review event',
+    test: ctx => isGh(ctx, 'api') && ctx.options.some(t => REVIEW_PATH.test(t))
+      && fieldValue(ctx, 'event') !== null && isPost(ctx),
+    msg: 'An event field on POST /pulls/{n}/reviews submits the review. Drop the field to '
+      + 'leave the review PENDING for a human to submit. See pr-rules, Pending by Default.',
+  },
+  {
+    name: 'submitPullRequestReview',
+    test: ctx => isGh(ctx, 'api') && query(ctx).includes('submitPullRequestReview'),
+    msg: 'submitPullRequestReview publishes the pending review. A human submits it, so leave '
+      + 'the review pending and report where it is. See pr-rules, Pending by Default.',
+  },
+  {
+    name: 'unattached reply',
+    test: ctx => {
+      const q = query(ctx);
+      return isGh(ctx, 'api') && q.includes('addPullRequestReviewThreadReply')
+        && !q.includes('pullRequestReviewId');
+    },
+    msg: 'addPullRequestReviewThreadReply without pullRequestReviewId belongs to no pending '
+      + 'review, so it publishes. Pass the id of a pending review. '
+      + 'See pr-rules, Pending by Default.',
+  },
+];
+
+function check(cmd) {
+  for (const argv of commands(cmd)) {
+    const ctx = parse(argv);
+    for (const rule of ASK) {
+      if (rule.test(ctx)) return { action: 'ask', name: rule.name, msg: rule.msg };
+    }
+  }
+  return { action: 'pass' };
+}
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+
+    const cmd = data.tool_input?.command ?? '';
+    if (!cmd) process.exit(0);
+
+    const r = check(cmd);
+    if (r.action === 'ask') {
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          permissionDecisionReason: r.msg,
+        },
+      }));
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { ASK, check, commands, parse };


### PR DESCRIPTION
## Problem

`pr-rules` -> Pending by Default requires agent-written review feedback to wait in a
pending review that a human submits. The rule is prose only: `gh pr review
--comment/--approve/--request-changes`, `gh pr comment` and REST `POST
/pulls/{n}/comments` with `in_reply_to` stay callable and publish the moment they run.
A published review comment notifies the author and every watcher, and editing it
afterwards does not unsend that, so until now the rule held only while the agent
remembered it. Resolves GH-49.

## Summary

- A `gh` command that publishes review feedback now raises a permission prompt instead
  of running, and the prompt names the pending-review alternative.
- The sanctioned pending path is untouched and runs without a prompt, as do
  `gh issue comment` progress notes and every read-only `gh` call.
- Naming a blocked command in a commit message or a progress note does not prompt.
- A `PreToolUse` run now produces one permission decision carrying every reason behind
  it, instead of one JSON document per deciding tool.

## Implementation

`tools/review-publish-guard.js` returns `permissionDecision: ask`, which holds even
under `bypassPermissions` where a settings `ask` entry would not. Six rules:

| Asks | Passes |
|---|---|
| `gh pr review` with `--comment`/`--approve`/`--request-changes` (and the `-c`/`-a`/`-r` shorthands) | `gh pr review --help`, `gh pr view`, `gh pr diff` |
| `gh pr comment` | `gh issue comment`, `gh pr comment --help` |
| `gh api` POST `pulls/{n}/comments` with `in_reply_to` | a GET of the same path |
| an `event` field on POST `pulls/{n}/reviews[/{id}/events]` | `POST /pulls/{n}/reviews` without `event` |
| `submitPullRequestReview` | `addPullRequestReview`, `addPullRequestReviewThread`, `deletePullRequestReview`, `gh api graphql --input` |
| `addPullRequestReviewThreadReply` with no `pullRequestReviewId` | the same reply carrying the review id |

The last three rows go beyond the wording of the issue. The `event` field on `POST
/pulls/{n}/reviews` is implied by its own acceptance criterion, which excludes that
call only "without an `event` field". `submitPullRequestReview` is the same act as `gh
pr review --approve` expressed over GraphQL, so leaving it out would make the guard
bypassable in the very API the skill points the agent at. A reply with no
`pullRequestReviewId` belongs to no pending review and therefore publishes, which is
trap 4 in `pr-rules` -> Pending by Default.

A command is read as argv rather than as text. One quote-aware pass cuts the line at
unquoted delimiters, command substitutions and subshells included, strips the quotes,
and hands each rule the command word, the options, and the values their flags consume.
This is what keeps prose out of the matching: a comment body arrives as a single token,
so the semicolons, chain operators and `gh` flags it quotes reach no rule, and
anchoring to the command word leaves a commit message that names a blocked command
alone. Regex over the raw command string could not hold both ends of that -- it either
split a call apart on a quoted `;` or prompted on a quoted mention.

`hooks/PreToolUse.js` needed a change to carry this: it now emits the strictest single
decision (`deny` over `ask` over `allow`) and joins every reason behind it. Two tools
deciding on one command used to write two JSON objects onto one stdout, which parses as
neither, and the reason is all the user reads before answering -- one tool's reason
alone misstates what is about to run.

Not covered, and stated rather than hidden: a body passed via `--input <file>` is
opaque to any command-line matcher, and the GitLab side stays out of scope per the
issue.

## Test plan

- [x] `npm test` -- 218 pass, 0 fail (51 in `test/review-publish-guard.test.js`, 9 in
      `test/PreToolUse.test.js`)
- [x] Each banned form asks and each pending form passes, including the near misses:
      `gh pr review --help`, `gh pr view`, `gh issue comment`, `POST /pulls/{n}/reviews`
      without `event`
- [x] Prose is not matched: a commit message, an `echo`, and a progress note naming a
      blocked command all pass; a call inside `$( )` or a subshell still asks
- [x] Quoted bodies do not steer the match: `-f body='use -f; then rerun'`,
      `body='build && test'` and `body='run gh api -X GET first'` all still ask
- [x] Dispatcher contract: two guards firing on one command emit one JSON document
      carrying both reasons; `deny` outranks `ask`; a block still exits 2
- [x] The full pending cycle from `pr-rules` (lookup query, `addPullRequestReview`,
      `addPullRequestReviewThread`, `addPullRequestReviewThreadReply`,
      `deletePullRequestReview`, `gh api graphql --input`) runs silently end to end
      through `hooks/PreToolUse.js`
- [x] Manual: a `gh pr review --comment` call in a live session prompts instead of
      publishing -- needs `node install.js` into `~/.claude`, which is outside this
      working tree; the same call was verified end to end through
      `hooks/PreToolUse.js` with `CLAUDE_CONFIG_DIR` pointed at the checkout

## Verification for a reviewer

```
npm test
CLAUDE_CONFIG_DIR=$(pwd) node hooks/PreToolUse.js <<'EOF'
{"tool_name":"Bash","tool_input":{"command":"gh pr review 49 --approve"}}
EOF
```

The first prints an `ask` decision naming the pending alternative; swapping the command
for `gh pr view 49` prints nothing and exits 0.
