### PR TITLE
GH-113: Reconcile the changelog section against the previous release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ one references it — a second statement is not emphasis, it is a copy that drif
 agent reading both has nothing telling it which one wins.
 
 - `architecture` — how modules, services and processes fit together; ADR format; tradeoff axes. Hands off a single interface's own hygiene to `cpp-api-design`, modelling inside one context to `ddd`, the requirement behind the decision to `requirements`.
-- `changelog` — the `CHANGELOG.md` file: subsections, bullet wording, what goes in, the release-time rename. Hands off the version number to `release`, the definition of a breaking change to `cpp-api-design`.
+- `changelog` — the `CHANGELOG.md` file: subsections, bullet wording, what goes in, the release-time reconciliation and rename. Hands off the version number to `release`, the definition of a breaking change to `cpp-api-design`.
 - `ci-cd-and-automation` — the pipeline producing the "CI green" signal: what it gates, stage order, flaky checks, who owns a red build. Hands off the per-language checks to `cpp-coding`/`hook-scripts`, merge gating to `pr-rules`, tag automation to `release`, pipeline credentials to `security-and-hardening`.
 - `code-review-and-quality` — what a review looks for: the five axes, change size, dependency bumps, orphaned code. Hands off how a finding is worded to `pr-rules`, security depth to `security-and-hardening`, performance depth to `performance-optimization`, public-surface and access review to `cpp-api-design`/`cpp-encapsulation`.
 - `comments` — a comment in any language, whatever marker opens it: whether one is justified at all, its length, its timeless character. Hands off Doxygen blocks to `cpp-doxygen`, case history to `commit-rules`.

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -67,6 +67,39 @@ Use only what applies. Order:
 
 ## On Release
 
-1. Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` (today's date)
-2. Prepend a new empty `## [Unreleased]` section above it
-3. Leave empty subsections out — add them only when there's content
+1. Reconcile the section against the previous release. The reader's baseline is the last
+   version they can have, so a bullet is an entry only when the state it is measured
+   against reached that version. A bullet measured against something introduced in
+   the same `[Unreleased]` section — "X now does Y instead of Z", a `### Fixed` bullet
+   for a defect that never reached a release — describes a transition no release
+   contained. It is not an entry but an edit to the bullet that introduced the thing —
+   under `### Added`, or under `### CI` when that is where it arrived: fold what it says
+   about the shipped state into that bullet, and delete the bullet you took it from. Drop
+   it outright when that bullet already describes the shipped state. A thing introduced
+   and removed in the same section shipped nothing, so both bullets go; one introduced
+   and deprecated ships deprecated, so correct the `### Added` bullet and keep the
+   `### Deprecated` entry, the section a reader scans before upgrading. A change measured
+   against the previous release is a real `### Changed` entry and stays.
+   - Reconcile clause by clause: one bullet can carry a change against the previous
+     release beside an edit to an unreleased one, or several unreleased edits folding
+     into different `### Added` bullets.
+   - Test the `### Added` bullet's claim, not its form. Fold when the unreleased change
+     leaves that bullet wrong about what ships or short of it: the parts it lists are
+     read as all of them, and a qualifier it states (`on every edited C++ file`) as
+     holding. A gloss that qualifies nothing (`blocks credential leaks`) survives a
+     change widening only the surface it runs on, and fails one widening the class it
+     names. Drop otherwise — a bullet naming a thing without claiming its contents
+     (`Skills: a, b, c`) ships it whole, whatever revisions it went through.
+   - Nothing to fold into means the thing never reached `### Added` at all. Drop the
+     bullet either way, and add the thing there first when What Goes In admits it.
+   - An `### Added` bullet measured against another one folds first, so every later
+     bullet tests against the merged claim.
+   - The baseline is the last version the reader can have, which is not always a tag: a
+     project shipping untagged builds, or a fork, keeps the entries measured against
+     those. With no such version, every bullet reconciles this way.
+   - Dropping is not a completeness check. It removes a bullet measured against a state
+     no release had; whether `### Added` carries what that bullet said is confirmed by
+     `release` → Step 2.
+2. Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` (today's date)
+3. Prepend a new empty `## [Unreleased]` section above it
+4. Leave empty subsections out — add them only when there's content

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -34,9 +34,10 @@ Git tag format: `vX.Y.Z`.
 
 ## Step 2 — Update CHANGELOG.md
 
-`changelog` skill → On Release owns the edit itself — renaming `[Unreleased]` into the
-new version section and prepending a fresh empty one. What this step adds: confirm every
-notable change since the last release is actually in there before the version is frozen.
+`changelog` skill → On Release owns the edit itself — reconciling the section against the
+previous release, renaming `[Unreleased]` into the new version section, and prepending a
+fresh empty one. What this step adds: confirm every notable change since the last release
+is actually in there before the version is frozen.
 
 ## Step 3 — Bump Version Strings
 
@@ -61,7 +62,8 @@ to users is a separate gate → `shipping-and-launch` skill.
 - [ ] Build passes on all compilers declared in project (check `AGENTS.md`)
 - [ ] All tests pass; CI green on all compiler targets
 - [ ] No breaking API change without `MAJOR` bump (`cpp-api-design` → Breaking Changes)
-- [ ] `CHANGELOG.md` covers all changes since last release, `[Unreleased]` renamed
+- [ ] `CHANGELOG.md` covers all changes since last release, reconciled against the
+      previous release, `[Unreleased]` renamed (`changelog` → On Release)
 - [ ] Version string consistent across **all** version files (grep confirms)
 - [ ] Submodule ref updated in root repo (if applicable)
 - [ ] Commit trailers conform to `commit-rules` skill


### PR DESCRIPTION
## Problem

`skills/changelog/SKILL.md` -> On Release had three steps: rename `[Unreleased]`, prepend a
new empty one, drop empty subsections. None reconciled the section against what the reader
has already seen, so at a release the running development log shipped verbatim. Every bullet
of the form "X now does Y instead of Z" lands on a reader who never saw Z, because Z never
shipped.

`skills/release/SKILL.md` -> Step 2 did not catch it: it confirms every notable change is
present, which is completeness, not coherence.

The defect is in the skill, not in this repository's `CHANGELOG.md`. Editing one bullet fixes
one reader; the step fixes every release, here and in every project that loads the skill.

## Summary

- On Release gains a first step that reconciles the section before the rename.
- A bullet measured against an unreleased state is folded into the bullet that introduced the
  thing, or dropped - it is an edit to that bullet rather than an entry of its own.
- `release` -> Step 2 and its Pre-Release Checklist now gate on the reconciliation having run.

## Implementation

- The rule's subject is a bullet, not a `### Changed` bullet. Applied to this repository's
  section it reaches 49 bullets: all 15 under `### Fixed` describe a defect in something
  introduced in the same section, two of three under `### CI` fold into the third, and two
  `### Added` bullets are measured against another `### Added` bullet.
- The fold-versus-drop test is on the introducing bullet's claim, not its form, with two
  limbs: the parts it lists are read as all of them, and a qualifier it states as holding.
  Both are load-bearing - a parts-list test alone drops the two bullets this change exists to
  repair, since one lists three tools and ships three while its defect is a false scope.
- Nothing to fold into means the thing never reached `### Added`; the bullet drops either way
  and the thing is added when What Goes In admits it. Keeping the drop outside that condition
  is what stops a bullet surviving with nothing behind it.
- `skills/release/SKILL.md` -> Step 2 names the reconciliation and its Step 4 checklist line
  gates on it. Step 4 is the gate for the tag, and it previously reached into On Release for
  the rename while leaving the substantive half ungated.
- `AGENTS.md`'s ownership map line for `changelog` names the reconciliation, so the concern
  has an owner.

## Test plan

- [x] The step applied by hand to this repository's current `[Unreleased]` section, twice and
      independently: once by the author, once by the reviewer deriving verdicts before
      reading the author's. The two agreed on every bullet after the corrections in this
      branch; before them they split on five of a fourteen-bullet sample, always fold versus
      drop
- [x] The corrected rule re-applied cold to bullets neither pass had worked, plus `### CI`,
      landing where the first run landed
- [x] The qualifier limb tested by deleting it and re-running the two repairs, which are lost
      without it
- [x] `grep` confirms the rule is stated once, in `changelog`; `release` and `AGENTS.md`
      carry references with no criterion
- [x] `npm test`

## What the dry run turned up

Two `### Added` bullets are currently wrong about what ships, and folding repairs both: the
lint tools are described as running on every edited C++ file when each requires its config
file in the repository, and `comment-check` is described as firing on a C++ file when it
covers roughly sixty extensions across six syntax families. Confirmed against
`hooks/PostToolUse.js` and `tools/comment-check.js`. The section already contradicts itself
on this pair - the second bullet says "unlike the lint tools which require a project config
file" - and nothing in this repository checks for it.

## No changelog entry, deliberately

`changelog` first ships inside the bare name list `Skills: changelog, commit-rules, ...`
under `### Added`, which makes no claim about what the skill contains. Under the new step's
own rule a `### Changed` bullet recording an intermediate revision of it is dropped at
release, so the entry would be written to be deleted.

## Known gap

Folding and adding apply different admission standards: a fact folds in unconditionally when
a bullet exists, and is tested against What Goes In when none does. Two facts of the same kind
can therefore be decided by whether an earlier bullet happened to exist. Defensible - folding
corrects a bullet that would otherwise mislead, while adding makes a new claim - and left as
it is.
