### PR TITLE
GH-104: Map the development lifecycle onto one table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,19 +282,69 @@ into a pipeline carrying a task from idea to release:
 idea → /spec (spec-architect) → /build (implementer) → /ship (code-reviewer + security-auditor → release-manager)
 ```
 
-| Stage | Command | Agent(s) | Invoke the agent directly, without the command, when… |
-|-------|---------|----------|---------------------------------------------------------|
-| Spec | `/spec` | `spec-architect` | only a spec or ADR is needed, with no follow-on build |
-| Build | `/build` | `implementer` | resuming work on one task that already has a spec |
-| Review | (part of `/ship`) | `code-reviewer` | reviewing a diff that isn't ready to ship yet |
-| Security audit | (part of `/ship`) | `security-auditor` | auditing a change touching a trust boundary, outside a full ship pass |
-| Release | (part of `/ship`) | `release-manager` | cutting a release whose review/audit already happened elsewhere |
-
 Each command is a thin wrapper — see the corresponding `commands/<name>.md` for the
 exact handoff. Skills keep auto-applying contextually per `config/CLAUDE.md`'s "Skills
 — auto-apply" section regardless of which agent or command is active; an agent exists
 to bundle several skills under one persona for a specific pipeline stage, not to
-replace skill auto-apply.
+replace skill auto-apply. When to invoke a persona directly rather than through its
+command is stated in that persona's own Composition section in `agents/<name>.md`.
+
+### Lifecycle map
+
+That pipeline is one axis of a lifecycle two other files state along their own:
+`pr-rules` → Workflow as seven steps from a new task to a closed issue, and
+`issue-rules` → Lifecycle as the four states the issue passes through. This table is the
+only place the three are lined up against each other; every rule stays in the skill that
+owns it, and a stage with no command, no persona or no step of its own says so rather
+than naming the nearest one.
+
+| Stage | Command / persona | `pr-rules` step | Issue state | Skills |
+|-------|-------------------|-----------------|-------------|--------|
+| Intake | — | before 1 | not created yet | `requirements`, `project-planning` |
+| Spec | `/spec` → `spec-architect` | feeds 1 | `Open`, once it exists | `requirements`, `ddd`, `architecture`, `cpp-api-design` |
+| Issue | — | 1 | `Open` | `issue-rules`, `github-cli` / `gitlab-cli` |
+| Branch | — | 2 | → `In Progress` | `commit-rules` → Branch Naming |
+| Build | `/build` → `implementer` | 3 | `In Progress` | `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`; `debugging` on a fix; `commit-rules` per commit |
+| PR | — | 4 | → `In Review` | `pr-rules`, `changelog`, `submodule-sync`, `ci-cd-and-automation`, `github-cli` / `gitlab-cli` |
+| Review | `/ship`, or `/review-loop` to iterate → `code-reviewer` | none; step 6 waits on it | `In Review` | `code-review-and-quality`, `cpp-api-design`, `cpp-encapsulation`, `comments` / `cpp-doxygen`, `pr-rules` |
+| Security audit | `/ship`, or `/review-loop` to iterate → `security-auditor` | none; step 6 waits on it | `In Review` | `security-and-hardening`, `pr-rules` |
+| Pre-merge check | — | 5 | `In Review` | `pr-rules` → Pre-Merge Checklist, `issue-rules` → Progress Comments, `github-cli` / `gitlab-cli` |
+| Merge | — | 6 | `In Review` | `pr-rules` → Merge Strategy, `commit-rules`, `github-cli` / `gitlab-cli` |
+| Close | — | 7 | issue closed; not `Done` until deployed (`issue-rules` → Lifecycle), or left `In Review` with a follow-up linked | `issue-rules` → Lifecycle, `github-cli` / `gitlab-cli` |
+| Release | `/ship` on a go verdict → `release-manager` | after 7 | → `Done` | `changelog`, `release`, `shipping-and-launch`, `submodule-sync` |
+
+No file assigns issue-state transitions to a role: `issue-rules` → Lifecycle defines each
+state by a condition — branch exists, PR open, merged and deployed — rather than by an
+act with an actor. The acts reserved to the human are the merge (`pr-rules` → Merge
+Strategy 2) and submitting review feedback (Pending by Default), which Merge Strategy 2
+names as the lighter act it follows. The issue comments steps 1, 5 and 7 require
+are the one kind of issue comment `pr-rules` → Pending by Default leaves an agent free to
+publish.
+
+Where the two axes do not line up one-to-one:
+
+- **`/spec` against step 1.** `commands/spec.md` takes an idea or a task description and
+  names no tracker, so the spec may be written before the issue exists or against one
+  that already does. What both sides fix is the issue's content rather than the order: an
+  issue without a test plan (and, for features, acceptance criteria) is not ready to
+  implement against — the criteria from `requirements`, the test plan from `issue-rules`
+  → Description Template.
+- **`/build` against step 3.** It implements one task from the spec, so a branch whose
+  issue holds several tasks runs it several times. It neither names the branch (step 2)
+  nor opens the PR (step 4).
+- **`/ship` against steps 5 and 6.** It neither replaces them nor wraps them: its review
+  pass is what step 6 waits on, its `release-manager` hand-off is the Release row, and
+  steps 5, 6 and 7 sit between the two under no command at all.
+- **Uncovered stages.** Intake, and steps 1, 2, 4, 5, 6 and 7 — issue, branch, PR,
+  pre-merge check, merge, close — have no command and no persona; they are carried out
+  directly under the skill the row names. Only step 6 states why: Merge Strategy 2 gives
+  the merge to the human.
+- **The Release row does not run once per pass.** `changelog` → On Release renames one
+  `[Unreleased]` section covering everything merged since the previous version, so one
+  release gathers the closed issues of many passes.
+- **The changelog entry sits on both axes.** `pr-rules` → Pre-Open Checklist requires
+  `CHANGELOG.md` updated before step 4; `commands/ship.md` has `release-manager` prepare
+  the entry after review. Unresolved — see GH-105.
 
 ## Installation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### Changed
 
+- The development lifecycle was stated twice along axes that never referenced each other — `pr-rules` → Workflow's seven steps, and `AGENTS.md`'s pipeline of commands and personas — so nothing said whether `/build` is step 3 or steps 2 to 4, or where planning and release sit. `AGENTS.md` → Idea-to-Release Pipeline now carries a lifecycle map: one row per stage against the seven steps, the `issue-rules` state the issue is in, and the skills that apply there. Both ends are on it, and a stage no command or persona covers says so rather than naming the nearest one; `pr-rules` → Workflow points at it
+
 - A dot-file or dot-directory is now ignored unless `.gitignore` names it as one this repository tracks. Every tool, editor and agent runtime leaves one behind, and each had to be noticed and added by hand before `git status` was quiet again; an untracked directory nobody has got round to sits next to a file that genuinely should have been committed, and trains the reader to skim past both
 
 - `pr-rules` and `issue-rules` skills: the platform commands moved out into `github-cli` and `gitlab-cli`, leaving each rule stated in exactly one place. The process skills keep the rules and point at the platform skill for the command; a `gh` or `glab` change no longer means editing rules that are not about a CLI, and every other consumer of the same commands reads them from one file

--- a/README.md
+++ b/README.md
@@ -120,15 +120,18 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 
 Persona subagents forming an idea-to-release pipeline. Each is scoped to one stage and
 carries the `Skill` tool to load the skills it applies, rather than restating their rules
-— see `AGENTS.md` → "Adding an agent".
+— see `AGENTS.md` → "Adding an agent". Where each stage sits against the `pr-rules`
+Workflow steps and the issue lifecycle, and which stages no agent or command covers, is
+mapped in `AGENTS.md` → Lifecycle map. When to invoke a persona directly rather than
+through its command is stated in that persona's own Composition section.
 
-| Agent | Stage | Skills applied |
-|-------|-------|-----------------|
-| `spec-architect` | Idea → spec → architecture | `requirements`, `ddd`, `architecture`, `cpp-api-design` |
-| `implementer` | Implementation (TDD) | `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing` |
-| `code-reviewer` | Review | `code-review-and-quality`, `cpp-encapsulation`, `cpp-api-design`, `comments`, `cpp-doxygen`, `pr-rules` |
-| `security-auditor` | Security audit | `security-and-hardening`, `pr-rules` |
-| `release-manager` | Release | `changelog`, `release`, `shipping-and-launch` |
+| Agent | Stage |
+|-------|-------|
+| `spec-architect` | Spec |
+| `implementer` | Build |
+| `code-reviewer` | Review |
+| `security-auditor` | Security audit |
+| `release-manager` | Release |
 
 ## Commands
 

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -27,6 +27,8 @@ End-to-end order of actions from a new task to a merged, closed issue. Steps run
 
 Every step that touches the tracker or the PR is carried out with the hosting platform's CLI — `github-cli` for `gh`, `gitlab-cli` for `glab`. This skill states what must be true at each step; the platform skill states the command that gets there.
 
+Where the repository provides one, its `AGENTS.md` → Lifecycle map lines these steps up against the pipeline stage, command and persona behind each, the `issue-rules` state the issue sits in meanwhile, and what runs before step 1 and after step 7. The steps themselves stay here.
+
 **1. Scope and issue** — before any code change:
 - Identify the repository the change belongs to (root repo or a submodule); the issue is created and tracked there, not in the root repo.
 - Search the tracker for an existing issue covering the task. If found, check it has a test plan and, for features, acceptance criteria (`issue-rules` → Description Template); if incomplete for this task, update the issue before writing code.


### PR DESCRIPTION
## Problem

The development lifecycle was described twice, along two axes that never referenced each
other: `pr-rules` → Workflow as seven steps from a new task to a closed issue, and
`AGENTS.md` → Idea-to-Release Pipeline as `/spec` → `/build` → `/ship` with a stage table.
`grep` for `/spec`, `/build` or `/ship` in `pr-rules` returned nothing, and `AGENTS.md` never
mentioned the seven steps.

So a reader could not tell whether `/build` is step 3 or steps 2 to 4, whether `/ship`
replaces steps 5 and 6 or wraps them, where `requirements` and `project-planning` attach, or
who moves an issue between `issue-rules` lifecycle states. Everything was written down; how
the pieces line up was not. Filed as GH-104.

## Summary

- One table lines the pipeline stages up against the `pr-rules` steps, the `issue-rules`
  state, and the skills that apply at each point.
- The ends of the cycle are on it: where `requirements` and `project-planning` run before an
  issue exists, and where `release` and `shipping-and-launch` run after it closes.
- A stage no command or persona covers says so. Six of twelve rows are uncovered, and only
  one of them states a reason.
- `pr-rules` → Workflow and `README.md` point at the map instead of implying a
  correspondence neither stated.

## Implementation

- The map lives in `AGENTS.md` → Idea-to-Release Pipeline. The old stage table folded into
  it: three of its four columns are now the map's, and its fourth duplicated the
  `**Invoke directly when:**` line each persona's Composition section already carries.
- No rule moved. Every cell references the skill that owns the rule, and the correspondence
  is stated in exactly one place.
- Where the axes do not line up, the map says so rather than inventing a correspondence: six
  bullets cover `/spec` against step 1, `/build` against step 3, `/ship` against steps 5 and
  6, the uncovered stages, why the Release row does not run once per pass, and the changelog
  timing conflict below.
- `issue-rules` defines each state by a condition rather than by an act, so the map states
  that no file assigns a transition to a role, instead of supplying an actor model the
  sources do not have.
- The `pr-rules` pointer is conditional - "where the repository provides one" - because
  `install.js` does not ship the root `AGENTS.md`, and that skill is loaded in repositories
  whose `AGENTS.md` is a different file.

## Test plan

- [x] `npm test` - 512 pass, 0 fail
- [x] Every row's `pr-rules` step and issue-state cell checked against `skills/pr-rules` and
      `skills/issue-rules`
- [x] Every `—` in the command column checked against all four files in `commands/`
- [x] Every skill named on the map exists under `skills/`
- [x] The claim that no file assigns a state transition to a role, checked by grep
- [x] The deleted fourth column checked against all five personas' Composition sections
- [x] `node install.js --dry-run` confirms the root `AGENTS.md` does not ship, which is what
      the conditional pointer is for
- [x] No second copy of the correspondence in `README.md`, `CONTRIBUTING.md`,
      `config/CLAUDE.md` or under `skills/`
- [x] CI green on node 18, 20, 22

## Found by the map, filed rather than fixed

- **GH-105**: `pr-rules` → Pre-Open Checklist requires `CHANGELOG.md` updated before the PR
  opens; `commands/ship.md` has `release-manager` prepare the entry after review. Both are
  followed today by different parts of the pipeline. The map names the conflict and resolves
  nothing - resolving it changes a rule.
- `project-planning` is named by no persona and no command, while `issue-rules` expects an
  issue to carry a milestone that nothing in the pipeline produces.
- Neither `github-cli` nor `gitlab-cli` documents an issue-close command, though step 7 and
  `issue-rules` → Lifecycle both require closing an issue.
- `issue-rules` → Lifecycle has no name for the state the Close row describes: merged and
  closed in the tracker, not yet deployed, therefore neither `Done` nor `Closed`.

