### PR TITLE
GH-133, GH-130: Catch a path both shipped and retired, and prune stale gate state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,14 @@ cost never reaches the rendering path.
 
 1. Create `tools/<name>.js` — reads stdin JSON, writes plain text to stdout (warn) or
    stderr+exit(2) (block)
-2. Add it to the appropriate dispatcher in `hooks/PreToolUse.js` or `hooks/PostToolUse.js`
-   — the dispatcher, not the tool, wraps that text in the `additionalContext` the model
-   reads (see `skills/hook-scripts/SKILL.md` → Reaching the Model)
+2. Add it to the dispatcher of the event it belongs to — `hooks/PreToolUse.js`,
+   `hooks/PostToolUse.js`, `hooks/SessionStart.js`, `hooks/UserPromptSubmit.js` or
+   `hooks/Stop.js`. Which channel carries the text to the model is the event's, not the
+   tool's: on `PreToolUse` and `PostToolUse` the dispatcher wraps it in the
+   `additionalContext` the model reads, while on `SessionStart` and `UserPromptSubmit`
+   plain stdout on exit 0 reaches the model as written and the dispatcher forwards it
+   unchanged — so a tool that wrapped its own output there would have the wrapper read
+   back as the text (see `skills/hook-scripts/SKILL.md` → Reaching the Model)
 3. Export pure logic (regexes, helpers) and add tests under `test/<name>.test.js`
    (see `skills/node-testing/SKILL.md` for conventions: flat `test()`, fixtures, `CLAUDE_CONFIG_DIR` isolation)
 4. Run `npm test`
@@ -171,6 +176,20 @@ every prompt:
   the tree it belongs to. Hashing rather than dropping keeps each agent distinct — an id
   dropped for being unplain would pool that agent back into the session, which is the
   case the check exists for.
+
+  `tools/session-env-prune.js` takes a state file away once its session has gone a week
+  without a gated call, and it runs on `SessionStart` rather than on the write. A sweep in
+  the gate would put a directory listing in front of every gated call, growing with the
+  files it exists to remove; session start costs the gate nothing and fires exactly when
+  the directory can have grown, since a machine that starts no further session writes no
+  further state either. The state of the session being started is kept whatever its age,
+  including the `unknown` name a payload carrying no session id writes to, so resuming an
+  old session does not spend its denials a second time. Only the two
+  `.skill-gate.json` names above are taken: `session-env/` is Claude Code's directory, and
+  the per-session directory it keeps there is not this repository's to delete. Losing a
+  state file early costs a full transcript rescan and one deny spent again, never more —
+  `size` and `skills` are a cache over the transcript and are rebuilt from it, and an empty
+  `denied` denies where it would have warned, never the reverse.
 
   A state file carries a `version`. Version 1 is the first whose `denied` map belongs to
   a single agent; a file without one predates the agent key and pooled every agent in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `templates/SKILL.md` template for consistent skill authoring
 - Skills: `architecture` (ADRs, design tradeoffs), `node-testing` (`test/*.test.js` conventions), `project-planning` (scoping, estimation, milestones), `requirements` (user stories, acceptance criteria)
 - `commit-trailer-guard` tool: blocks `git commit` commands containing banned AI-attribution trailers (`Co-Authored-By`, `Generated-by`)
-- `SessionStart` hook: warn-only `submodule-status-check` (flags ahead/uninitialized/conflicted submodules)
+- `SessionStart` hook: `submodule-status-check` flags ahead/uninitialized/conflicted submodules, and `session-env-prune` removes the skill-gate state of every session that has gone a week without a gated call, keeping the state of the session being started whatever its age
 - `background-call-counter` tool: tracks pending background agents; `Stop` notification deferred until all `run_in_background` agents complete, preventing premature "Task complete" toasts
 - `issue-rules` skill: title format (`Type(scope): Subject`), description templates for features and bugs (Goal, Acceptance criteria, Test plan), labels, priority levels (P0–P3), and lifecycle states
 - Skills: `comments` (non-Doxygen comment style — brief, general, no fix narration), `cpp-encapsulation` (public/protected/private access-specifier discipline)
@@ -119,3 +119,5 @@
 - The suite runs on Windows as well as Linux, on every node version in the matrix. This repository installs into a Windows config directory and is developed there, so a green run on Linux alone said nothing about the platform the code is written for. Every combination reports as its own job and none cancels another, so a failure names the platform it belongs to
 
 - `npm test` no longer depends on the shell to expand a glob. The script carried `test/*.test.js`, which npm hands to `cmd.exe` unexpanded on Windows, so on node 18 and 20 no test ran at all. `node --test` finds the test files itself, whichever shell ran the script
+
+- `npm test` now fails when `config/retired.json` lists a path this repository still ships, naming the entry to remove. Install writes that path, and its retired-path warning fires only for one install does not own, so the path was shipped and retired at once with nothing saying so - the shape a half-finished rename leaves behind

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ pipeline of persona agents and commands built on top of them.
 **`Stop`** — fires when Claude Code finishes a response turn:
 - `stop-notify.js` — desktop notification (Windows toast / macOS notification / Linux notify-send); deferred until every call started in the background (`run_in_background: true`) has completed
 
-**`SessionStart`** — fires once when a session begins, warn-only:
+**`SessionStart`** — fires once when a session begins:
+- `session-env-prune.js` — removes the `skill-gate.js` state of every session that has gone a week without a gated call, keeping the state of the session being started whatever its age; it runs here rather than in the gate so that no gated call ever pays for a directory listing, and it takes only the files the gate wrote, never the per-session directory Claude Code keeps beside them
 - `submodule-status-check.js` — warns if any git submodule is ahead/uninitialized/conflicted
 
 **`UserPromptSubmit`** — runs on every user message:
@@ -201,8 +202,9 @@ Uses node's built-in `node:test` runner, so there is nothing to install first. E
 of install. Between them they exercise the payloads a guard decides on and the decision it
 returns, the skill and agent frontmatter the routing reads, the `settings.json` merge, an
 install/uninstall round trip against a temporary `CLAUDE_CONFIG_DIR` rather than the real
-one, and the rule that every file under `test/` is a test file, since the runner loads
-each of them as one.
+one, the rule that every file under `test/` is a test file, since the runner loads each of
+them as one, and the rule that no path `config/retired.json` retires is one install still
+ships.
 
 ## Manual setup
 

--- a/config/settings.json
+++ b/config/settings.json
@@ -51,7 +51,7 @@
           {
             "type": "command",
             "command": "node -e \"const{spawnSync}=require('child_process'),p=require('path'),o=require('os'),d=process.env.CLAUDE_CONFIG_DIR||p.join(o.homedir(),'.claude');spawnSync('node',[p.join(d,'hooks','SessionStart.js')],{stdio:'inherit'})\"",
-            "timeout": 10
+            "timeout": 30
           }
         ]
       }

--- a/hooks/SessionStart.js
+++ b/hooks/SessionStart.js
@@ -10,13 +10,15 @@ const toolsDir = path.join(configDir, 'tools');
 // marker byte per pending call, so an empty one is a count of zero.
 try { require('fs').writeFileSync(path.join(configDir, '.background-call-count'), ''); } catch {}
 
-const CHECKS = ['submodule-status-check.js'];
+// `settings.json` gives this event 30s and each tool below takes at most 10 of them: a
+// third one needs that budget raised, or a stalled tool leaves the next no run at all.
+const TOOLS = ['session-env-prune.js', 'submodule-status-check.js'];
 
 let raw = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', c => { raw += c; });
 process.stdin.on('end', () => {
-  for (const tool of CHECKS) {
+  for (const tool of TOOLS) {
     const r = spawnSync('node', [path.join(toolsDir, tool)], {
       input: raw, encoding: 'utf8', stdio: 'pipe', timeout: 10000,
     });

--- a/test/SessionStart.test.js
+++ b/test/SessionStart.test.js
@@ -10,11 +10,18 @@ const { get: count, increment } = require('../tools/background-call-counter');
 
 const HOOK = path.join(__dirname, '..', 'hooks', 'SessionStart.js');
 
-// A config dir whose checks do nothing, so a session start says nothing about this machine.
+// The dispatcher spawns each tool out of the config dir, so a stub standing in for one
+// records that it ran without the real tool's dependencies reaching the fixture.
+function stubTool(dir, name, body = '') {
+  fs.writeFileSync(path.join(dir, 'tools', name), body);
+}
+
+// A config dir whose tools do nothing, so a session start says nothing about this machine.
 function mkConfig() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-config-test-'));
   fs.mkdirSync(path.join(dir, 'tools'));
-  fs.writeFileSync(path.join(dir, 'tools', 'submodule-status-check.js'), '');
+  stubTool(dir, 'submodule-status-check.js');
+  stubTool(dir, 'session-env-prune.js');
   return dir;
 }
 
@@ -40,6 +47,20 @@ test('clears a count left behind by a crashed session', () => {
 
     assert.strictEqual(r.status, 0);
     assert.strictEqual(count(dir), 0);
+  } finally { rmConfig(dir); }
+});
+
+test('runs the prune that clears state left by sessions that are over', () => {
+  const dir = mkConfig();
+  try {
+    const marker = path.join(dir, 'pruned');
+    stubTool(dir, 'session-env-prune.js',
+      `require('fs').writeFileSync(${JSON.stringify(marker)}, '');\n`);
+
+    const r = runSessionStart(dir);
+
+    assert.strictEqual(r.status, 0);
+    assert.ok(fs.existsSync(marker));
   } finally { rmConfig(dir); }
 });
 

--- a/test/retired.test.js
+++ b/test/retired.test.js
@@ -1,0 +1,78 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoDir = path.join(__dirname, '..');
+
+// Paths under `dir`, relative to it, in the `/` form config/retired.json is written in.
+// `exclude` holds top-level names only, which is where install.js applies its own.
+function filesUnder(dir, exclude = new Set()) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    if (exclude.has(entry.name)) return [];
+    if (!entry.isDirectory()) return [entry.name];
+    return filesUnder(path.join(dir, entry.name)).map(rel => `${entry.name}/${rel}`);
+  });
+}
+
+// install.js copies one file out of each skill directory and nothing beside it.
+function skillFiles() {
+  const skillsDir = path.join(repoDir, 'skills');
+  if (!fs.existsSync(skillsDir)) return [];
+  return fs.readdirSync(skillsDir)
+    .filter(name => fs.existsSync(path.join(skillsDir, name, 'SKILL.md')))
+    .map(name => `skills/${name}/SKILL.md`);
+}
+
+// The two files install.js writes at the root of the config dir, out of `config/`.
+function configFiles() {
+  return ['settings.json', 'CLAUDE.md']
+    .filter(name => fs.existsSync(path.join(repoDir, 'config', name)));
+}
+
+// A retired entry names a path relative to the Claude config dir, so the set it is
+// checked against is what install.js writes there rather than what the repo holds:
+// `hooks/` without `git/`, whose pre-commit hook goes into `.git/` instead; `tools/`,
+// `agents/` and `commands/` whole; one `SKILL.md` per skill; and `config/`'s two files
+// under the name they take at the root.
+function shipped() {
+  const paths = new Set();
+  const addAll = dests => { for (const dest of dests) paths.add(dest); };
+  // A vacuous pass would hide the walk having missed a source install copies. Only the
+  // four install warns about when they are absent are held to it; `agents/` and
+  // `commands/` are optional there, since a fresh checkout may carry neither.
+  const add = (from, dests) => {
+    if (!dests.length) throw new Error(`no file found under ${from}, which install.js copies`);
+    addAll(dests);
+  };
+  add('hooks/', filesUnder(path.join(repoDir, 'hooks'), new Set(['git'])).map(rel => `hooks/${rel}`));
+  add('tools/', filesUnder(path.join(repoDir, 'tools')).map(rel => `tools/${rel}`));
+  add('skills/', skillFiles());
+  add('config/', configFiles());
+  addAll(filesUnder(path.join(repoDir, 'agents')).map(rel => `agents/${rel}`));
+  addAll(filesUnder(path.join(repoDir, 'commands')).map(rel => `commands/${rel}`));
+  return paths;
+}
+
+function retiredPaths() {
+  const src = path.join(repoDir, 'config', 'retired.json');
+  const listed = JSON.parse(fs.readFileSync(src, 'utf8')).retired;
+  if (!Array.isArray(listed)) throw new Error(`${src} carries no retired array`);
+  return listed;
+}
+
+test('no entry in config/retired.json names a path this repo still ships', () => {
+  const paths = shipped();
+  for (const entry of retiredPaths()) {
+    assert.ok(!paths.has(entry),
+      `${entry} is retired in config/retired.json and still shipped by this repo: install `
+      + 'creates the file, so the retired-path warning never fires and the path is both at '
+      + 'once. Drop the entry, or drop the file the repo still ships under it.');
+  }
+});
+
+test('the pre-commit hook install writes into .git/ is not a path the config dir carries', () => {
+  assert.ok(!shipped().has('hooks/git/pre-commit'));
+});

--- a/test/session-env-prune.test.js
+++ b/test/session-env-prune.test.js
@@ -1,0 +1,192 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { prune, RETENTION_MS } = require('../tools/session-env-prune');
+
+const pruneJs = path.join(__dirname, '..', 'tools', 'session-env-prune.js');
+
+const MINUTE = 60 * 1000;
+const DAY = 24 * 60 * MINUTE;
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'session-env-'));
+}
+function rmTmp(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+// A state file whose last gated call was `age` milliseconds ago.
+function writeState(dir, name, age) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, '{}');
+  const at = new Date(Date.now() - age);
+  fs.utimesSync(file, at, at);
+  return file;
+}
+
+// The state of one session, under the session-env directory of a config dir of its own.
+function mkConfigDir(name, age) {
+  const dir = mkTmp();
+  const sessionEnv = path.join(dir, 'session-env');
+  fs.mkdirSync(sessionEnv);
+  return { dir, state: writeState(sessionEnv, name, age) };
+}
+
+function runPrune(configDir, input) {
+  return spawnSync('node', [pruneJs], {
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+  });
+}
+
+test('removes state left behind by a session that is over', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 's1.skill-gate.json', 30 * DAY);
+    prune(dir);
+    assert.strictEqual(fs.existsSync(state), false);
+  } finally { rmTmp(dir); }
+});
+
+test('keeps state a session is still using', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 's1.skill-gate.json', 0);
+    prune(dir);
+    assert.ok(fs.existsSync(state));
+  } finally { rmTmp(dir); }
+});
+
+test('keeps the state of the session being started, however old it is', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 's1.skill-gate.json', 30 * DAY);
+    prune(dir, 's1');
+    assert.ok(fs.existsSync(state));
+  } finally { rmTmp(dir); }
+});
+
+test('keeps the state a payload carrying no session id is written to', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 'unknown.skill-gate.json', 30 * DAY);
+    prune(dir);
+    assert.ok(fs.existsSync(state));
+  } finally { rmTmp(dir); }
+});
+
+test('keeps the state of a subagent of the session being started', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 's1.a1.skill-gate.json', 30 * DAY);
+    prune(dir, 's1');
+    assert.ok(fs.existsSync(state));
+  } finally { rmTmp(dir); }
+});
+
+test('removes state of another session whose id begins with the live one', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 's10.skill-gate.json', 30 * DAY);
+    prune(dir, 's1');
+    assert.strictEqual(fs.existsSync(state), false);
+  } finally { rmTmp(dir); }
+});
+
+test('leaves the per-session directory Claude Code keeps beside its own state alone', () => {
+  const dir = mkTmp();
+  try {
+    const theirs = path.join(dir, 'e2eb2f76-56ff-41fe-be3c-9ee662105090');
+    fs.mkdirSync(theirs);
+    prune(dir);
+    assert.ok(fs.existsSync(theirs));
+  } finally { rmTmp(dir); }
+});
+
+test('takes every file it can when one entry cannot be removed', () => {
+  const dir = mkTmp();
+  try {
+    const first = writeState(dir, 'a.skill-gate.json', 30 * DAY);
+    const last = writeState(dir, 'z.skill-gate.json', 30 * DAY);
+    // Unlinking a directory fails on every platform, which is the entry a session
+    // starting alongside this one would produce by removing a file mid-sweep.
+    const stuck = path.join(dir, 'm.skill-gate.json');
+    fs.mkdirSync(stuck);
+    const aged = new Date(Date.now() - 30 * DAY);
+    fs.utimesSync(stuck, aged, aged);
+
+    assert.doesNotThrow(() => prune(dir));
+
+    assert.strictEqual(fs.existsSync(first), false);
+    assert.strictEqual(fs.existsSync(last), false);
+  } finally { rmTmp(dir); }
+});
+
+test('keeps state whose last call is just inside the retention', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 's1.skill-gate.json', RETENTION_MS - MINUTE);
+    prune(dir);
+    assert.ok(fs.existsSync(state));
+  } finally { rmTmp(dir); }
+});
+
+test('run as a script, finds the session-env of the config dir it is pointed at', () => {
+  const { dir, state } = mkConfigDir('s1.skill-gate.json', 30 * DAY);
+  try {
+    const r = runPrune(dir, { session_id: 's2' });
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(fs.existsSync(state), false);
+  } finally { rmTmp(dir); }
+});
+
+test('run as a script, keeps the state of the session named in the payload', () => {
+  const { dir, state } = mkConfigDir('s1.skill-gate.json', 30 * DAY);
+  try {
+    const r = runPrune(dir, { session_id: 's1' });
+    assert.strictEqual(r.status, 0);
+    assert.ok(fs.existsSync(state));
+  } finally { rmTmp(dir); }
+});
+
+test('says nothing on the stdout a session start reads into the model context', () => {
+  const { dir } = mkConfigDir('s1.skill-gate.json', 30 * DAY);
+  try {
+    assert.strictEqual(runPrune(dir, { session_id: 's2' }).stdout, '');
+  } finally { rmTmp(dir); }
+});
+
+test('exits 0 on malformed stdin', () => {
+  const { dir, state } = mkConfigDir('s1.skill-gate.json', 30 * DAY);
+  try {
+    const r = spawnSync('node', [pruneJs], {
+      input: 'not json',
+      encoding: 'utf8',
+      stdio: 'pipe',
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir },
+    });
+    assert.strictEqual(r.status, 0);
+    assert.ok(fs.existsSync(state));
+  } finally { rmTmp(dir); }
+});
+
+test('takes a directory no session has written state to yet', () => {
+  const dir = mkTmp();
+  try {
+    assert.strictEqual(prune(path.join(dir, 'session-env')), 0);
+  } finally { rmTmp(dir); }
+});
+
+test('removes state whose last call is just past the retention', () => {
+  const dir = mkTmp();
+  try {
+    const state = writeState(dir, 's1.skill-gate.json', RETENTION_MS + MINUTE);
+    prune(dir);
+    assert.strictEqual(fs.existsSync(state), false);
+  } finally { rmTmp(dir); }
+});

--- a/test/skill-gate.test.js
+++ b/test/skill-gate.test.js
@@ -172,6 +172,38 @@ test('loadedSkills rereads from the start when the transcript shrank', () => {
   } finally { rmTmp(dir); }
 });
 
+test('loadedSkills rebuilds the cursor and the skills of a state file taken away', () => {
+  const dir = mkTmp();
+  try {
+    const transcript = path.join(dir, 't.jsonl');
+    const state = path.join(dir, 'state.json');
+    fs.writeFileSync(transcript, transcriptLine('debugging') + '\n');
+    loadedSkills(transcript, state);
+    const before = JSON.parse(fs.readFileSync(state, 'utf8'));
+
+    fs.rmSync(state);
+    const skills = loadedSkills(transcript, state);
+
+    assert.deepStrictEqual(skills, ['debugging']);
+    const after = JSON.parse(fs.readFileSync(state, 'utf8'));
+    assert.strictEqual(after.size, before.size);
+    assert.deepStrictEqual(after.skills, before.skills);
+  } finally { rmTmp(dir); }
+});
+
+test('denyOnce spends a deny again once its state file is taken away', () => {
+  const dir = mkTmp();
+  try {
+    const state = path.join(dir, 's.json');
+    assert.strictEqual(denyOnce(state, 'a.cpp|comments'), true);
+    assert.strictEqual(denyOnce(state, 'a.cpp|comments'), false);
+
+    fs.rmSync(state);
+
+    assert.strictEqual(denyOnce(state, 'a.cpp|comments'), true);
+  } finally { rmTmp(dir); }
+});
+
 test('loadedSkills returns nothing for a missing transcript', () => {
   const dir = mkTmp();
   try {
@@ -454,6 +486,20 @@ test('gate keeps its state inside session-env for an agent id carrying a travers
     });
     const stray = fs.readdirSync(dir).filter(entry => entry.endsWith('.skill-gate.json'));
     assert.deepStrictEqual(stray, []);
+  } finally { rmTmp(dir); }
+});
+
+test('gate leaves the state of every other session alone, however old it is', () => {
+  const dir = mkConfigDir({ 'cpp-coding': 'description: d\nmetadata:\n  paths: ["**/*.cpp"]\n' });
+  try {
+    const other = path.join(dir, 'session-env', 's0.skill-gate.json');
+    fs.writeFileSync(other, '{}');
+    const lastYear = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(other, lastYear, lastYear);
+
+    runGate(dir, { tool_name: 'Edit', tool_input: { file_path: 'D:/repo/a.cpp' }, session_id: 's1' });
+
+    assert.ok(fs.existsSync(other));
   } finally { rmTmp(dir); }
 });
 

--- a/tools/session-env-prune.js
+++ b/tools/session-env-prune.js
@@ -1,0 +1,54 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { stateOf, STATE_SUFFIX } = require(path.join(__dirname, 'skill-gate.js'));
+
+// How long the state of a session other than the one starting survives: one resumed
+// inside the window still finds the denials it spent.
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Read off `stateOf`, which names a file for every payload: an id the gate had to rewrite
+// is matched as the gate wrote it, and a payload carrying none keeps the name it wrote to.
+function sessionPrefix(sessionId) {
+  return path.basename(stateOf(sessionId)).slice(0, -STATE_SUFFIX.length) + '.';
+}
+
+function prune(dir, sessionId) {
+  const live = sessionPrefix(sessionId);
+  const now = Date.now();
+  let names;
+  try { names = fs.readdirSync(dir); } catch { return 0; }
+  let removed = 0;
+  for (const name of names) {
+    // Claude Code keeps per-session directories of its own beside these.
+    if (!name.endsWith(STATE_SUFFIX)) continue;
+    if (name.startsWith(live)) continue;
+    const file = path.join(dir, name);
+    // One entry another session is writing or has just removed leaves the rest to sweep.
+    try {
+      if (now - fs.statSync(file).mtimeMs < RETENTION_MS) continue;
+      fs.unlinkSync(file);
+      removed += 1;
+    } catch {}
+  }
+  return removed;
+}
+
+// Silent when it worked: `SessionStart` stdout is added to the model's context as written.
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { raw += c; });
+  process.stdin.on('end', () => {
+    let data;
+    try { data = JSON.parse(raw); } catch { process.exit(0); }
+    try {
+      prune(path.dirname(stateOf(data.session_id)), data.session_id);
+    } catch (err) {
+      process.stderr.write(`session-env-prune: state was left in place — ${String(err?.message).split('\n')[0]}\n`);
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { prune, RETENTION_MS };

--- a/tools/skill-gate.js
+++ b/tools/skill-gate.js
@@ -186,12 +186,16 @@ function transcriptOf(transcriptPath, sessionId, agentId) {
   return path.join(path.dirname(transcriptPath), session, 'subagents', `agent-${agent}.jsonl`);
 }
 
+// Exported, so `session-env-prune.js` knows which files are this repo's without
+// spelling the name a second time.
+const STATE_SUFFIX = '.skill-gate.json';
+
 // `agent_id` is absent on the main thread, which therefore keeps the session's own name.
 function stateOf(sessionId, agentId) {
   const session = plain(sessionId, 'unknown');
   const agent = plain(agentId);
   const scope = agent ? `${session}.${agent}` : session;
-  return path.join(configDir, 'session-env', `${scope}.skill-gate.json`);
+  return path.join(configDir, 'session-env', `${scope}${STATE_SUFFIX}`);
 }
 
 function verdict(data) {
@@ -224,4 +228,5 @@ if (require.main === module) runAsScript(verdict);
 
 module.exports = {
   skillsIn, loadedSkills, notice, denyOnce, writeTargets, gateTargets, stateOf, verdict,
+  STATE_SUFFIX,
 };


### PR DESCRIPTION
## Problem

Two debts, both surfaced by earlier work in this series and both closed here rather than left
standing.

**GH-133.** Nothing failed if a path listed in `config/retired.json` was also one this repository
ships: install creates the file, the tracked check then skips the retired-path warning, and the
path is shipped and retired at once, in silence. That is the shape a half-finished rename takes -
the old path recorded as retired, the new one added, and one reference left behind pointing at
the old file, which install keeps writing.

**GH-130.** Nothing removed a `session-env/` state file, and after GH-101 there is one per agent
rather than one per session. A session's state is dead the moment that session ends, and nothing
said so or acted on it.

## Summary

- `npm test` fails when a retired path is one the repository still ships, naming the path.
- State left behind by a session that is over does not accumulate; the session being started
  keeps its own state whatever its age.

## Implementation

- `test/retired.test.js` reads the shipped set off `install.js` rather than off a list, so the
  two cannot drift. That set differs from the obvious guess in three ways: `hooks/git/` is
  excluded, only `skills/<name>/SKILL.md` is copied, and `config/`'s two files ship renamed to
  the config root.
- The prune runs on `SessionStart` rather than in the gate. The gate is untouched, so the
  criterion that its per-call cost must not grow with the directory holds by construction.
- It takes only files carrying the gate's own name. `session-env/` is not this repository's
  directory: of 100 entries here, 77 are empty per-session directories Claude Code creates
  itself and 23 are the gate's state files, and neither `install.js` nor `config/settings.json`
  mentions it - the location is resolved inside `skill-gate.js`. Deleting another program's
  directories from a hook is a decision this change does not take.
- The state-file suffix is named once, in `skill-gate.js`, and the prune destructures it.
  Restating it would have made a rename of the gate's state file a silent no-op with the suite
  still green - the same shape as the defect the other half of this branch exists to catch.
- `SessionStart`'s budget goes to 30 s, matching the other two events. A per-tool bound only
  means anything if the event budget exceeds the sum of the tools' bounds; at 10 s for both it
  could never fire for the second, so a prune that stalled would have cost the submodule warning
  entirely. Sharing the 10 s would have taken the cut from the wrong tool - the prune does one
  readdir plus a stat per entry, while the submodule check shells out to git.

## Test plan

- [x] `npm test`
- [x] The retired check goes red against an entry naming a shipped path, with a message naming
      it: confirmed by adding `tools/skill-gate.js` temporarily, and again with
      `skills/comments/SKILL.md`, which is the rename case
- [x] The check cannot pass vacuously - the walk throws if a directory install copies contributes
      nothing, for the four mandatory sources; `agents/` and `commands/` may be empty, which is
      what `install.js` itself treats as optional
- [x] Renaming the state-file suffix turns five prune tests red. Before it was named once, the
      same rename left them green
- [x] A gated call leaves another session's year-old state where it is, red-confirmed by
      temporarily putting the sweep into the gate's `verdict`
- [x] The prune keeps the state of the session named in the payload whatever its age, including
      the payload that carries no `session_id` and writes to `unknown`
- [x] One entry that cannot be removed does not abandon the rest of the sweep
- [x] A lost state file is rebuilt from the transcript: the second call rewrites it with the same
      cursor and skills, and the denial it held is gone - the half that is not derivable

## What a lost state file costs, since the prune rests on it

The file holds a byte cursor, the skills seen in the transcript, and the denials spent. The
cursor and the skills are a cache over the transcript rather than a record: on any read failure
the transcript is read from byte 0 and both are rebuilt. Only the denials are not derivable, and
losing them turns the next repeat into a deny instead of a warning - strictly stricter, never a
deadlock, and never a certification of an agent that loaded nothing, since the loaded set comes
from the transcript.

## Why the state was not moved to a temp directory

The issue proposed weighing that first, on the grounds that it would remove the concern rather
than manage it. Rejected on three counts. Temp is not pruned in practice - `os.tmpdir()` here
holds over 1300 entries, the oldest 566 days. It costs test isolation, since `CLAUDE_CONFIG_DIR`
is the single knob every path resolves against. And it gives up a boundary: the path must stay
derivable from the session and agent ids for the next call to find it, and both readers of that
file also write to it, so a predictable name in a world-writable directory is the classic
insecure-temp-file shape. Under `~/.claude/` that costs nothing, because anyone who can write the
state file can equally write the tools themselves.

## Two things this branch corrects beyond the issues

- `AGENTS.md` -> "Adding a new tool check" step 2 stated that the dispatcher wraps a tool's text
  in `additionalContext`. That holds for `PreToolUse` and `PostToolUse` only: on `SessionStart`
  and `UserPromptSubmit`, plain stdout on exit 0 reaches the model as written, so a tool wrapping
  its own output there has the wrapper read back as the text. The step now names the channel per
  event.
- The `### Added` bullet for the `SessionStart` hook said "warn-only", which a tool that deletes
  files falsifies. Folded rather than left standing beside a new bullet.

## Scope

Two issues in one branch. They share no code and would have reverted independently, so a split
would have been cleaner in principle; at this size, with both being debts from the same session
and the same review pass, it costs nothing.
