### PR TITLE
GH-57: Route skills by frontmatter triggers instead of one flat reminder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,28 @@ No hardcoded user paths anywhere. No npm dependencies.
 
 See `skills/hook-scripts/SKILL.md` for full hook development conventions.
 
+## How a skill reaches the agent
+
+Two paths, so that a skill arrives when it applies instead of every skill arriving on
+every prompt:
+
+- `tools/skills-reminder.js` (`UserPromptSubmit`) lists every skill except those that
+  declare `reminder: false`, meaning their `paths:` are the whole trigger. Declaring
+  `paths:` alone does not remove a skill from this list: most are triggered by intent
+  too, and design work runs before the file that will carry it exists.
+- `tools/skill-gate.js` (`PreToolUse` on `Edit`/`Write`/`MultiEdit`/`NotebookEdit`)
+  matches the edited file against every skill's `paths:`, adds the skills named in
+  their `with:`, subtracts the ones already loaded in this session's transcript, and
+  warns with what's left. Loaded skills are tracked per session in
+  `session-env/<session_id>.skill-gate.json` against a transcript byte cursor.
+
+Both read `tools/skill-catalog.js`, which parses `tier`/`paths`/`with` out of each
+`SKILL.md` frontmatter — the frontmatter is the only place a skill's triggers are
+declared, so there is no second list to keep in sync.
+
+When several skills fire on one task they are ordered `process` → `domain` → `narrow`.
+The narrower skill rules its own topic and must not restate the wider one.
+
 ## Adding a skill
 
 0. Pre-flight check, before creating any file:
@@ -43,7 +65,13 @@ See `skills/hook-scripts/SKILL.md` for full hook development conventions.
      adjacent skills (e.g. `encapsulation` covers access-specifier rules;
      `api-design` covers public surface shape — the two must not restate each other).
 1. Copy `templates/SKILL.md` to `skills/<name>/SKILL.md`
-2. Fill in frontmatter (name, description, tags)
+2. Fill in frontmatter (name, description, tags), then decide how it is triggered:
+   - `tier` — `process`, `domain`, or `narrow` (see "How a skill reaches the agent")
+   - `paths` — the files this skill owns, when a kind of file should trigger it
+   - `reminder: false` — only when those files are the *whole* trigger; it drops the
+     skill from the every-prompt reminder and leaves it to the edit-time gate
+   - `with` — skills that must arrive together with this one, so the pair is never
+     half-applied
 3. Write rules sections following the template structure
 4. Add an entry to the skill table in `README.md`
 5. Add the skill's trigger line to `config/CLAUDE.md`'s "Skills — auto-apply" section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - C++ lint tools: `clang-format`, `clang-tidy`, `cppcheck` wrappers running on every edited C++ file
 - Desktop stop notification via `stop-notify` (Windows / macOS / Linux)
 - Skills: `api-design`, `changelog`, `commit-rules`, `cpp-coding`, `cpp-testing`, `ddd`, `doxygen`, `editing`, `hook-scripts`, `pr-rules`, `release`, `submodule-sync`
-- `UserPromptSubmit` hook: injects active skills reminder into each prompt
+- `UserPromptSubmit` hook: injects a reminder of the available skills into each prompt, with their full trigger text and tier; a skill whose trigger is exactly the files it owns is left to the edit-time gate instead
 - Portable `config/settings.json` using `CLAUDE_CONFIG_DIR` / `os.homedir()` — no hardcoded user paths
 - `install.js` bootstrap with JSON-merge for `~/.claude/settings.json` — existing machine-specific settings preserved
 - `templates/SKILL.md` template for consistent skill authoring
@@ -23,6 +23,8 @@
 - Skills: `security-and-hardening` (trust boundaries, input validation, secrets, least privilege), `performance-optimization` (profile-measure-optimize workflow), `observability-and-instrumentation` (logging, metrics, tracing)
 - Skills: `ci-cd-and-automation` (pipeline design and quality gates), `deprecation-and-migration` (retiring a public API, migration guides), `shipping-and-launch` (release readiness, staged rollout, rollback planning)
 - `writing-style` skill: technical register and vocabulary for documentation, issue/PR/commit text, and conversation, in any human language — no slang, no unnecessary borrowings from another language
+- Skill routing frontmatter: every skill declares `tier` (`process`/`domain`/`narrow`), and optionally `paths` globs for the files it owns, `with` for the skills that always apply alongside it, and `reminder: false` when those files are its whole trigger
+- `skill-gate` tool: on `Edit`/`Write`/`MultiEdit`/`NotebookEdit`, names the skills claiming the edited file and their companions, leaving out those already loaded in the session
 - `install.js` support for `agents/*.md` → `~/.claude/agents/` and `commands/*.md` → `~/.claude/commands/` (both optional; a checkout without either installs cleanly)
 - Agents: `spec-architect`, `implementer`, `code-reviewer`, `security-auditor`, `release-manager` — persona subagents forming an idea-to-release pipeline, each scoped to one stage and pointed at the skills it applies
 - Commands: `/spec`, `/build`, `/ship` — orchestrate the persona agents into an idea-to-release pipeline; `/ship` fans `code-reviewer` and `security-auditor` out in parallel, merges into a go/no-go, and hands off to `release-manager` on go

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pipeline of persona agents and commands built on top of them.
 - `commit-trailer-guard.js` — blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
 - `review-publish-guard.js` — prompts for confirmation before a `gh` command that publishes review feedback on the spot (`gh pr review --comment/--approve/--request-changes`, `gh pr comment`, REST `in_reply_to`, an `event` field on `POST /pulls/{n}/reviews`, `submitPullRequestReview`, and a thread reply carrying no `pullRequestReviewId`); the pending-review path stays unprompted
 - `secret-guard.js` — blocks writes (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) containing private keys, AWS keys, GitHub PATs; warns on probable credentials
+- `skill-gate.js` — on the same write tools, names the skills that claim the edited file (their `paths:` frontmatter) plus the ones they list in `with:`, minus whatever is already loaded this session; warn-only
 
 **`PostToolUse`** — runs after `Edit` / `Write` / `MultiEdit` / `NotebookEdit` on C++ files (`.h`, `.hpp`, `.cpp`, `.cc`, `.cxx`):
 - `comment-check.js` — runs unconditionally (no config file needed); reminds to check any newly added non-Doxygen comment against the `comments` skill
@@ -38,9 +39,16 @@ pipeline of persona agents and commands built on top of them.
 - `claude-md-skills-sync-check.js` — warns if `CLAUDE.md`'s skill list has drifted from `skills/`
 
 **`UserPromptSubmit`** — runs on every user message:
-- `skills-reminder.js` — injects a reminder of available skills and their triggers, generated live from `skills/*/SKILL.md` frontmatter
+- `skills-reminder.js` — injects a reminder of the available skills, generated live from `skills/*/SKILL.md` frontmatter; a skill declaring `reminder: false` is left to `skill-gate.js` alone
 
 ## Skills
+
+Each skill declares in its frontmatter how it is triggered and how it ranks against the
+others: `tier` (`process` sets the approach, `domain` shapes the code, `narrow` rules one
+topic), optional `paths` globs naming the files it owns, optional `with` naming the
+skills that always apply alongside it, and optional `reminder: false` for a skill whose
+`paths` are its whole trigger. When several fire on one task they are loaded
+`process` → `domain` → `narrow`, and the narrower one wins on its own topic.
 
 | Skill | Description |
 |-------|-------------|

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -12,6 +12,16 @@ Local commits, local file edits within a git repo, and read operations do not re
 
 ## Skills — auto-apply
 
+Applying a skill means loading it with the Skill tool. Recalling that a skill exists, or
+having read it in an earlier session, is not applying it.
+
+Several skills apply to most tasks. Load them all, in this order: process skills
+(`requirements`, `architecture`, `project-planning`, `debugging`,
+`test-driven-development`, `code-review-and-quality`) settle the approach, then the
+domain skill for the code at hand, then narrow-scope skills (`comments`, `doxygen`,
+`encapsulation`, `commit-rules`, `issue-rules`, `pr-rules`, `changelog`,
+`writing-style`). Where two overlap, the narrower one rules its own topic.
+
 When writing or reviewing C++ implementation code → apply `cpp-coding` skill.
 When writing, reviewing, or adding tests to C++ code → apply `cpp-testing` skill.
 When designing public API, adding public headers, or reviewing public interface → apply `api-design` skill.

--- a/hooks/PreToolUse.js
+++ b/hooks/PreToolUse.js
@@ -9,10 +9,10 @@ const toolsDir = path.join(configDir, 'tools');
 const DISPATCH = {
   Agent:        ['bg-agent-counter.js'],
   Bash:         ['bash-safety.js', 'commit-trailer-guard.js', 'review-publish-guard.js'],
-  Edit:         ['secret-guard.js'],
-  Write:        ['secret-guard.js'],
-  MultiEdit:    ['secret-guard.js'],
-  NotebookEdit: ['secret-guard.js'],
+  Edit:         ['secret-guard.js', 'skill-gate.js'],
+  Write:        ['secret-guard.js', 'skill-gate.js'],
+  MultiEdit:    ['secret-guard.js', 'skill-gate.js'],
+  NotebookEdit: ['secret-guard.js', 'skill-gate.js'],
 };
 
 // Claude Code reads this hook's stdout as a single JSON document when a tool decides

--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -5,6 +5,10 @@ description: Apply when designing new API, adding public headers, or reviewing p
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
+  paths:
+    - "**/*.h"
+    - "**/*.hpp"
   tags:
     - cpp
     - api

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when designing system or module architecture, evaluating arch
 license: Unlicense
 metadata:
   author: ssoft
+  tier: process
   tags:
     - architecture
     - planning

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -5,6 +5,10 @@ description: Apply when editing CHANGELOG.md or asked about changelog format
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
+  reminder: false
+  paths:
+    - "**/CHANGELOG.md"
   tags:
     - git
     - changelog

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when designing or reviewing a CI/CD pipeline, build automatio
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - ci
     - automation

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when reviewing code changes for correctness, readability, arc
 license: Unlicense
 metadata:
   author: ssoft
+  tier: process
   tags:
     - review
     - quality

--- a/skills/comments/SKILL.md
+++ b/skills/comments/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when writing or reviewing non-Doxygen code comments (inline n
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
   tags:
     - cpp
     - comments

--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when writing or reviewing commit messages or naming branches
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
   tags:
     - git
     - commits

--- a/skills/cpp-coding/SKILL.md
+++ b/skills/cpp-coding/SKILL.md
@@ -5,6 +5,15 @@ description: Apply when writing or reviewing C++ implementation code
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
+  paths:
+    - "**/*.cpp"
+    - "**/*.cc"
+    - "**/*.cxx"
+    - "**/*.h"
+    - "**/*.hpp"
+  with:
+    - "comments"
   tags:
     - cpp
     - coding

--- a/skills/cpp-testing/SKILL.md
+++ b/skills/cpp-testing/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when writing, reviewing, or adding tests to C++ code
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - cpp
     - testing

--- a/skills/ddd/SKILL.md
+++ b/skills/ddd/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when designing domain models, domain APIs, or structuring a m
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - cpp
     - ddd

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when investigating a bug, test failure, or unexpected behavio
 license: Unlicense
 metadata:
   author: ssoft
+  tier: process
   tags:
     - debugging
     - quality

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when retiring a public API, planning a breaking change, or wr
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - api
     - migration

--- a/skills/doxygen/SKILL.md
+++ b/skills/doxygen/SKILL.md
@@ -5,6 +5,13 @@ description: Apply when adding or modifying Doxygen comments for public C++ head
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
+  reminder: false
+  paths:
+    - "**/*.h"
+    - "**/*.hpp"
+  with:
+    - "api-design"
   tags:
     - cpp
     - doxygen

--- a/skills/editing/SKILL.md
+++ b/skills/editing/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when editing any file in the project
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - workflow
     - editing

--- a/skills/encapsulation/SKILL.md
+++ b/skills/encapsulation/SKILL.md
@@ -5,6 +5,10 @@ description: Apply when choosing access specifiers, designing a class's public/p
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
+  paths:
+    - "**/*.h"
+    - "**/*.hpp"
   tags:
     - cpp
     - encapsulation

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when carrying out a GitHub action with the gh CLI - issues, p
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - github
     - cli

--- a/skills/gitlab-cli/SKILL.md
+++ b/skills/gitlab-cli/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when carrying out a GitLab action with the glab CLI - issues,
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - gitlab
     - cli

--- a/skills/hook-scripts/SKILL.md
+++ b/skills/hook-scripts/SKILL.md
@@ -5,6 +5,13 @@ description: Apply when writing or modifying hook scripts in hooks/ or tools/
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
+  reminder: false
+  paths:
+    - "**/hooks/*.js"
+    - "**/tools/*.js"
+  with:
+    - "comments"
   tags:
     - hooks
     - workflow

--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when creating or reviewing tracker issues
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
   tags:
     - git
     - issues

--- a/skills/node-testing/SKILL.md
+++ b/skills/node-testing/SKILL.md
@@ -5,6 +5,12 @@ description: Apply when writing or reviewing tests under test/*.test.js for Clau
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
+  reminder: false
+  paths:
+    - "**/test/*.test.js"
+  with:
+    - "test-driven-development"
   tags:
     - testing
     - node

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when adding logging, metrics, or tracing, or reviewing how a 
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - observability
     - quality

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when diagnosing or fixing a reported performance problem, or 
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - performance
     - quality

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when opening, reviewing, or preparing a PR/MR
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
   tags:
     - git
     - pr

--- a/skills/project-planning/SKILL.md
+++ b/skills/project-planning/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when scoping work, breaking a feature down into tasks, estima
 license: Unlicense
 metadata:
   author: ssoft
+  tier: process
   tags:
     - planning
     - project-management

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when preparing a release, bumping version, or tagging
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - git
     - release

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when eliciting requirements, writing user stories or use case
 license: Unlicense
 metadata:
   author: ssoft
+  tier: process
   tags:
     - requirements
     - planning

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when code accepts external input, crosses a trust boundary, o
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - security
     - quality

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when preparing to ship a release to users, beyond the version
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - release
     - operations

--- a/skills/submodule-sync/SKILL.md
+++ b/skills/submodule-sync/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when syncing git submodules or working across submodule bound
 license: Unlicense
 metadata:
   author: ssoft
+  tier: domain
   tags:
     - git
     - submodules

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when implementing a feature or bug fix, before writing implem
 license: Unlicense
 metadata:
   author: ssoft
+  tier: process
   tags:
     - testing
     - workflow

--- a/skills/writing-style/SKILL.md
+++ b/skills/writing-style/SKILL.md
@@ -5,6 +5,7 @@ description: Apply when writing documentation, issue/PR/commit text, or communic
 license: Unlicense
 metadata:
   author: ssoft
+  tier: narrow
   tags:
     - writing
     - style

--- a/templates/SKILL.md
+++ b/templates/SKILL.md
@@ -5,6 +5,25 @@ description: <one-line description of when to use this skill>
 license: <license identifier, e.g. MIT>
 metadata:
   author: <author or team name>
+  # process = sets the approach, domain = shapes the code, narrow = rules one topic.
+  # Several skills firing on one task are loaded in that order; the narrower one wins
+  # on its own topic and must not restate the wider one.
+  tier: <process | domain | narrow>
+  # Optional. Globs of the files this skill owns, matched against the full path with
+  # forward slashes — write '**/' in front of anything that isn't repo-root-anchored.
+  # A skill with paths is announced by tools/skill-gate.js when such a file is edited.
+  # An item may hold a comma; it may not hold an escaped quote, which the frontmatter
+  # reader does not decode.
+  paths:
+    - "**/*.<ext>"
+  # Optional, defaults to true. Set false only when the paths above are the whole
+  # trigger, which drops the skill from the every-prompt reminder and leaves it to the
+  # gate. A skill whose intent is wider than its files keeps the default: an API is
+  # designed before the header exists, and no edit has happened yet to announce it.
+  reminder: false
+  # Optional. Skills that always apply alongside this one; the gate names them too.
+  with:
+    - <skill-name>
   tags:
     - <primary-tag>
     - <secondary-tag>

--- a/test/skill-catalog.test.js
+++ b/test/skill-catalog.test.js
@@ -1,0 +1,174 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { globToRegExp, parseFrontmatter, loadCatalog, matchSkills } = require('../tools/skill-catalog');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'skill-catalog-'));
+}
+function rmTmp(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+function writeSkill(skillsDir, name, frontmatter) {
+  const dir = path.join(skillsDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\nname: ${name}\n${frontmatter}---\nbody\n`);
+}
+
+test('globToRegExp matches an extension anywhere below the root', () => {
+  const re = globToRegExp('**/*.cpp');
+  assert.ok(re.test('D:/work/src/foo.cpp'));
+  assert.ok(re.test('foo.cpp'));
+  assert.ok(!re.test('D:/work/src/foo.h'));
+});
+
+test('globToRegExp keeps a single star inside one path segment', () => {
+  const re = globToRegExp('**/test/*.test.js');
+  assert.ok(re.test('D:/repo/test/secret-guard.test.js'));
+  assert.ok(!re.test('D:/repo/test/nested/secret-guard.test.js'));
+});
+
+test('globToRegExp escapes regex metacharacters in literal text', () => {
+  const re = globToRegExp('**/CHANGELOG.md');
+  assert.ok(re.test('D:/repo/CHANGELOG.md'));
+  assert.ok(!re.test('D:/repo/CHANGELOGxmd'));
+});
+
+test('parseFrontmatter reads a block sequence', () => {
+  const fm = parseFrontmatter('---\nname: x\nmetadata:\n  paths:\n    - "**/*.cpp"\n    - "**/*.h"\n---\nbody\n');
+  assert.deepStrictEqual(fm.paths, ['**/*.cpp', '**/*.h']);
+});
+
+test('parseFrontmatter reads an inline sequence', () => {
+  const fm = parseFrontmatter('---\nname: x\nmetadata:\n  with: [comments, encapsulation]\n---\nbody\n');
+  assert.deepStrictEqual(fm.with, ['comments', 'encapsulation']);
+});
+
+test('parseFrontmatter keeps a comma that sits inside a quoted inline item', () => {
+  const fm = parseFrontmatter('---\nname: x\nmetadata:\n  paths: ["**/a,b.md", "**/c.md"]\n---\nbody\n');
+  assert.deepStrictEqual(fm.paths, ['**/a,b.md', '**/c.md']);
+});
+
+test('parseFrontmatter stops at the closing delimiter', () => {
+  const fm = parseFrontmatter('---\nname: x\n---\ntier: process\n');
+  assert.strictEqual(fm.tier, undefined);
+});
+
+test('parseFrontmatter reads a CRLF file', () => {
+  const fm = parseFrontmatter('---\r\nname: x\r\nmetadata:\r\n  tier: process\r\n  paths:\r\n    - "**/*.h"\r\n---\r\nbody\r\n');
+  assert.strictEqual(fm.tier, 'process');
+  assert.deepStrictEqual(fm.paths, ['**/*.h']);
+});
+
+test('parseFrontmatter returns an empty object without frontmatter', () => {
+  assert.deepStrictEqual(parseFrontmatter('no frontmatter here\n'), {});
+});
+
+test('loadCatalog defaults tier to domain and leaves paths empty', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'alpha', 'description: Apply when alpha\n');
+    assert.deepStrictEqual(loadCatalog(tmp), [
+      { name: 'alpha', description: 'Apply when alpha', tier: 'domain', paths: [], companions: [], reminder: true },
+    ]);
+  } finally { rmTmp(tmp); }
+});
+
+test('loadCatalog keeps a path-triggered skill in the reminder by default', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'alpha', 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n');
+    assert.strictEqual(loadCatalog(tmp)[0].reminder, true);
+  } finally { rmTmp(tmp); }
+});
+
+test('loadCatalog reads reminder: false', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'alpha', 'description: d\nmetadata:\n  reminder: false\n');
+    assert.strictEqual(loadCatalog(tmp)[0].reminder, false);
+  } finally { rmTmp(tmp); }
+});
+
+test('loadCatalog skips a directory without SKILL.md', () => {
+  const tmp = mkTmp();
+  try {
+    fs.mkdirSync(path.join(tmp, 'empty'));
+    writeSkill(tmp, 'real', 'description: Apply when real\n');
+    assert.deepStrictEqual(loadCatalog(tmp).map(s => s.name), ['real']);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills returns skills whose paths match the edited file', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'cpp-coding', 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n');
+    writeSkill(tmp, 'node-testing', 'description: d\nmetadata:\n  paths: ["**/test/*.test.js"]\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'D:/repo/src/a.cpp'), ['cpp-coding']);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills pulls in companions of a matched skill', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'cpp-coding', 'description: d\nmetadata:\n  tier: domain\n  paths: ["**/*.cpp"]\n  with: [comments]\n');
+    writeSkill(tmp, 'comments', 'description: d\nmetadata:\n  tier: narrow\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'D:/repo/a.cpp'), ['cpp-coding', 'comments']);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills orders process before domain before narrow', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'narrow-one', 'description: d\nmetadata:\n  tier: narrow\n  paths: ["**/*.cpp"]\n');
+    writeSkill(tmp, 'process-one', 'description: d\nmetadata:\n  tier: process\n  paths: ["**/*.cpp"]\n');
+    writeSkill(tmp, 'domain-one', 'description: d\nmetadata:\n  tier: domain\n  paths: ["**/*.cpp"]\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'a.cpp'), ['process-one', 'domain-one', 'narrow-one']);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills lists a companion once when two skills name it', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'a-skill', 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n  with: [comments]\n');
+    writeSkill(tmp, 'b-skill', 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n  with: [comments]\n');
+    writeSkill(tmp, 'comments', 'description: d\nmetadata:\n  tier: narrow\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'a.cpp'), ['a-skill', 'b-skill', 'comments']);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills lists a skill once when it is both path-matched and a companion', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'cpp-coding', 'description: d\nmetadata:\n  paths: ["**/*.h"]\n  with: [doxygen]\n');
+    writeSkill(tmp, 'doxygen', 'description: d\nmetadata:\n  tier: narrow\n  paths: ["**/*.h"]\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'a.h'), ['cpp-coding', 'doxygen']);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills ignores a companion that names no installed skill', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'a-skill', 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n  with: [not-installed]\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'a.cpp'), ['a-skill']);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills returns nothing for a path no skill claims', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'cpp-coding', 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'D:/repo/readme.txt'), []);
+  } finally { rmTmp(tmp); }
+});
+
+test('matchSkills normalises backslash paths before matching', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'cpp-coding', 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n');
+    assert.deepStrictEqual(matchSkills(loadCatalog(tmp), 'D:\\repo\\src\\a.cpp'), ['cpp-coding']);
+  } finally { rmTmp(tmp); }
+});

--- a/test/skill-gate.test.js
+++ b/test/skill-gate.test.js
@@ -1,0 +1,199 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { skillsIn, notice, loadedSkills } = require('../tools/skill-gate');
+
+const gateJs = path.join(__dirname, '..', 'tools', 'skill-gate.js');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'skill-gate-'));
+}
+function rmTmp(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+function writeSkill(skillsDir, name, frontmatter) {
+  const dir = path.join(skillsDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\nname: ${name}\n${frontmatter}---\nbody\n`);
+}
+function transcriptLine(skill) {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name: 'Skill', input: { skill } }] },
+  });
+}
+// A config dir holding the skills the gate matches against, plus the session-env
+// directory it keeps its transcript cursor in.
+function mkConfigDir(skills) {
+  const dir = mkTmp();
+  fs.mkdirSync(path.join(dir, 'session-env'), { recursive: true });
+  for (const [name, frontmatter] of Object.entries(skills)) {
+    writeSkill(path.join(dir, 'skills'), name, frontmatter);
+  }
+  return dir;
+}
+function runGate(configDir, input) {
+  return spawnSync('node', [gateJs], {
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+  });
+}
+
+test('skillsIn finds each Skill invocation in a transcript chunk', () => {
+  const text = transcriptLine('debugging') + '\n' + transcriptLine('editing') + '\n';
+  assert.deepStrictEqual(skillsIn(text), ['debugging', 'editing']);
+});
+
+test('skillsIn ignores other tool calls', () => {
+  const text = JSON.stringify({ message: { content: [{ name: 'Read', input: { file_path: 'a.cpp' } }] } });
+  assert.deepStrictEqual(skillsIn(text), []);
+});
+
+test('notice names the file and every missing skill', () => {
+  const text = notice('D:/repo/src/a.cpp', ['cpp-coding', 'comments']);
+  assert.ok(text.includes('a.cpp'));
+  assert.ok(text.includes('cpp-coding'));
+  assert.ok(text.includes('comments'));
+  assert.ok(text.includes('Skill tool'));
+});
+
+test('loadedSkills reads a transcript and remembers it across calls', () => {
+  const dir = mkTmp();
+  try {
+    const transcript = path.join(dir, 't.jsonl');
+    const state = path.join(dir, 'state.json');
+    fs.writeFileSync(transcript, transcriptLine('debugging') + '\n');
+    assert.deepStrictEqual(loadedSkills(transcript, state), ['debugging']);
+    fs.appendFileSync(transcript, transcriptLine('editing') + '\n');
+    assert.deepStrictEqual(loadedSkills(transcript, state), ['debugging', 'editing']);
+  } finally { rmTmp(dir); }
+});
+
+test('loadedSkills finds a skill whose line was still being written at the last read', () => {
+  const dir = mkTmp();
+  try {
+    const transcript = path.join(dir, 't.jsonl');
+    const state = path.join(dir, 'state.json');
+    const line = transcriptLine('debugging');
+    const cut = line.indexOf('"name":"Skill"') + 6;
+    fs.writeFileSync(transcript, line.slice(0, cut));
+    assert.deepStrictEqual(loadedSkills(transcript, state), []);
+    fs.appendFileSync(transcript, line.slice(cut) + '\n');
+    assert.deepStrictEqual(loadedSkills(transcript, state), ['debugging']);
+  } finally { rmTmp(dir); }
+});
+
+test('loadedSkills holds back a line that never got its newline, and takes it once it does', () => {
+  const dir = mkTmp();
+  try {
+    const transcript = path.join(dir, 't.jsonl');
+    const state = path.join(dir, 'state.json');
+    fs.writeFileSync(transcript, transcriptLine('debugging'));
+    assert.deepStrictEqual(loadedSkills(transcript, state), []);
+    assert.deepStrictEqual(loadedSkills(transcript, state), []);
+    fs.appendFileSync(transcript, '\n');
+    assert.deepStrictEqual(loadedSkills(transcript, state), ['debugging']);
+  } finally { rmTmp(dir); }
+});
+
+test('loadedSkills rereads from the start when the transcript shrank', () => {
+  const dir = mkTmp();
+  try {
+    const transcript = path.join(dir, 't.jsonl');
+    const state = path.join(dir, 'state.json');
+    fs.writeFileSync(transcript, transcriptLine('debugging') + '\n' + transcriptLine('editing') + '\n');
+    loadedSkills(transcript, state);
+    fs.writeFileSync(transcript, transcriptLine('release') + '\n');
+    assert.deepStrictEqual(loadedSkills(transcript, state), ['release']);
+  } finally { rmTmp(dir); }
+});
+
+test('loadedSkills returns nothing for a missing transcript', () => {
+  const dir = mkTmp();
+  try {
+    assert.deepStrictEqual(loadedSkills(path.join(dir, 'absent.jsonl'), path.join(dir, 's.json')), []);
+  } finally { rmTmp(dir); }
+});
+
+test('gate names the skills claiming the edited file', () => {
+  const dir = mkConfigDir({
+    'cpp-coding': 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n  with: [comments]\n',
+    comments: 'description: d\nmetadata:\n  tier: narrow\n',
+  });
+  try {
+    const r = runGate(dir, { tool_name: 'Edit', tool_input: { file_path: 'D:/repo/a.cpp' }, session_id: 's1' });
+    assert.strictEqual(r.status, 0);
+    assert.ok(r.stdout.includes('cpp-coding'));
+    assert.ok(r.stdout.includes('comments'));
+  } finally { rmTmp(dir); }
+});
+
+test('gate stays silent for a path no skill claims', () => {
+  const dir = mkConfigDir({ 'cpp-coding': 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n' });
+  try {
+    const r = runGate(dir, { tool_name: 'Edit', tool_input: { file_path: 'D:/repo/notes.txt' }, session_id: 's1' });
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(r.stdout.trim(), '');
+  } finally { rmTmp(dir); }
+});
+
+test('gate stays silent for a tool that edits nothing', () => {
+  const dir = mkConfigDir({ 'cpp-coding': 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n' });
+  try {
+    const r = runGate(dir, { tool_name: 'Bash', tool_input: { command: 'ls a.cpp' }, session_id: 's1' });
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(r.stdout.trim(), '');
+  } finally { rmTmp(dir); }
+});
+
+test('gate omits a skill already loaded in the transcript', () => {
+  const dir = mkConfigDir({
+    'cpp-coding': 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n  with: [comments]\n',
+    comments: 'description: d\nmetadata:\n  tier: narrow\n',
+  });
+  try {
+    const transcript = path.join(dir, 't.jsonl');
+    fs.writeFileSync(transcript, transcriptLine('cpp-coding') + '\n');
+    const r = runGate(dir, {
+      tool_name: 'Write',
+      tool_input: { file_path: 'D:/repo/a.cpp' },
+      transcript_path: transcript,
+      session_id: 's1',
+    });
+    assert.ok(!r.stdout.includes('cpp-coding'));
+    assert.ok(r.stdout.includes('comments'));
+  } finally { rmTmp(dir); }
+});
+
+test('gate stays silent once every matching skill is loaded', () => {
+  const dir = mkConfigDir({ 'cpp-coding': 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n' });
+  try {
+    const transcript = path.join(dir, 't.jsonl');
+    fs.writeFileSync(transcript, transcriptLine('cpp-coding') + '\n');
+    const r = runGate(dir, {
+      tool_name: 'Edit',
+      tool_input: { file_path: 'D:/repo/a.cpp' },
+      transcript_path: transcript,
+      session_id: 's1',
+    });
+    assert.strictEqual(r.stdout.trim(), '');
+  } finally { rmTmp(dir); }
+});
+
+test('gate exits 0 on malformed stdin', () => {
+  const dir = mkConfigDir({});
+  try {
+    const r = spawnSync('node', [gateJs], {
+      input: 'not json', encoding: 'utf8', stdio: 'pipe',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    });
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(r.stdout.trim(), '');
+  } finally { rmTmp(dir); }
+});

--- a/test/skills-reminder.test.js
+++ b/test/skills-reminder.test.js
@@ -4,7 +4,8 @@ const assert = require('node:assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { shortHint, buildSkillList, buildContext } = require('../tools/skills-reminder');
+const { trigger, buildSkillList, buildContext } = require('../tools/skills-reminder');
+const { loadCatalog } = require('../tools/skill-catalog');
 
 function mkTmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'skills-reminder-'));
@@ -12,26 +13,23 @@ function mkTmp() {
 function rmTmp(dir) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
-function writeSkill(skillsDir, name, description) {
+function writeSkill(skillsDir, name, description, metadata = '') {
   const dir = path.join(skillsDir, name);
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: ${description}\n---\nbody\n`);
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: ${description}\n${metadata}---\nbody\n`);
 }
 
-test('shortHint strips leading "Apply when"', () => {
-  assert.strictEqual(shortHint('Apply when writing tests'), 'writing tests');
+test('trigger strips leading "Apply when"', () => {
+  assert.strictEqual(trigger('Apply when writing tests'), 'writing tests');
 });
 
-test('shortHint leaves short text without "Apply when" unchanged', () => {
-  assert.strictEqual(shortHint('Short description'), 'Short description');
+test('trigger leaves text without "Apply when" unchanged', () => {
+  assert.strictEqual(trigger('Short description'), 'Short description');
 });
 
-test('shortHint truncates long text at word boundary with ellipsis', () => {
-  const long = 'a'.repeat(40) + ' ' + 'b'.repeat(40);
-  const hint = shortHint(long);
-  assert.ok(hint.length <= 71);
-  assert.ok(hint.endsWith('…'));
-  assert.ok(!hint.includes('b'));
+test('trigger keeps a long description whole', () => {
+  const long = 'Apply when ' + 'word '.repeat(30).trim();
+  assert.strictEqual(trigger(long), 'word '.repeat(30).trim());
 });
 
 test('buildSkillList returns empty array for missing directory', () => {
@@ -45,8 +43,8 @@ test('buildSkillList includes every skill directory with a SKILL.md', () => {
     writeSkill(tmp, 'beta', 'Apply when doing beta things');
     const list = buildSkillList(tmp);
     assert.strictEqual(list.length, 2);
-    assert.ok(list.some(e => e.startsWith('alpha:')));
-    assert.ok(list.some(e => e.startsWith('beta:')));
+    assert.ok(list.some(e => e.startsWith('alpha ')));
+    assert.ok(list.some(e => e.startsWith('beta ')));
   } finally {
     rmTmp(tmp);
   }
@@ -57,7 +55,7 @@ test('buildSkillList skips directories without SKILL.md', () => {
   try {
     fs.mkdirSync(path.join(tmp, 'no-skill-here'));
     writeSkill(tmp, 'real', 'Apply when real');
-    assert.deepStrictEqual(buildSkillList(tmp), ['real: real']);
+    assert.deepStrictEqual(buildSkillList(tmp), ['real [domain]: real']);
   } finally {
     rmTmp(tmp);
   }
@@ -75,32 +73,75 @@ test('buildSkillList skips SKILL.md without a description field', () => {
   }
 });
 
+test('buildSkillList leaves out a skill that opts out with reminder: false', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'intent-only', 'Apply when intent says so');
+    writeSkill(tmp, 'file-bound', 'Apply when editing a hook',
+      'metadata:\n  paths: ["**/hooks/*.js"]\n  reminder: false\n');
+    assert.deepStrictEqual(buildSkillList(tmp), ['intent-only [domain]: intent says so']);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('buildSkillList keeps a path-triggered skill whose intent is wider than its files', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'api-design', 'Apply when designing an API', 'metadata:\n  paths: ["**/*.h"]\n');
+    assert.deepStrictEqual(buildSkillList(tmp), ['api-design [domain]: designing an API']);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('buildSkillList orders process before domain before narrow', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'aaa-narrow', 'Apply when narrow', 'metadata:\n  tier: narrow\n');
+    writeSkill(tmp, 'bbb-process', 'Apply when process', 'metadata:\n  tier: process\n');
+    writeSkill(tmp, 'ccc-domain', 'Apply when domain', 'metadata:\n  tier: domain\n');
+    assert.deepStrictEqual(buildSkillList(tmp).map(e => e.split(' ')[0]),
+      ['bbb-process', 'ccc-domain', 'aaa-narrow']);
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
 test('buildContext returns null when no skills found', () => {
   assert.strictEqual(buildContext(path.join(os.tmpdir(), 'does-not-exist-xyz')), null);
 });
 
-test('buildContext produces a pipe-joined reminder string', () => {
+test('buildContext lists one skill per line under the header', () => {
   const tmp = mkTmp();
   try {
     writeSkill(tmp, 'alpha', 'Apply when doing alpha things');
     writeSkill(tmp, 'beta', 'Apply when doing beta things');
     const ctx = buildContext(tmp);
     assert.ok(ctx.startsWith('SKILLS'));
-    assert.ok(ctx.includes('alpha: doing alpha things'));
-    assert.ok(ctx.includes('beta: doing beta things'));
-    assert.ok(ctx.includes(' | '));
+    assert.ok(ctx.includes('\n- alpha [domain]: doing alpha things'));
+    assert.ok(ctx.includes('\n- beta [domain]: doing beta things'));
   } finally {
     rmTmp(tmp);
   }
 });
 
-test('buildContext output matches every real skill directory in this repo', () => {
+test('buildContext header names the Skill tool as the way to apply a skill', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'alpha', 'Apply when doing alpha things');
+    assert.ok(buildContext(tmp).includes('Skill tool'));
+  } finally {
+    rmTmp(tmp);
+  }
+});
+
+test('buildSkillList covers every skill in this repo that has not opted out', () => {
   const realSkillsDir = path.join(__dirname, '..', 'skills');
-  const dirs = fs.readdirSync(realSkillsDir).filter(name =>
-    fs.existsSync(path.join(realSkillsDir, name, 'SKILL.md')));
+  const intentOnly = loadCatalog(realSkillsDir).filter(s => s.reminder);
   const list = buildSkillList(realSkillsDir);
-  assert.strictEqual(list.length, dirs.length);
-  for (const name of dirs) {
-    assert.ok(list.some(e => e.startsWith(`${name}:`)), `missing entry for ${name}`);
+  assert.strictEqual(list.length, intentOnly.length);
+  for (const skill of intentOnly) {
+    assert.ok(list.some(e => e.startsWith(`${skill.name} [`)), `missing entry for ${skill.name}`);
   }
 });

--- a/tools/skill-catalog.js
+++ b/tools/skill-catalog.js
@@ -1,0 +1,109 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+// Declaration order is the load order skills firing on one task are announced in.
+const TIERS = ['process', 'domain', 'narrow'];
+const DEFAULT_TIER = 'domain';
+
+function globToRegExp(glob) {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        // '**/' spans any number of directories, including none at all
+        if (glob[i + 2] === '/') { re += '(?:.*/)?'; i += 2; } else { re += '.*'; i += 1; }
+      } else {
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else {
+      re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+function readSequence(block, key) {
+  const inline = block.match(new RegExp(`^\\s*${key}:\\s*\\[(.*)\\]\\s*$`, 'm'));
+  if (inline) {
+    // A glob may itself contain a comma, so only a comma outside quotes separates items
+    return [...inline[1].matchAll(/(?:^|,)\s*(?:"([^"]*)"|'([^']*)'|([^,]*))/g)]
+      .map(m => (m[1] ?? m[2] ?? m[3]).trim())
+      .filter(Boolean);
+  }
+  const lines = block.split('\n');
+  const start = lines.findIndex(l => new RegExp(`^\\s*${key}:\\s*$`).test(l));
+  if (start === -1) return undefined;
+  const items = [];
+  for (const line of lines.slice(start + 1)) {
+    const m = line.match(/^\s+-\s+(.*)$/);
+    if (!m) break;
+    items.push(m[1].trim().replace(/^["']|["']$/g, ''));
+  }
+  return items;
+}
+
+function parseFrontmatter(source) {
+  // A skill file checked out on Windows carries CRLF; every pattern below anchors on \n
+  const text = String(source).replace(/\r\n/g, '\n');
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return {};
+  const block = m[1];
+  const scalar = key => block.match(new RegExp(`^\\s*${key}:\\s*(.+)$`, 'm'))?.[1].trim();
+  const fm = {};
+  const description = scalar('description');
+  if (description !== undefined) fm.description = description;
+  const tier = scalar('tier');
+  if (tier !== undefined) fm.tier = tier;
+  const reminder = scalar('reminder');
+  if (reminder !== undefined) fm.reminder = reminder !== 'false';
+  const paths = readSequence(block, 'paths');
+  if (paths !== undefined) fm.paths = paths;
+  const companions = readSequence(block, 'with');
+  if (companions !== undefined) fm.with = companions;
+  return fm;
+}
+
+function loadCatalog(skillsDir) {
+  if (!fs.existsSync(skillsDir)) return [];
+  const catalog = [];
+  for (const name of fs.readdirSync(skillsDir).sort()) {
+    const skillFile = path.join(skillsDir, name, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+    let text;
+    try { text = fs.readFileSync(skillFile, 'utf8'); } catch { continue; }
+    const fm = parseFrontmatter(text);
+    if (fm.description === undefined) continue;
+    catalog.push({
+      name,
+      description: fm.description,
+      tier: TIERS.includes(fm.tier) ? fm.tier : DEFAULT_TIER,
+      paths: fm.paths ?? [],
+      companions: fm.with ?? [],
+      // Design work precedes the file it produces, so paths alone never opt a skill out.
+      reminder: fm.reminder ?? true,
+    });
+  }
+  return catalog;
+}
+
+function matchSkills(catalog, filePath) {
+  const normalised = String(filePath).replace(/\\/g, '/');
+  const byName = new Map(catalog.map(skill => [skill.name, skill]));
+  const selected = catalog.filter(skill =>
+    skill.paths.some(pattern => globToRegExp(pattern).test(normalised)));
+  const companions = selected
+    .flatMap(skill => skill.companions)
+    .map(name => byName.get(name))
+    .filter(skill => skill && !selected.includes(skill));
+  return [...selected, ...new Set(companions)]
+    .map((skill, position) => ({ skill, position }))
+    .sort((a, b) =>
+      TIERS.indexOf(a.skill.tier) - TIERS.indexOf(b.skill.tier) || a.position - b.position)
+    .map(entry => entry.skill.name);
+}
+
+module.exports = { TIERS, globToRegExp, parseFrontmatter, loadCatalog, matchSkills };

--- a/tools/skill-gate.js
+++ b/tools/skill-gate.js
@@ -1,0 +1,76 @@
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { loadCatalog, matchSkills } = require(path.join(__dirname, 'skill-catalog.js'));
+
+const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+const SKILL_CALL = /"name"\s*:\s*"Skill"\s*,\s*"input"\s*:\s*\{\s*"skill"\s*:\s*"([^"]+)"/g;
+
+function skillsIn(text) {
+  return [...text.matchAll(SKILL_CALL)].map(m => m[1]);
+}
+
+// The transcript only grows, so a run scans the bytes appended since the previous one.
+function loadedSkills(transcriptPath, statePath) {
+  let state = { size: 0, skills: [] };
+  try { state = JSON.parse(fs.readFileSync(statePath, 'utf8')); } catch {}
+
+  let size;
+  try { size = fs.statSync(transcriptPath).size; } catch { return []; }
+  if (size < state.size) state = { size: 0, skills: [] };
+
+  let chunk = '';
+  let consumed = state.size;
+  if (size > state.size) {
+    const fd = fs.openSync(transcriptPath, 'r');
+    try {
+      const buffer = Buffer.alloc(size - state.size);
+      fs.readSync(fd, buffer, 0, buffer.length, state.size);
+      // The last line may still be half-written; leave it for the next run, which is
+      // also what keeps a multi-byte character from being split across two reads
+      const complete = buffer.lastIndexOf(0x0a) + 1;
+      chunk = buffer.subarray(0, complete).toString('utf8');
+      consumed = state.size + complete;
+    } finally { fs.closeSync(fd); }
+  }
+
+  const skills = [...new Set([...state.skills, ...skillsIn(chunk)])];
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify({ size: consumed, skills }));
+  } catch {}
+  return skills;
+}
+
+function notice(filePath, missing) {
+  return `${path.basename(filePath)}: load with the Skill tool before editing — `
+    + `${missing.join(', ')} (process, then domain, then narrow scope).`;
+}
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+    if (!EDIT_TOOLS.has(data.tool_name)) process.exit(0);
+
+    const filePath = data.tool_input?.file_path ?? data.tool_input?.path ?? '';
+    if (!filePath) process.exit(0);
+
+    const matched = matchSkills(loadCatalog(path.join(configDir, 'skills')), filePath);
+    if (!matched.length) process.exit(0);
+
+    const statePath = path.join(configDir, 'session-env', `${data.session_id ?? 'unknown'}.skill-gate.json`);
+    const loaded = new Set(data.transcript_path ? loadedSkills(data.transcript_path, statePath) : []);
+    const missing = matched.filter(name => !loaded.has(name));
+    if (missing.length) process.stdout.write(notice(filePath, missing));
+    process.exit(0);
+  });
+}
+
+module.exports = { skillsIn, loadedSkills, notice };

--- a/tools/skills-reminder.js
+++ b/tools/skills-reminder.js
@@ -1,40 +1,36 @@
 'use strict';
-const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { TIERS, loadCatalog } = require(path.join(__dirname, 'skill-catalog.js'));
 
 const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 const skillsDir = path.join(configDir, 'skills');
 
-const MAX_HINT_LEN = 70;
+const HEADER = [
+  'SKILLS — before acting, match the work against this list and load every matching',
+  'skill with the Skill tool. Loading is the only way a skill applies: recalling that',
+  'a skill exists, or that you read it in an earlier session, does not count.',
+  'Several may match one task — load them all, process tier first, then domain, then',
+  'narrow; the narrower skill wins on its own topic. Skills tied to a kind of file are',
+  'left out here — they are named at the moment that file is edited.',
+].join('\n');
 
-function shortHint(description) {
-  let hint = description.replace(/^Apply when\s+/i, '').trim();
-  if (hint.length <= MAX_HINT_LEN) return hint;
-  const cut = hint.slice(0, MAX_HINT_LEN);
-  const lastSpace = cut.lastIndexOf(' ');
-  return (lastSpace > 0 ? cut.slice(0, lastSpace) : cut) + '…';
+function trigger(description) {
+  return description.replace(/^Apply when\s+/i, '').trim();
 }
 
+// A skill that opted out is announced by skill-gate instead, when its file is edited.
 function buildSkillList(dir) {
-  if (!fs.existsSync(dir)) return [];
-  const entries = [];
-  for (const name of fs.readdirSync(dir).sort()) {
-    const skillFile = path.join(dir, name, 'SKILL.md');
-    if (!fs.existsSync(skillFile)) continue;
-    let text;
-    try { text = fs.readFileSync(skillFile, 'utf8'); } catch { continue; }
-    const m = text.match(/^description:\s*(.+)$/m);
-    if (!m) continue;
-    entries.push(`${name}: ${shortHint(m[1])}`);
-  }
-  return entries;
+  return loadCatalog(dir)
+    .filter(skill => skill.reminder)
+    .sort((a, b) => TIERS.indexOf(a.tier) - TIERS.indexOf(b.tier) || a.name.localeCompare(b.name))
+    .map(skill => `${skill.name} [${skill.tier}]: ${trigger(skill.description)}`);
 }
 
 function buildContext(dir) {
   const entries = buildSkillList(dir);
   if (!entries.length) return null;
-  return 'SKILLS — apply before matching work:\n' + entries.join(' | ');
+  return HEADER + '\n' + entries.map(e => `- ${e}`).join('\n');
 }
 
 if (require.main === module) {
@@ -52,4 +48,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { shortHint, buildSkillList, buildContext };
+module.exports = { trigger, buildSkillList, buildContext };


### PR DESCRIPTION
## Problem

One flat list of all 31 skills went out on every prompt, each an equal-weight advisory
with its trigger truncated at 70 characters - the truncation cut exactly the part that
says when a skill applies. Nothing tied a skill to the file about to be edited, nothing
ranked the several skills that apply to one task, and nothing noticed a skill that was
never loaded. A task matching five skills got none of them. Reported as GH-57.

## Summary

- A skill declares in its own frontmatter how it is triggered and how it ranks: `tier`,
  optional `paths`, optional `with`, optional `reminder: false`
- Skills owning a kind of file are also named at the moment such a file is edited
- A skill already loaded in the session is not named again
- Skills applying together are ordered `process` -> `domain` -> `narrow`, with the
  narrower one ruling its own topic
- The every-prompt reminder carries full trigger text and tier, and drops only the four
  skills whose trigger is exactly their files

## Implementation

- `tools/skill-catalog.js` - parses `tier`/`paths`/`with`/`reminder` out of `SKILL.md`
  frontmatter and matches a path against them. Frontmatter is the single source of truth,
  so no second list can drift out of sync. Line endings are normalised first: a Windows
  checkout carries CRLF, which silently emptied the catalog before that was handled.
- `tools/skill-gate.js` - `PreToolUse` on `Edit`/`Write`/`MultiEdit`/`NotebookEdit`.
  Matches the edited path, expands the companions named in `with`, subtracts the skills
  already loaded in this session and warns with the remainder. Warn-only, exit 0.
- Loaded skills come from the session transcript, scanned incrementally against a byte
  cursor kept in `session-env/<session_id>.skill-gate.json`. The alternative - rereading
  the whole transcript on every edit - costs megabytes of IO in a long session.
- `tools/skills-reminder.js` - keeps every skill that has not set `reminder: false`, sorts
  by tier and stops truncating trigger text.
- `reminder` defaults to true, so declaring `paths` alone never removes a skill from the
  reminder. `api-design` and `encapsulation` are the reason: an API and a class surface
  are designed before the header that will carry them exists, so no edit has happened yet
  for the gate to react to. Only `doxygen`, `changelog`, `node-testing` and `hook-scripts`
  opt out - their trigger is exactly the file they name.
- Every skill got a `tier`; seven got `paths`, four of those a `with`, four a
  `reminder: false`. The reminder holds 27 of 31 skills.
- Precedence is stated in `config/CLAUDE.md`, `AGENTS.md` and the reminder header itself.

Three defects were found by review before merge and are fixed in this commit:

- `readSequence` split an inline frontmatter sequence on every comma, so a glob holding
  one was silently torn into two patterns.
- The transcript cursor advanced past a line that was still being written, which lost the
  Skill call it carried: one read took its head, the next its tail, and the pattern
  matched in neither. The cursor now stops at the last newline.
- `byTier` looked a skill up by name and read `.tier` off the result without a guard.
  The helper is gone; `matchSkills` sorts the skill objects it already holds.

## Test plan

- [x] `npm test` - 257 tests, green
- [x] `test/skill-catalog.test.js` - glob matching per segment, regex metacharacter
      escaping, block and inline sequences, CRLF frontmatter, tier defaulting, `reminder`
      defaulting and parsing, companion expansion, deduplication, tier ordering,
      backslash paths
- [x] `test/skill-gate.test.js` - path match, companion expansion, subtraction of loaded
      skills, silence when everything is loaded, silence on a non-edit tool, silence on
      an unclaimed path, exit 0 on malformed stdin, transcript cursor across calls and
      after the transcript shrinks
- [x] `test/skills-reminder.test.js` - opt-out honoured, path-triggered skill without an
      opt-out still listed, tier ordering, full trigger text kept, header names the
      Skill tool
- [x] Manual: `hooks/PreToolUse.js` against `widget.h` names `api-design, cpp-coding,
      doxygen, encapsulation, comments`; `tools/skill-gate.js` names `hook-scripts,
      comments`; `test/a.test.js` names `test-driven-development, node-testing`
- [ ] Not verified: behaviour after `node install.js` in a live session - the hook is
      registered but has not run under Claude Code itself yet

## Verify locally

```
npm test
printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"D:/repo/src/widget.h"},"session_id":"x"}' \
  | CLAUDE_CONFIG_DIR="$PWD" node tools/skill-gate.js
```
