### PR TITLE
GH-109: State each rule where it is owned, not where it drifted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,17 @@ Configuration repository for Claude Code.
 ## Repository layout
 
 ```
-hooks/      Event dispatcher scripts (PreToolUse, PostToolUse, Stop)
+hooks/      Event dispatcher scripts (PreToolUse, PostToolUse, Stop, SessionStart,
+            UserPromptSubmit), and hooks/git/ which install writes to .git/ instead
 tools/      Atomic tool scripts invoked by hooks
 skills/     Skill definitions loaded by /skill-name slash commands
 agents/     Persona subagent definitions (one markdown file per agent)
 commands/   Slash command definitions (one markdown file per command)
-settings.json   Portable global Claude Code configuration
+config/     What install deploys as configuration: settings.json, the CLAUDE.md it
+            writes to ~/.claude/, and retired.json — paths this repo no longer ships
+lib/        Pure helpers shared by install.js and uninstall.js
+templates/  Starting points for a new skill, agent or command
+test/       One test file per unit, run by npm test
 install.js  Bootstrap script — copies files to ~/.claude/
 ```
 
@@ -357,13 +362,15 @@ node uninstall.js            # full restore to pre-install state
 
 `settings.json` is JSON-merged into `~/.claude/settings.json`; existing machine-specific settings are preserved (`defaultMode`, user `allow`/`ask`/`deny` entries). Every file install overwrites is copied into `.claude-config-backups` and recorded before it is written — `settings.json` alone is exempt, because it is merged and reverted by subtracting install's own additions rather than snapshot-replaced. A manifest at `~/.claude/.claude-config-manifest.json` records every created file and every backup so `uninstall.js` can restore the exact prior state byte-for-byte.
 
+What the git-hook step installs, and the single repository it applies to, is stated in `README.md` → Installation.
+
 ## Tests
 
 ```
 npm test
 ```
 
-Tests live in `test/<name>.test.js` using node's built-in `node:test` runner. They cover regex correctness (bash-safety, secret-guard), escape functions (stop-notify), and install/uninstall round-trip against a temp `CLAUDE_CONFIG_DIR`.
+Tests live in `test/<name>.test.js` using node's built-in `node:test` runner. What the suite covers is stated in `README.md` → Tests.
 
 ## Commit conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### Changed
 
+- `CONTRIBUTING.md` no longer carries a branch pattern and a commit-type list that contradict `commit-rules`, nor a five-step recipe for adding a skill that left it reaching no agent at all - the template it started from ships an opt-out from the every-prompt reminder and a placeholder path glob, and the recipe named neither. Each rule now comes from the file that owns it, and the order of work from `pr-rules` -> Workflow and the lifecycle map rather than a third partial account. `README.md`'s manual setup installs what `node install.js` installs and names what it cannot cover: nothing is backed up, and `uninstall.js` has no record to reverse. The git pre-commit hook is stated to apply to this checkout alone
+
 - The development lifecycle was stated twice along axes that never referenced each other — `pr-rules` → Workflow's seven steps, and `AGENTS.md`'s pipeline of commands and personas — so nothing said whether `/build` is step 3 or steps 2 to 4, or where planning and release sit. `AGENTS.md` → Idea-to-Release Pipeline now carries a lifecycle map: one row per stage against the seven steps, the `issue-rules` state the issue is in, and the skills that apply there. Both ends are on it, and a stage no command or persona covers says so rather than naming the nearest one; `pr-rules` → Workflow points at it
 
 - A dot-file or dot-directory is now ignored unless `.gitignore` names it as one this repository tracks. Every tool, editor and agent runtime leaves one behind, and each had to be noticed and added by hand before `git status` was quiet again; an untracked directory nobody has got round to sits next to a file that genuinely should have been committed, and trains the reader to skim past both

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,49 @@
 # Contributing
 
-## Commit format
+## Workflow
 
-Conventional Commits — see `skills/commit-rules/SKILL.md` for full rules.
+The order of work - issue, branch, commits, PR, pre-merge check, merge, close - is stated
+in full in `skills/pr-rules/SKILL.md` -> Workflow, and lined up against the pipeline
+stage, the state the issue is in and the skills that apply in `AGENTS.md` -> Lifecycle
+map. Follow those two; this file does not carry a third version of them.
 
-```
-type(scope): subject
-```
+## Commits and branches
 
-Types: `feat`, `fix`, `refactor`, `docs`, `chore`, `test`, `ci`.
-Subject: imperative mood, lowercase after colon, ≤ 72 chars total.
-Body: describe what changed and why. Do not enumerate file names or reference commit hashes.
+Conventional Commits. The message format, the type vocabulary, the body and the branch
+name pattern are owned by `skills/commit-rules/SKILL.md` - read it before the first
+commit rather than copying the shape of a nearby one.
 
-No `Co-Authored-By` or AI-attribution trailers.
+Two of its rules are enforced rather than left to the reader: this checkout's pre-commit
+hook rejects a commit made directly on a protected branch (`main`, `master`, `dev`,
+`develop`), and the `commit-trailer-guard` tool blocks
+a `git commit` an agent runs with an AI-attribution trailer in the message.
 
 ## Hook and tool scripts
 
-- Node.js built-ins only — no npm, no third-party `require`
-- No hardcoded paths — use `process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude')`
-- Exit codes: `0` = allow/warn (stdout), `2` = block (stderr). Never `1`.
+Node built-ins only, and no shell logic inside a script - the only shell is the `node -e`
+launcher in `settings.json`; no hardcoded paths, `process.env.CLAUDE_CONFIG_DIR ||
+path.join(os.homedir(), '.claude')` instead; exit `0` to allow or warn on stdout and `2`
+to block on stderr, never `1`. That is the short form of
+`skills/hook-scripts/SKILL.md` -> Hard Rules and Exit Codes, which the rest of a patch to
+`hooks/` or `tools/` is read against.
 
-See `skills/hook-scripts/SKILL.md` for full conventions.
+A new tool also has to be routed to and covered by a test, or nothing ever runs it - see
+`AGENTS.md` -> Adding a new tool check for the steps.
 
 ## Skills
 
-Each skill lives in `skills/<name>/SKILL.md`. Skills are plain Markdown loaded
-by Claude Code at runtime — no build step.
+A skill is one file, `skills/<name>/SKILL.md`, plain Markdown loaded at runtime with no
+build step. Keep its content to rules and patterns, not explanations of why Claude Code
+behaves the way it does.
 
-Keep skill content focused on rules and patterns, not explanations of why
-Claude Code works the way it does.
+Creating that file is not the whole job: the frontmatter decides when the skill is
+triggered and at which tier, the ownership map states its boundary against its
+neighbours, and `config/CLAUDE.md` carries its auto-apply line, which the session-start
+check warns about while it is missing. `AGENTS.md` -> Adding a skill carries the steps,
+from the pre-flight check against that map through to `node install.js`;
+`AGENTS.md` -> Renaming or retiring a skill covers the other direction.
 
-Use `templates/SKILL.md` as the starting template when creating a new skill:
+## Tests
 
-1. Copy `templates/SKILL.md` to `skills/<name>/SKILL.md`
-2. Fill in frontmatter (name, description, tags)
-3. Write rules sections following the template structure
-4. Add entry to the skill table in `README.md`
-5. Run `node install.js` to deploy
-
-## Branches
-
-Work on feature branches. Direct commits to `main` are blocked by the pre-commit hook.
-
-Branch naming: `<owner>/feat/<topic>`, `<owner>/fix/<topic>`, `<owner>/chore/<topic>`.
+Run `npm test` before opening a PR. Conventions for the files under `test/` are in
+`skills/node-testing/SKILL.md`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pipeline of persona agents and commands built on top of them.
 | `skills/` | Skill definitions (SKILL.md files loaded by `/skill-name`) |
 | `agents/` | Persona subagent definitions (one markdown file per agent) |
 | `commands/` | Slash command definitions (one markdown file per command) |
-| `config/settings.json` | Portable global configuration (hooks, permissions, statusline) |
+| `config/` | What install deploys as configuration: `settings.json` (hooks, permissions, statusline), the `CLAUDE.md` it writes to `~/.claude/`, and `retired.json` - paths this repo no longer ships, which install warns about but never deletes |
 
 ## Hooks
 
@@ -152,8 +152,10 @@ Requires Node.js (no npm packages needed).
 node install.js
 ```
 
-Copies `hooks/`, `tools/`, `skills/`, `agents/`, and `commands/` into `~/.claude/` and
-merges `config/settings.json` into `~/.claude/settings.json` (existing machine-specific
+Copies `hooks/` (without `hooks/git/`, which is not part of `~/.claude/`), `tools/`,
+`agents/` and `commands/` into `~/.claude/`, one `SKILL.md` per skill into
+`~/.claude/skills/<name>/`, and `config/CLAUDE.md` to `~/.claude/CLAUDE.md`;
+`config/settings.json` is merged into `~/.claude/settings.json` (existing machine-specific
 settings are preserved). `agents/` and `commands/` are optional — installing without
 either is not an error. Every file install overwrites is backed up and recorded before it
 is written — `settings.json` alone is exempt, because it is merged and reverted by
@@ -182,31 +184,83 @@ node uninstall.js              # full restore using manifest
 node uninstall.js --dry-run    # preview what would be restored
 ```
 
+`hooks/git/pre-commit` is the one file install writes outside `~/.claude/`, and it goes
+into this checkout's own `.git/hooks/pre-commit`. No other repository on the machine
+receives it, so the checks it carries apply to work on this repository alone - among them
+a refusal to commit at all until `user.name` and `user.email` are set locally, the block
+on committing to a protected branch, and a `clang-format` pass over staged C/C++ files.
+`--no-git-hook` skips that one copy and leaves the rest of the install unchanged.
+
 ## Tests
 
 ```
 npm test
 ```
 
-Uses node's built-in `node:test` runner. Covers safety regexes, shell-escape functions,
-and install/uninstall round-trip in a temporary `CLAUDE_CONFIG_DIR`.
-
-See [install.js](install.js) for details.
+Uses node's built-in `node:test` runner, so there is nothing to install first. Each
+`test/<name>.test.js` takes one unit: a tool, the dispatcher that routes to it, or a step
+of install. Between them they exercise the payloads a guard decides on and the decision it
+returns, the skill and agent frontmatter the routing reads, the `settings.json` merge, and
+an install/uninstall round trip against a temporary `CLAUDE_CONFIG_DIR` rather than the
+real one.
 
 ## Manual setup
 
-Copy the directories manually:
+For a machine without Node, or to see exactly what lands where. The copies below place
+the same files `node install.js` does; the two steps after them are the ones no copy
+reproduces.
 
-```
+```powershell
 # Windows (PowerShell)
-Copy-Item -Recurse hooks $env:USERPROFILE\.claude\hooks
-Copy-Item -Recurse tools $env:USERPROFILE\.claude\tools
-Copy-Item -Recurse skills $env:USERPROFILE\.claude\skills
-Copy-Item -Recurse agents $env:USERPROFILE\.claude\agents
-Copy-Item -Recurse commands $env:USERPROFILE\.claude\commands
-
-# Linux / macOS
-cp -r hooks tools skills agents commands ~/.claude/
+$dest = "$env:USERPROFILE\.claude"
+foreach ($d in 'hooks', 'tools', 'agents', 'commands', 'skills') {
+    New-Item -ItemType Directory -Force "$dest\$d" | Out-Null
+}
+Get-ChildItem hooks -Exclude git | Copy-Item -Destination "$dest\hooks" -Recurse -Force
+Copy-Item -Recurse -Force tools\*    "$dest\tools"
+Copy-Item -Recurse -Force agents\*   "$dest\agents"
+Copy-Item -Recurse -Force commands\* "$dest\commands"
+Get-ChildItem skills -Directory | ForEach-Object {
+    New-Item -ItemType Directory -Force "$dest\skills\$($_.Name)" | Out-Null
+    Copy-Item "$($_.FullName)\SKILL.md" "$dest\skills\$($_.Name)\SKILL.md"
+}
+Copy-Item config\CLAUDE.md "$dest\CLAUDE.md"
 ```
 
-Then copy or merge `settings.json` into `~/.claude/settings.json`.
+```sh
+# Linux / macOS
+dest=~/.claude
+mkdir -p "$dest"/hooks "$dest"/tools "$dest"/agents "$dest"/commands "$dest"/skills
+for f in hooks/*; do
+    [ "$(basename "$f")" = git ] || cp -R "$f" "$dest/hooks/"
+done
+cp -R tools/* "$dest/tools/"
+cp -R agents/* "$dest/agents/"
+cp -R commands/* "$dest/commands/"
+for d in skills/*/; do
+    [ -f "$d/SKILL.md" ] || continue
+    mkdir -p "$dest/skills/$(basename "$d")"
+    cp "$d/SKILL.md" "$dest/skills/$(basename "$d")/SKILL.md"
+done
+cp config/CLAUDE.md "$dest/CLAUDE.md"
+```
+
+`hooks/git/` is left out on purpose: nothing under `~/.claude/` reads it. Each skill
+contributes its `SKILL.md` and nothing else from its directory, which is why the skills
+are copied one at a time rather than as a tree.
+
+Two steps remain:
+
+- **`config/settings.json`.** Copy it to `~/.claude/settings.json` if that file does not
+  exist yet. If it does, merge by hand: add this repository's `hooks` entries and
+  `permissions` to what is already there, and take over the single `statusLine` slot. A
+  plain copy would drop every machine-local setting the file already holds.
+- **The git pre-commit hook**, if you want it in this checkout: copy `hooks/git/pre-commit`
+  to `.git/hooks/pre-commit` and make it executable. It applies to this repository only,
+  as under `node install.js` above.
+
+Manual setup writes no manifest, so it cannot be undone by `node uninstall.js` - that
+command reverses what `install.js` recorded, and knows nothing about files copied by
+hand. Nothing is backed up either: an existing `~/.claude/CLAUDE.md` or `settings.json` is
+overwritten and gone. Re-running the copies upgrades the files this checkout ships, but
+leaves behind any file an earlier version installed and this one no longer has.


### PR DESCRIPTION
## Problem

`CONTRIBUTING.md` and parts of `README.md` stated things the code and the skills contradict.
A contributor following them wrote a branch name the skill rejects, used a commit type the
vocabulary does not include, and added a skill missing four of the steps the ceremony
requires - including the frontmatter that decides whether the skill is triggered at all.

`README.md`'s manual setup put `hooks/git/pre-commit` under `~/.claude/hooks/git/` where
nothing reads it, and omitted `config/CLAUDE.md` entirely, so a manual install silently lost
the global instructions. Its Tests section named three areas as though they were the whole
suite. Nothing anywhere said the git pre-commit hook lands in this repository's own `.git`
only, so its branch protection and `clang-format` pass apply here and in no project a user
works on. Filed as GH-109.

## Summary

- `CONTRIBUTING.md` states no rule another file owns; it points at the file that does.
- The manual setup installs what `node install.js` installs, and names the two steps no copy
  reproduces plus what it can never do - no manifest, no backup, no pruning.
- The git pre-commit hook's single repository is stated where the flag skipping it is
  offered.
- `AGENTS.md`'s repository layout matches the repository again.

## Implementation

- Every wrong copy was replaced by a reference, not by a corrected copy: branch naming and
  the type vocabulary to `commit-rules`, the skill ceremony to `AGENTS.md`, the order of work
  to `pr-rules` → Workflow and the lifecycle map.
- Two pieces of prose were kept deliberately, both stating something no skill does: the
  hook and tool hard rules, labelled as the short form with the owner named, because they
  decide whether a patch is admissible at all; and which machinery enforces which commit
  rule. The second is qualified to an agent's commit - `commit-trailer-guard` reads a hook
  payload, so a human typing `git commit` is never intercepted.
- `AGENTS.md` hands the two descriptive facts it duplicated - what the git-hook step installs
  and what the suite covers - to `README.md`, and keeps every normative rule itself. A
  pointer out of the auto-loaded file costs a read, so only facts an agent does not need on
  every task go behind one.

## Test plan

- [x] `npm test` - 512 pass, 0 fail
- [x] Both manual-setup blocks run into scratch directories and diffed against a real
      install: the only differences are `.claude-config-manifest.json` and `settings.json`,
      which the section names as not reproduced. Verified independently a second time,
      including a re-run over a populated tree to check the upgrade path
- [x] Every rule the old `CONTRIBUTING.md` stated checked against the file that now owns it,
      so nothing was lost rather than referenced
- [x] Every pointer followed to an existing section
- [x] The pre-commit hook's checks read from `hooks/git/pre-commit`, the guard's reach from
      `tools/commit-trailer-guard.js`, the copy semantics from `install.js`
- [x] No non-ASCII in prose added to the human-facing files, and no untouched line converted
- [x] CI green on node 18, 20, 22

## Corrected while writing this

The issue claimed a skill added by the old five steps "reaches no agent, because nothing
declares when it applies". I corrected that to a weaker statement, having checked that
`loadCatalog` defaults `tier` and `reminder` when the keys are absent - then the review
showed the correction was itself wrong for the path the recipe prescribed. Step 1 was "copy
`templates/SKILL.md`", and the template ships `reminder: false` and a placeholder glob, so
such a skill reaches neither the reminder nor the gate. The original claim was right; the
shipped text states the verified version. Filed as GH-110.

## Follow-ups

- **GH-110**: a skill built from `templates/SKILL.md` reaches no agent.
- `commit-rules` and `AGENTS.md` both describe the pre-commit hook as blocking `main` alone,
  where it protects four branches. The owner is `commit-rules`; not touched here, since this
  change may not edit `skills/`.
- `AGENTS.md` still repeats `README.md`'s installation account nearly verbatim. Pre-existing,
  and the same one-fact-one-place question this change answers for two adjacent sentences.

