### PR TITLE
GH-119: Run the test suite on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,7 @@
 ### CI
 
 - GitHub Actions workflow running `npm test` on Node 18, 20, 22 on every push and PR to `main`
+
+- The suite runs on Windows as well as Linux, on every node version in the matrix. This repository installs into a Windows config directory and is developed there, so a green run on Linux alone said nothing about the platform the code is written for. Every combination reports as its own job and none cancels another, so a failure names the platform it belongs to
+
+- `npm test` no longer depends on the shell to expand a glob. The script carried `test/*.test.js`, which npm hands to `cmd.exe` unexpanded on Windows, so on node 18 and 20 no test ran at all. `node --test` finds the test files itself, whichever shell ran the script

--- a/README.md
+++ b/README.md
@@ -199,9 +199,10 @@ npm test
 Uses node's built-in `node:test` runner, so there is nothing to install first. Each
 `test/<name>.test.js` takes one unit: a tool, the dispatcher that routes to it, or a step
 of install. Between them they exercise the payloads a guard decides on and the decision it
-returns, the skill and agent frontmatter the routing reads, the `settings.json` merge, and
-an install/uninstall round trip against a temporary `CLAUDE_CONFIG_DIR` rather than the
-real one.
+returns, the skill and agent frontmatter the routing reads, the `settings.json` merge, an
+install/uninstall round trip against a temporary `CLAUDE_CONFIG_DIR` rather than the real
+one, and the rule that every file under `test/` is a test file, since the runner loads
+each of them as one.
 
 ## Manual setup
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "type": "commonjs",
   "license": "Unlicense",
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test"
   }
 }

--- a/skills/node-testing/SKILL.md
+++ b/skills/node-testing/SKILL.md
@@ -142,5 +142,17 @@ directory behind, and must not skip cleanup either.
 ```bash
 npm test
 # equivalent to:
-node --test "test/**/*.test.js"
+node --test
 ```
+
+Pass no path. `node --test` walks the tree itself: anywhere under a directory named
+`test` it loads every `.js`, `.cjs` and `.mjs` file whatever its name, and elsewhere the
+files matching `*.test.js`, `*-test.js`, `*_test.js`, `test-*.js` or `test.js`. Every
+file under `test/` therefore has to stand alone as a test file — a shared helper put
+there is loaded and run as one, giving a passing test nobody wrote, or a red suite when
+its top-level code throws. That is why the fixture helpers above are repeated in each
+file, and `test/test-layout.test.js` holds the directory to it.
+
+A glob written into the script is expanded by the shell instead: `cmd.exe`, which npm
+runs a script through on Windows, does not expand one, and node does so itself only from
+version 22 — so on node 18 and 20 a script carrying a glob finds no test file at all.

--- a/test/test-layout.test.js
+++ b/test/test-layout.test.js
@@ -1,0 +1,31 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const testDir = __dirname;
+
+// `node --test` loads every .js, .cjs and .mjs file under a directory named `test`,
+// recursively and whatever its name.
+function scriptsUnder(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return scriptsUnder(full);
+    return /\.(js|cjs|mjs)$/.test(entry.name) ? [path.relative(testDir, full)] : [];
+  });
+}
+
+function loadedScripts() {
+  const scripts = scriptsUnder(testDir);
+  // A vacuous pass would hide the walk reaching nothing at all.
+  if (scripts.length === 0) throw new Error(`no script files under ${testDir}`);
+  return scripts;
+}
+
+test('every script under test/ is itself a test file', () => {
+  for (const script of loadedScripts()) {
+    assert.ok(script.endsWith('.test.js'),
+      `${script} is loaded and run as a test by \`node --test\`, so it has to be one`);
+  }
+});


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` ran the suite on `ubuntu-latest` alone. This repository is
developed on Windows and installs into a Windows config directory, so the platform the code
is written for was the one nothing verified: the `win32` branch of `tools/stop-notify.js`,
the backslash normalisation in `matchSkills`, the CRLF stripping in `parseFrontmatter`, and
the byte-for-byte install/uninstall round trip, whose exposure is the path separator itself.

Adding the platform turned up a defect in the suite's own entry point. `package.json` ran
`node --test test/*.test.js`, and npm runs a script through `cmd.exe` on Windows, which does
not expand a glob. Node expands one itself only from version 22, so on node 18 and 20 the
command found no test file and exited 1 without running anything.

## Summary

- The suite runs on Windows as well as Linux, on every node version in the matrix, each
  combination reporting as its own job so a failure names the platform it belongs to.
- `npm test` no longer depends on which shell ran it.
- Every file under `test/` is now held to being a test file, since the runner loads each one
  as one.

## Implementation

- `.github/workflows/ci.yml` gains `os: [ubuntu-latest, windows-latest]` and
  `runs-on: ${{ matrix.os }}`. `fail-fast: false` is deliberate: under the default the first
  red cell cancels the rest, which destroys the signal the platform was added for.
- `package.json` runs `node --test` with no path. The narrower `node --test test/` was
  rejected by measurement, not preference - node 22 tries to execute the directory as a
  module and fails with `MODULE_NOT_FOUND`, trading a broken 18/20 for a broken 22.
- `skills/node-testing/SKILL.md` states the discovery rule that replaces the glob. It is
  wider than the old list: every `.js`, `.cjs` and `.mjs` file under a directory named
  `test`, whatever its name, plus five name patterns elsewhere in the tree. The sets coincide
  today only because every file under `test/` happens to be a `*.test.js`.
- `test/test-layout.test.js` holds that invariant. Without it, the obvious next step from the
  skill's own Filesystem Fixtures section - moving `mkTmp`/`rmTmp` into `test/helpers.js` -
  gives a passing test nobody wrote, or a red suite when the helper's top-level code throws.

## Test plan

- [x] The workflow run on this branch shows a Windows job per node version:
      `test (windows-latest, 18 | 20 | 22)`, all six cells green
- [x] Every job ran the whole suite rather than none of it - all six report the same test
      count, so discovery finds the same set on both platforms and all three versions
- [x] A deliberately failing test fails the Windows job. Checked on a throwaway branch rather
      than this one: all six cells went red and none cancelled another, which is `fail-fast`
      doing its job as well
- [x] `npm test` locally on Windows
- [x] The defect this change fixes, reproduced before fixing it: the real `npm test` through
      `cmd.exe` against the official portable builds of 18.20.8, 20.20.2 and 22.23.2 - the
      first two exit 1 with `Could not find`, the third runs the suite
- [x] `test/test-layout.test.js` fails against a real `test/helpers.js` and passes once it is
      removed

## Known gaps, named rather than left implicit

- `tools/stop-notify.js`'s `win32` branch is the first motivation in GH-119 and this change
  does not reach it. `NOTIFIERS[os.platform()]` is dispatched only under
  `require.main === module`, which no test triggers on any platform, so no CI job could cover
  it. Filed as #120.
- Whether the Windows job exercises the CRLF path depends on the runner's `core.autocrlf`,
  which nothing in the repository pins - there is no `.gitattributes` and the committed blobs
  are LF. That coverage is incidental rather than guaranteed.
- The workflow carries no `permissions:` block and pins both actions by major tag rather than
  SHA. Both pre-existing and untouched here; they belong to a security pass over
  `.github/workflows/ci.yml`.
- `on: push` on every branch plus `pull_request` on `main` means a push to a PR branch now
  triggers twelve jobs where it triggered six. Pre-existing duplication, doubled by the
  matrix; a `concurrency` group would settle it.
