### PR TITLE
GH-96: Ignore dot-paths unless the repository names one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-# Project-local Claude Code settings (auto-managed by Claude Code)
-.claude/
+# Dot-paths belong to tools, editors and agent runtimes unless this repository says
+# otherwise. Add an exception below for each one it tracks, rather than a rule per tool.
+.*
+!.gitignore
+!.github/
 
 # Node.js
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### Changed
 
+- A dot-file or dot-directory is now ignored unless `.gitignore` names it as one this repository tracks. Every tool, editor and agent runtime leaves one behind, and each had to be noticed and added by hand before `git status` was quiet again; an untracked directory nobody has got round to sits next to a file that genuinely should have been committed, and trains the reader to skim past both
+
 - `pr-rules` and `issue-rules` skills: the platform commands moved out into `github-cli` and `gitlab-cli`, leaving each rule stated in exactly one place. The process skills keep the rules and point at the platform skill for the command; a `gh` or `glab` change no longer means editing rules that are not about a CLI, and every other consumer of the same commands reads them from one file
 - `commit-rules` skill: added Branch Naming section — `<user>/<type>/<TRACKER-N>/<subject>` format, TRACKER-N omitted when no issue exists
 - `pr-rules` skill: added Workflow section (issue → branch → commits → PR → merge); PR title now uses tracker ID in place of `Type(scope)` when a tracked issue exists; subject starts with uppercase in all variants


### PR DESCRIPTION
## Problem

Every tool that touches this checkout leaves a dot-directory behind, and each one had to be
noticed and added to `.gitignore` by hand before `git status` was quiet again. `.claude/` was
named for that reason; `.serena/` arrived later and has shown up untracked in every
`git status` since.

That is not only noise. An untracked directory nobody has got round to sits next to a file
that genuinely should have been committed, and trains the reader to skim past both - which
this repository has already paid for once, when a new test file was nearly committed without
its tests because it sat among that noise. Filed as GH-96.

## Summary

- A dot-file or dot-directory is ignored unless `.gitignore` names it as one this repository
  tracks.
- `.serena/` and any future tool directory are covered without being named.
- `.gitignore` and `.github/` stay tracked, and new files under `.github/` are still seen.

## Implementation

- `.gitignore` ignores `.*` and re-includes `!.gitignore` and `!.github/`. The set this
  repository owns is two paths, so an exception each is cheaper than a rule per tool and
  needs no upkeep as tools come and go.
- The `.claude/` rule is dropped: `.*` covers it, and leaving both would state the same thing
  twice.
- Already-tracked files are unaffected by `.gitignore`, so nothing is untracked by this
  change.

## Test plan

- [x] `git status --porcelain` shows only this change on an otherwise clean tree
- [x] `git check-ignore -v` names the rule for `.serena/`, `.claude/` and a fabricated
      `.newtool/state.json`
- [x] `git ls-files` still lists `.github/workflows/ci.yml` and `.gitignore`
- [x] A new file under `.github/` shows as untracked rather than being ignored
- [x] `.gitignore` itself is not ignored
- [x] `npm test` - 507 pass, 0 fail
- [x] CI green on node 18, 20, 22

## Decided, not deferred

`.claude/` stays ignored in full, and `.claude/CLAUDE.md` is not tracked. `AGENTS.md` is the
one instruction file this repository ships; a per-runtime pointer duplicating it would be a
second place to keep in step. Nothing in `AGENTS.md`, `README.md` or `CONTRIBUTING.md` claims
otherwise, so no document needs a correction - the rule above already covers the directory
without naming it.

