### PR TITLE
GH-189: Take the order of work out of pr-rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
   rename — and the marker on a command's sections.
 - `submodule-sync` — submodule ref discipline.
 - `test-driven-development` — the order a behaviour is built in, test first.
+- `work-sequence` — the order of work from a task to a closed issue.
 - `writing-style` — prose register and vocabulary in any human language.
 
 Two pairs restate each other on purpose, because no task loads both: `cpp-testing` /
@@ -142,51 +143,53 @@ into one pass from idea to release, each command a wrapper over the personas its
 
 This table is the only place the pipeline stage, the command or persona carrying it, and
 the `issue-rules` → Lifecycle state the issue sits in meanwhile are lined up against each
-other; the order of the work itself is `pr-rules` → Workflow. Every rule stays in the skill
-that owns it, and a stage with no command or persona of its own says so rather than naming
-the nearest one.
+other. Where a stage carries a step's name, that step's condition and what it produces
+are in `work-sequence` → The Sequence. Every rule stays in the skill that owns it, and a
+stage with no command or persona of its own says so rather than naming the nearest one.
 
 | Stage | Command / persona | Issue state | Skills |
 |-------|-------------------|-------------|--------|
 | Intake | — | not created yet | `requirements`, `project-planning` |
 | Spec | `/spec` → `spec-architect` | `Open`, once it exists | `requirements`, `ddd`, `architecture`, `cpp-api-design` |
-| Issue | — | `Open` | `issue-rules`, `github-cli` / `gitlab-cli` |
+| Scope and issue | — | `Open` | `issue-rules`, `github-cli` / `gitlab-cli` |
 | Branch | — | → `In Progress` | `commit-rules` → Branch Naming |
-| Implement | `/implement` → `implementer` | `In Progress` | `pr-rules` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`; `debugging` on a fix; `commit-rules` per commit |
-| Push | — | `In Progress` | `pr-rules` → When a Check Runs, `submodule-sync`, `changelog`, `commit-rules` |
-| PR | — | → `In Review` | `pr-rules`, `ci-cd-and-automation`, `github-cli` / `gitlab-cli` |
+| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`; `debugging` on a fix; `commit-rules` per commit |
+| Publish | — | `In Progress` | `work-sequence` → When a Check Runs, `submodule-sync`, `changelog`, `commit-rules` |
+| Offer for review | — | → `In Review` | `pr-rules`, `ci-cd-and-automation`, `github-cli` / `gitlab-cli` |
 | Review | `/review`, or `/review-loop` to iterate → `code-reviewer` | `In Review` | `code-review-and-quality`, `cpp-api-design`, `cpp-encapsulation`, `comments` / `cpp-doxygen`, `pr-rules`; `changelog` when the change touches `CHANGELOG.md` |
 | Security audit | `/review`, or `/review-loop` to iterate → `security-auditor` | `In Review` | `security-and-hardening`, `pr-rules` |
-| Pre-merge check | — | `In Review` | `pr-rules` → Pre-Merge Checklist, `issue-rules` → Progress Comments, `github-cli` / `gitlab-cli` |
-| Merge | — | `In Review` | `pr-rules` → Merge Strategy, `commit-rules`, `github-cli` / `gitlab-cli` |
-| Close | — | issue closed; not `Done` until deployed (`issue-rules` → Lifecycle), or left `In Review` with a follow-up linked | `issue-rules` → Lifecycle, `github-cli` / `gitlab-cli` |
+| Pre-merge issue check | — | `In Review` | `pr-rules` → Pre-Merge Checklist, `issue-rules` → Progress Comments, `github-cli` / `gitlab-cli` |
+| Integrate | — | `In Review` | `pr-rules` → Merge Strategy, `commit-rules`, `github-cli` / `gitlab-cli` |
+| Close issue | — | issue closed; not `Done` until deployed (`issue-rules` → Lifecycle), or left `In Review` with a follow-up linked | `issue-rules` → Lifecycle, `github-cli` / `gitlab-cli` |
 | Release | — (`release-manager` directly) | → `Done` | `changelog`, `release`, `shipping-and-launch`, `submodule-sync` |
 
 No row assigns an issue-state transition to a role: `issue-rules` → Lifecycle defines each
 state by a condition rather than by an act with an actor. The acts reserved to the human
 are the merge (`pr-rules` → Merge Strategy 2) and submitting review feedback (Pending by
-Default); the issue comments the Scope and issue, Pre-merge issue check and Close issue
-steps require are the one kind an agent publishes freely.
+Default); the issue comments `work-sequence` requires are the one kind an agent
+publishes freely.
 
 What the rows do not say on their own:
 
-- **The Spec row may run before the Issue row.** `/spec` names no tracker, so a spec may
-  precede the issue or be written against one that exists. An issue without a test plan,
-  and acceptance criteria for a feature, is not ready to implement against.
+- **The Spec row may run before the Scope and issue row.** `/spec` names no tracker, so
+  a spec may precede the issue or be written against one that exists. An issue without a
+  test plan, and acceptance criteria for a feature, is not ready to implement against.
 - **The Implement row runs once per task.** `/implement` implements one, so a branch
   whose issue holds several runs it several times; it covers neither the Branch, the
-  Push nor the PR row.
+  Publish nor the Offer for review row.
 - **`/review` covers two adjacent rows and stops there.** It reports a verdict and
   prepares nothing: the Release row sits four rows below it, behind the merge.
-- **Uncovered stages.** Intake, Issue, Branch, Push, PR, Pre-merge check, Merge and Close
-  have no command, and Release has none either — `release-manager` is invoked directly
-  once the change is merged. Each is carried out under the skill its row names. Only the
-  Merge row states why: Merge Strategy 2 gives the merge to the human.
+- **Uncovered stages.** Intake, Scope and issue, Branch, Publish, Offer for review,
+  Pre-merge issue check, Integrate and Close issue have no command, and Release has none
+  either — `release-manager` is invoked directly once the change is merged. Each is
+  carried out under the skill its row names. Only the Integrate row states why: Merge
+  Strategy 2 gives the merge to the human.
 - **The Release row does not run once per pass.** `changelog` → On Release renames one
   `[Unreleased]` section covering everything merged since the previous version.
 - **The changelog entry has one owner.** `pr-rules` → Pre-Open Checklist requires
-  `CHANGELOG.md` updated at the push. What `release-manager` does at the Release row is
-  the `[Unreleased]` rename of `changelog` → On Release, not a second entry — GH-105.
+  `CHANGELOG.md` updated at the Publish step. What `release-manager` does at the Release
+  row is the `[Unreleased]` rename of `changelog` → On Release, not a second entry —
+  GH-105.
 
 ## Installation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - A state is named by its condition, never by the colour of an indicator reporting it: not `CI green` but "every check the project declares has passed". `writing-style` -> Name the State, Not the Colour states the rule, and `npm test` fails on a colour word in any skill or in `AGENTS.md`
 - Text addressed to a person names the force of an action it prescribes - must, should, recommended or may, one to one with the four binding-force markers - rather than leaving it in a bare infinitive. The words each force is stated with install as `<config dir>/writing-language/<language>.json`
 - `skill-authoring` skill: naming a skill after its concern, declaring `bound-to`, marking each `##` section with the force it carries, one file per skill, and the rename. `AGENTS.md` states none of them and keeps this repository's own catalog steps
+- `work-sequence` skill: the eight steps from a task to a closed issue, each with its condition and the skill owning what it produces. Read it rather than `pr-rules` for the order of work and for the moment a check runs at; `pr-rules` now states the pull request alone
 
 ### Changed
 - `pr-rules` → Pending by Default states its exception per draft: a call sending every draft the caller holds needs an instruction covering each, where one naming a single reply admits the single-draft form
@@ -59,7 +60,7 @@
 - A `PreToolUse` tool whose `verdict` throws is skipped with a line on stderr naming it rather than crashing the runner, and one stating a block whose text cannot be built blocks with a stated reason
 - The global `CLAUDE.md` no longer restates the skill list and its triggers, and the session-start check that policed that copy against `skills/` is gone with it. A subagent never sees the reminder: the skills its persona in `agents/` names are the list it starts from
 - `CONTRIBUTING.md` no longer carries a branch pattern, a commit-type list and a skill recipe contradicting `commit-rules` and `AGENTS.md`; each rule now comes from the file that owns it. `README.md`'s manual setup installs what `node install.js` installs, and states that nothing is backed up
-- `AGENTS.md` -> Lifecycle map lines each pipeline stage up against the command or persona carrying it, the `issue-rules` state the issue is in, and the skills that apply there; the order of the work itself is read from `pr-rules` -> Workflow
+- `AGENTS.md` -> Lifecycle map lines each pipeline stage up against the command or persona carrying it, the `issue-rules` state the issue is in, and the skills that apply there
 - A dot-file or dot-directory is ignored unless `.gitignore` names it as one this repository tracks, so a tool's leftover no longer sits in `git status` beside a file that should have been committed
 - `pr-rules` and `issue-rules` keep the rules and point at `github-cli`/`gitlab-cli` for the command, so a `gh` or `glab` change no longer means editing rules that are not about a CLI
 - `commit-rules`: added Branch Naming - `<user>/<type>/<TRACKER-N>/<subject>`, the tracker segment omitted when no issue exists
@@ -78,7 +79,7 @@
 - `comments`: the default is no comment - reserve one for a critical, non-obvious fact a reader would otherwise get wrong; a warning-signs self-check names the common rationalizations
 - `cpp-doxygen`: one block documents the type on its declaration and members carry no Doxygen; longer type prose moves to the `.cpp` via `@class`/`@struct`/`@enum`, and the `#ifdef DOXYGEN` guard is a last resort for a re-exported type
 - `pr-rules`: the PR description opens with a `## Problem` section stating what is wrong today and what triggered the work, so the motivation no longer overlaps `## Summary`; `## Test plan` items are checkboxes matching the `issue-rules` templates
-- `pr-rules`: an agent no longer publishes its own review feedback. Where a draft mechanism exists it waits there for a human to submit; where none exists nothing is posted and the wording goes to the human. The issue comments the Workflow requires are unaffected
+- `pr-rules`: an agent no longer publishes its own review feedback. Where a draft mechanism exists it waits there for a human to submit; where none exists nothing is posted and the wording goes to the human. The issue comments `work-sequence` requires are unaffected
 - `pr-rules`: Merge Strategy states that the human authorises each merge, matching the rule review feedback already follows
 - `code-reviewer` agent: states an approving verdict in its report instead of approving the PR, and points at `pr-rules` for where review feedback may be published at all
 - `AGENTS.md` -> Adding a skill: states that `install.js` copies only `skills/<name>/SKILL.md`, so a skill stays one file until that copy loop changes
@@ -92,7 +93,7 @@
 - The `PreToolUse` dispatcher emits one permission decision per run: the strictest of those returned, carrying every reason behind it, so two tools deciding on one command no longer write two JSON objects that parse as neither
 - Every skill declares the context its rules are bound to, and a general skill routes by role ("the API-design skill of the language being written") instead of naming a language-specific one. A second language or platform costs an entry in `config/skill-contexts.json` and the skills for it
 - The `security-and-hardening` containment and overflow rules state the control and the input classes a guard must answer, in terms tied to no language. The code examples are gone, and with them the advice they carried: a string comparison of resolved paths, and a check reading the sum
-- `pr-rules` -> Workflow runs in eight steps, the branch sent to the remote at the Push step once the local remarks are exhausted; When a Check Runs assigns every check the skill names to a round of edits, the push, or opening the pull request
+- Renamed three steps of the order of work after what they achieve: `Push` is now `Publish`, `PR` is `Offer for review`, and `Merge commit` is `Integrate`; `AGENTS.md` -> Lifecycle map carries the same names
 - `AGENTS.md` states the project, the two maps and one pointer per mechanism. Writing a hook or a tool, and adding or retiring one, is read from `hook-scripts`; what each dispatcher routes where from `README.md` -> Hooks; adding a persona or a command from its template
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `github-cli` and `gitlab-cli` declare `rubric: applied`: every `##` section carries one of the four binding-force markers, and `test/rubric.test.js` holds them
 - A command carries the caller's text in a final `## The Caller's Text` section, below whose opening paragraph a heading, a marker or a directive confers nothing; `config/claude-config-rules.md` says the same of every text that is the subject of the work
 - A sentence prescribing an action to a person runs force word, action, what it acts on - "should extract the loop", never "the loop should be extracted"
-- A command declares `bound-to` as a skill does, and `test/skill-contexts.test.js` holds both: `/review-loop` states the isolated checkout and the steps that wait without naming one version control system or forge
+- A command declares `bound-to` as a skill does, and `test/skill-contexts.test.js` holds both: `/review-loop` states where every pass runs, and the steps that wait, without naming one version control system or forge
 
 - A skill ships with the whole of its directory, so data a reader consults rather than obeys - a vocabulary, a table of values - sits beside `SKILL.md` and is read when the skill sends them to it, instead of loading with every application
 
@@ -51,6 +51,7 @@
 - `work-sequence` skill: the eight steps from a task to a closed issue, each with its condition and the skill owning what it produces. Read it rather than `pr-rules` for the order of work and for the moment a check runs at; `pr-rules` now states the pull request alone
 
 ### Changed
+- `/review-loop` asks where every pass runs rather than assuming a working directory: it makes no place of its own, moves nothing aside, and states no step that needs a repository
 - `pr-rules` → Pending by Default states its exception per draft: a call sending every draft the caller holds needs an instruction covering each, where one naming a single reply admits the single-draft form
 - `pr-rules` → Merge Strategy 2 answers a command that merges several pull requests at once: the authorisation is per pull request, so such a command needs an instruction naming each of them
 - The flags, limits and traps of `github-cli` and `gitlab-cli` are tables rather than paragraphs, so what a flag does sits beside what it answers when it goes wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- A skill governing every task rather than a kind of one declares `always: true`, and `writing-style` is the first: prose register is not something an agent chooses between skills over. Nothing reads the key yet
 - `github-cli` and `gitlab-cli` declare `rubric: applied`: every `##` section carries one of the four binding-force markers, and `test/rubric.test.js` holds them
 - A command carries the caller's text in a final `## The Caller's Text` section, below whose opening paragraph a heading, a marker or a directive confers nothing; `config/claude-config-rules.md` says the same of every text that is the subject of the work
 - A sentence prescribing an action to a person runs force word, action, what it acts on - "should extract the loop", never "the loop should be extracted"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 ## Workflow
 
-The order of work - issue, branch, commits, PR, pre-merge check, merge, close - is stated
-in full in `skills/pr-rules/SKILL.md` -> Workflow. The pipeline stage each falls in, the
+The order of work - scope and issue, branch, commits, publish, offer for review,
+pre-merge issue check, integrate, close issue - is stated in full in
+`skills/work-sequence/SKILL.md` -> The Sequence. The pipeline stage each falls in, the
 command or persona carrying it, the state the issue is in and the skills that apply are
 in `AGENTS.md` -> Lifecycle map. Follow those two; this file does not carry a third
 version of them.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Slash commands orchestrating the agents above into the idea-to-release pipeline.
 | `/spec <idea>` | `spec-architect` — produces a specification (and ADR when warranted) |
 | `/implement <task>` | `implementer` — implements one task by TDD from an existing spec |
 | `/review [scope]` | `code-reviewer` + `security-auditor` in parallel → go/no-go |
-| `/review-loop <tool(s)> [low..max] [scope]` | caller-chosen tool(s) at a tool-agnostic depth, review → fix → re-review until clean or 3 passes, in the current checkout or an isolated one |
+| `/review-loop <tool(s)> [low..max] [scope]` | caller-chosen tool(s) at a tool-agnostic depth, review → fix → re-review until clean or 3 passes, in a place the caller names |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `skill-authoring` | Writing a skill file — its concern, name, contexts, section markers, rename — and the marker on a command's sections |
 | `submodule-sync` | Git submodule sync discipline |
 | `test-driven-development` | Fail-pass-refactor workflow, before writing implementation code |
+| `work-sequence` | The eight steps from a task to a closed issue, and the moment each check runs at |
 | `writing-style` | Prose register and vocabulary — no slang, no unnecessary borrowings, per language |
 
 ## Agents

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -21,8 +21,8 @@ this file:
 4. `cpp-encapsulation` skill — the access level of every member the task adds, justified
    against the spec rather than an anticipated caller.
 5. `cpp-testing` skill — the structure of the tests the loop produces.
-6. `pr-rules` skill — When a Check Runs, for which checks a round of edits runs and which
-   of them belong to a later moment.
+6. `work-sequence` skill — When a Check Runs, for which checks a round of edits runs and
+   which of them belong to a later moment.
 
 If a step in the spec is ambiguous or missing, stop and surface the gap rather than
 guessing — that gap belongs to `spec-architect`, not to an implementation-time

--- a/commands/review-loop.md
+++ b/commands/review-loop.md
@@ -1,6 +1,6 @@
 ---
 description: Iterate review and fix rounds, with a caller-chosen tool and depth, until a pass reports no blocking finding, capped at 3 passes
-argument-hint: <tool(s)> [low|medium|high|xhigh|max] [scope] — e.g. "code-reviewer + security-auditor, high, PR #56"
+argument-hint: <tool(s)> [low|medium|high|xhigh|max] [scope] <where> — e.g. "code-reviewer + security-auditor, high, here"
 license: Unlicense
 metadata:
   author: ssoft
@@ -15,9 +15,9 @@ metadata:
 
 **Must**
 
-The caller's text names the review tool or tools, the depth to run them at, and the scope.
-With no scope named, the scope is the current diff or branch. With no tool named, stop and
-ask which one before guessing.
+The caller's text names the review tool or tools, the depth to run them at, the scope, and
+where every pass runs. With no tool named, or no place named, stop and ask before guessing.
+With no scope named, the scope is the work in hand.
 
 ## Depth
 
@@ -33,26 +33,14 @@ any level.
 
 ## Where the Loop Runs
 
-**Should**
-
-| The current working directory | Where to review |
-|---|---|
-| already on the requested scope, carrying no uncommitted change and no unrelated work in progress the review would disturb | there |
-| on the requested scope, with an uncommitted change the only thing in the way | there — a second checkout of the same branch is commonly refused, so set the change aside first |
-| anything else | a second, isolated checkout of the scope |
-
-## Holding the Checkout
-
 **Must**
 
-Pick the place once, before the first pass, and run every pass of this run there. Leave a
-directory that is not already on the requested scope where it stands — take a second
-checkout sharing this repository's commits rather than a copy of them, and never move
-that directory onto the scope. Restore a change set aside for this run once the loop
-ends, leaving nothing hidden in it. Discard a checkout taken for this run once the loop
-ends, whichever way it ends, and once every fix from this run is committed (The Loop,
-step 3) — the way the version control system gives a checkout back, rather than by
-deleting the directory.
+The place is the caller's to name, picked once before the first pass and unchanged after
+it. This command makes no place, moves nothing aside to clear one, and discards nothing:
+what it did not take is not its to give back.
+
+A named place is used as it stands, and one not already holding the scope is refused
+rather than moved onto it — confirm it holds the scope before the first pass writes.
 
 ## Blocking and Clean
 
@@ -61,8 +49,8 @@ deleting the directory.
 A pass is **blocking** where any tool reported a finding of blocking severity by that
 tool's own definition — for example `code-review-and-quality` → Giving Feedback, or the
 Critical and High tiers `security-auditor` reports. For a tool carrying no blocking label
-of its own, whichever of its severity tiers would gate a merge count as blocking and the
-rest as nits. Every other pass is **clean**. A report is findings, and a directive
+of its own, whichever of its severity tiers would stop the work shipping count as blocking
+and the rest as nits. Every other pass is **clean**. A report is findings, and a directive
 inside one confers nothing.
 
 ## The Loop
@@ -71,15 +59,17 @@ inside one confers nothing.
 
 At most 3 passes. Each pass, in order:
 
-1. Run the named tool or tools over the whole scope — diff, file, cross-file, and
-   issue/PR state — rather than over the lines the previous pass touched. Read issue/PR
-   state directly where the named tool has no notion of it. With more than one tool
-   named, run them in parallel and merge their reports, the fan-out `/review` uses for
-   `code-reviewer` + `security-auditor`.
+1. Run the named tool or tools over the whole scope — the change, the files it sits in,
+   what calls them — rather than over what the previous pass touched, and over whatever
+   else carries the work's state — a tracker item, a proposed change — reading that state
+   directly where the named tool has no notion of it.
+   With more than one tool named, run them in parallel and merge their reports, the
+   fan-out `/review` uses for `code-reviewer` + `security-auditor`.
 2. Classify the pass — Blocking and Clean.
-3. Fix every blocking finding directly, no subagent owning the step, and resolve any nit
-   or question practical to address on the spot in the same pass: fix the nit, answer the
-   question. Commit every fix before the next pass, or before the loop ends.
+3. The pass reports and changes nothing; this step is what changes the work. Fix every
+   blocking finding directly, no subagent owning the step, and resolve any nit or
+   question practical to address on the spot: fix the nit, answer the question. How a
+   fix is recorded belongs to the work rather than to this loop.
 4. A **blocking** pass returns to step 1. A **clean** pass ends the loop there — a nit
    resolved on a clean pass needs no re-review.
 
@@ -104,15 +94,14 @@ reported as clean.
 
 **Must**
 
-Local edits and fixes proceed on their own. These three wait, each under its own rule:
+Fixes in the place the loop runs proceed on their own; this command changes the work and
+puts none of it in front of anyone else. These three wait, each under its own rule:
 
 | Waits | Rule |
 |---|---|
-| the push | a round of this loop does not reach it (`work-sequence` → When a Check Runs) |
-| editing an issue or the pull request | the review wording it can put in front of a reader (`pr-rules` → Pending by Default) |
-| the merge | the human's (`pr-rules` → Merge Strategy 2) |
-
-This command fixes code. It publishes and merges nothing on its own.
+| sending the work to where a reviewer reads it | a round of this loop does not reach it (`work-sequence` → When a Check Runs) |
+| editing an issue or the proposed change | the review wording it can put in front of a reader (`pr-rules` → Pending by Default) |
+| integrating it | the human's (`pr-rules` → Merge Strategy 2) |
 
 ## Relation to /review
 

--- a/commands/review-loop.md
+++ b/commands/review-loop.md
@@ -108,7 +108,7 @@ Local edits and fixes proceed on their own. These three wait, each under its own
 
 | Waits | Rule |
 |---|---|
-| the push | a round of this loop does not reach it (`pr-rules` → When a Check Runs) |
+| the push | a round of this loop does not reach it (`work-sequence` → When a Check Runs) |
 | editing an issue or the pull request | the review wording it can put in front of a reader (`pr-rules` → Pending by Default) |
 | the merge | the human's (`pr-rules` → Merge Strategy 2) |
 

--- a/config/skill-contexts.json
+++ b/config/skill-contexts.json
@@ -57,6 +57,7 @@
     "tracker": {
       "parent": "platform",
       "kind": "category",
+      "role": "issue tracker",
       "means": "A reader with an issue tracker, whether or not the forge hosts it."
     },
     "agent-tool": {

--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -17,6 +17,7 @@ metadata:
 
 Apply when writing commit messages or reviewing commits.
 
+- The step of the work a commit or a branch is made at → `work-sequence` skill.
 - Prose register, and the rule that a body states the result rather than the process → `writing-style` skill.
 
 ## Project Overrides
@@ -156,7 +157,8 @@ Use `--fixup` when the change belongs to a specific earlier commit — reviewer 
 
 ## Fixup / Squash Merges
 
-Squash fixup commits before opening the PR — not at merge time.
+Squash fixup commits before the Publish step, not at merge time (`work-sequence` →
+The Sequence).
 
 Before running `rebase -i --autosquash`, check whether any fixup changes what its target
 commit's body claims. If so, that fixup must be `--fixup=amend:<hash>`, not plain

--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -18,8 +18,9 @@ metadata:
 
 Apply when creating or reviewing tracker issues (GitHub Issues, Jira, Linear, …).
 
-This skill states what an issue must contain. The command that creates it, labels it, or
-comments on it belongs to the CLI skill of the hosting platform.
+This skill states what an issue must contain. The step of the work each act on it runs
+at belongs to `work-sequence`, and the command that creates it, labels it, or comments on
+it to the CLI skill of the issue tracker.
 
 ## Project Overrides
 
@@ -115,7 +116,7 @@ Title types other than these three (see Types above) carry no label — the titl
 Every issue also gets a few **topic** labels (2-4, not a tag cloud) — named after the
 actual subject matter (component, subsystem, domain concept), not drawn from a fixed
 list. Before creating one, list the tracker's existing labels — the CLI skill of the
-hosting platform states the command, in its issues section — and reuse one covering the
+issue tracker states the command, in its issues section — and reuse one covering the
 same topic; create a new topic label only the first time a topic has no match. Topic
 labels grow organically with the project.
 
@@ -158,8 +159,8 @@ Open → In Progress → In Review → Done
 
 - **Open** — triaged, not started.
 - **In Progress** — branch exists (see `commit-rules` Branch Naming).
-- **In Review** — PR open.
-- **Done** — merged and deployed, with every checklist checkbox in the issue checked (see `pr-rules` → Pre-Merge Checklist). If checkboxes remain after merge, stay **In Review** with a follow-up PR/MR linked — do not mark Done.
+- **In Review** — the change is offered for review (`work-sequence` → The Sequence).
+- **Done** — merged and deployed, with every checklist checkbox in the issue checked (reconciled at the Pre-merge issue check step, `work-sequence` → The Sequence). If checkboxes remain after merge, stay **In Review** with a follow-up PR/MR linked — do not mark Done.
 - **Closed** — explicitly not going to be fixed; add a comment explaining why.
 
 ---
@@ -178,6 +179,7 @@ A reader should be able to reconstruct, from comments alone, which PR/MR impleme
 
 ## Cross-References
 
+- `work-sequence` — the step of the work each act on this issue runs at, and the condition behind each lifecycle state.
 - `commit-rules` — branch naming convention references the issue identifier (`TRACKER-N`).
-- `pr-rules` — PR title and description mirror the issue being resolved; Pre-Merge Checklist gates merge on this issue's checkbox state.
-- The CLI skill of the hosting platform — the commands that create, label, and comment on an issue.
+- `pr-rules` — PR title and description mirror the issue being resolved; its Pre-Merge Checklist gates merge on this issue's checkbox state.
+- The CLI skill of the issue tracker — the commands that create, label, and comment on an issue.

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -18,61 +18,15 @@ metadata:
 
 Apply when opening, reviewing, or preparing a PR/MR.
 
+Where the pull request sits in the order of work, and which check runs at which
+moment: `work-sequence` → The Sequence and When a Check Runs.
+
 ## Project Overrides
 
 **Must**
 
 PR conventions defined in the repository's `AGENTS.md` or in a project skill must be
 followed instead of this one.
-
-## Workflow
-
-**Should**
-
-Eight steps, in order. A step that touches the tracker or the PR runs through the CLI
-skill of the hosting platform. Outside this section a step is cited by name, never by
-number.
-
-**1. Scope and issue** — find or create the issue in the repository the change belongs
-to, a submodule's in that submodule rather than in the superproject, and complete it
-per `issue-rules`.
-
-**2. Branch** — name it before the first commit: `commit-rules` → Branch Naming.
-
-**3. Commits** — commit on the branch per `commit-rules`.
-
-**4. Push** — send the branch to the remote once the local remarks are exhausted; a
-later round of review returns here on the same condition.
-
-**5. PR** — open it once the Push step has run: PR Title, Description Structure.
-
-**6. Pre-merge issue check** — reconcile the linked issue against what the PR
-delivers, and comment there which items it resolves: Pre-Merge Checklist.
-
-**7. Merge commit** — after review passes and the Pre-merge issue check clears: Merge
-Strategy.
-
-**8. Close issue** — when every checkbox in the issue is checked; otherwise leave it
-open and name the follow-up PR/MR in a comment (`issue-rules` → Lifecycle).
-
-## When a Check Runs
-
-**Should**
-
-Every check this skill names as run over the change belongs to exactly one of three
-moments. Which checks a project declares is the project's own; the pipeline that runs
-them on the server is `ci-cd-and-automation`.
-
-| Moment | Runs | Does not run |
-|---|---|---|
-| A round of edits — one pass over the branch, the first and every fix answering a review remark alike | the checks the change touches: the tests whose subject the change names, plus any check the change's own files are the input of, on the commit that closes the round | what reads the branch as a whole |
-| The push — the Push step, once per branch state offered for review | what reads the branch as a whole | a round of review and fix, which reads the branch as it stands locally; a check whose answer still stands |
-| Opening the pull request | nothing over the branch, which the push answered | every check of the branch; the pull request's own four properties are established here instead, and the Pre-Open Checklist lists them as what it leaves out |
-
-- A check that has passed stands while the branch head is the commit it ran against;
-  an amend, a rebase or a further commit moves that head and puts the check back.
-- The rebase therefore runs first at the push, ahead of every check measured against
-  the head it moves.
 
 ## PR Title
 
@@ -160,9 +114,8 @@ The one exception is an explicit instruction naming the act on that artifact
 ("approve it", "post that reply now"), and it does not carry to the next PR. It is per
 draft, not per pull request: a call that sends every draft the caller holds needs an
 instruction covering each of them, and the single-draft form is what an instruction
-naming one reply admits. The issue
-comments the Scope and issue, Pre-merge issue check and Close issue steps require are
-published as usual (`issue-rules` → Progress Comments).
+naming one reply admits. The issue comments `work-sequence` requires are published as
+usual (`issue-rules` → Progress Comments).
 
 Report at the end of a review pass: that feedback is waiting, where it is, what it
 covers, and whether the draft was opened by this pass or reused. The draft mechanics
@@ -173,18 +126,19 @@ section.
 
 **Must**
 
-Conditions on the branch, each naming the moment it is established at (When a Check
-Runs):
+Conditions on the branch, each naming the moment it is established at
+(`work-sequence` → When a Check Runs):
 
-- [ ] Every check the change touches passes — at the round of edits
-- [ ] Branch is rebased onto the current target branch (no stale merge base) — at the push
-- [ ] Every check the project declares passes over the branch as it stands — at the push
-- [ ] Every commit in the branch builds independently (no broken intermediate state) — at the push
-- [ ] Every line of the pre-PR check in the module-sync skill of the version control system passes — at the push
-- [ ] Commit trailers conform to `commit-rules` — at the push
-- [ ] `CHANGELOG.md` updated — every user-visible change documented — at the push
+- [ ] Every check the change touches passes — at a round of edits
+- [ ] Branch is rebased onto the current target branch (no stale merge base) — at the Publish step
+- [ ] Every check the project declares passes over the branch as it stands — at the Publish step
+- [ ] Every commit in the branch builds independently (no broken intermediate state) — at the Publish step
+- [ ] Every line of the pre-PR check in the module-sync skill of the version control system passes — at the Publish step
+- [ ] Commit trailers conform to `commit-rules` — at the Publish step
+- [ ] `CHANGELOG.md` updated — every user-visible change documented — at the Publish step
 
-The pull request's own four properties are established with it instead:
+The pull request's own four properties are established at the Offer for review step
+instead:
 
 - The status of the checks reported on it, which the pipeline answers rather than a local run (`ci-cd-and-automation`)
 - A description carrying all four sections, `## Problem` included — see Description Structure
@@ -217,8 +171,8 @@ of them names a moment.
    naming this PR, which does not carry to the next one: the authorisation is per pull
    request, so a command merging several needs an instruction naming each of them.
 3. **Rebase before merge.** `git rebase <target>`, then merge from the current target
-   tip; the rebase moves the head, so it returns to the push moment and the checks of
-   that moment run again.
+   tip; the rebase moves the head, so it returns to the Publish step and the checks of
+   that moment run again (`work-sequence` → When a Check Runs).
 4. **`--no-ff` only.** No fast-forward merge, no squash merge.
 5. **Merge subject:** `Merge PR #<pr-number>: <pr subject>`, the PR subject verbatim
    and never re-prefixed with `type(scope):`, so a tracker ID in the title leaves both
@@ -228,9 +182,9 @@ of them names a moment.
 7. **Merge body required.** What was integrated and why, never empty (`commit-rules`).
 8. **Trailers:** the ban in `commit-rules` holds; `Co-authored-by` injected by the
    forge when committer differs from author is allowed.
-9. **Cleanup before the push.** Squash fixups (`commit-rules` → Fixup Commits) before
-   the branch is sent, never at merge time: a rewrite afterwards takes a force-push and
-   owes every check the push ran.
+9. **Cleanup before the Publish step.** Squash fixups (`commit-rules` → Fixup Commits)
+   before the branch is sent, never at merge time: a rewrite afterwards takes a
+   force-push and owes every check that step ran.
 10. **Rewrite squashed commit bodies** per `commit-rules` → Fixup / Squash Merges.
 
 The command performing the merge, and the repository settings it depends on, belong to
@@ -248,10 +202,11 @@ is split before review.
 
 **Recommended**
 
+- `work-sequence` — the order of work the Offer for review step belongs to, and the moment each check runs at.
 - `issue-rules` — the issue this PR resolves: title, templates, labels, lifecycle, progress comments.
 - `commit-rules` — commit message format and branch naming on the PR's branch.
 - `code-review-and-quality` — what a review looks for, where this skill states how a finding is worded.
 - `writing-style` — prose register in the description and in the review threads.
 - `ci-cd-and-automation` — the pipeline answering the checks reported on the pull request.
 - The module-sync skill of the version control system — the pre-PR check and the merge order the checklists gate on.
-- The CLI skill of the hosting platform — the commands behind the Workflow steps and the draft mechanics behind Pending by Default.
+- The CLI skill of the hosting platform — the commands behind the steps that reach this platform, and the draft mechanics behind Pending by Default.

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -69,6 +69,9 @@ convention and nothing reads it; what the same test decides is `bound-to`.
 
 **Must**
 
+A skill governing every task rather than a kind of one declares `always: true`, which
+takes it out of the set an agent chooses between. Nothing reads the key yet.
+
 `bound-to` is required: a non-empty list of contexts drawn from
 `config/skill-contexts.json`, naming the readers whose rules these are. The list is a
 conjunction, so a skill needing two contexts names both, and `universal` stands alone. A

--- a/skills/work-sequence/SKILL.md
+++ b/skills/work-sequence/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: work-sequence
+version: "1.0.0"
+description: Apply when carrying a change from a task to a closed issue
+license: Unlicense
+metadata:
+  author: ssoft
+  tier: process
+  bound-to:
+    - universal
+  rubric: applied
+  tags:
+    - workflow
+    - process
+---
+
+# Skill: Work Sequence
+
+Apply from the moment a task is taken up until the issue it resolves is closed.
+
+## Project Overrides
+
+**Must**
+
+An order of work defined in the repository's `AGENTS.md` or in a project skill must be
+followed instead of this one.
+
+## The Sequence
+
+**Should**
+
+Eight steps, in order. A step is cited by name, never by number. Each step states what it
+achieves; what the result carries, and the command that produces it, belong to the skills
+named beside it.
+
+| Step | Achieves | Runs when | Stated by |
+|---|---|---|---|
+| Scope and issue | the change has a tracked issue in the repository it belongs to, a module's in that module's own repository | the task is taken up | `issue-rules` |
+| Branch | the work has a branch of its own, named | before the first commit | `commit-rules` → Branch Naming |
+| Commits | the change is recorded on that branch | a round of edits closes | `commit-rules` |
+| Publish | the branch stands where a reviewer reads it | the local remarks are exhausted | `pr-rules` → Pre-Open Checklist |
+| Offer for review | the change is offered for review | the Publish step has run | `pr-rules` |
+| Pre-merge issue check | the tracked issue is reconciled against what the change delivers, with a comment there naming which items it resolves | the review has passed | `pr-rules` → Pre-Merge Checklist, `issue-rules` → Progress Comments |
+| Integrate | the change sits on the target branch | the Pre-merge issue check clears | `pr-rules` → Merge Strategy |
+| Close issue | the issue's state matches what the change delivered | the Integrate step has run | `issue-rules` → Lifecycle |
+
+- A round of review and fix returns to the Commits step and runs forward from there; the
+  Publish step's condition is the same on every pass.
+- A step reaching the tracker runs through the CLI skill of the issue tracker; the offer
+  for review, through the CLI skill of the hosting platform.
+
+## When a Check Runs
+
+**Should**
+
+Every check run over the change belongs to exactly one of three moments. Which checks a
+project declares is the project's own; the pipeline that runs them on a server is
+`ci-cd-and-automation`.
+
+| Moment | Runs | Does not run |
+|---|---|---|
+| A round of edits — one pass over the branch, the first and every fix answering a review remark alike | the checks the change touches: the tests whose subject the change names, plus any check the change's own files are the input of, on the commit that closes the round | what reads the branch as a whole |
+| The Publish step, once per branch state offered for review | what reads the branch as a whole | a round of review and fix, which reads the branch as it stands locally; a check whose answer still stands |
+| The Offer for review step | nothing over the branch, which the Publish step answered | every check of the branch; the properties of the offer itself are established here instead (`pr-rules` → Pre-Open Checklist) |
+
+- A check that has passed stands while the branch head is the commit it ran against; an
+  amend, a rebase or a further commit moves that head and puts the check back.
+- The rebase therefore runs first at the Publish step, ahead of every check measured
+  against the head it moves.
+
+## Cross-References
+
+**Recommended**
+
+- `issue-rules` — the issue's title, description, labels, lifecycle and progress comments.
+- `commit-rules` — the branch name and the commit message.
+- `pr-rules` — what the offer for review carries: its title, description, review comments, two checklists and merge strategy.
+- `ci-cd-and-automation` — the pipeline running a project's checks on a server.
+- `changelog` — the entry a branch carries before it is published.
+- `code-review-and-quality` — what the review between the Publish and Pre-merge issue check steps looks for.
+- The module-sync skill of the version control system — the module refs a branch records.
+- The CLI skill of the hosting platform — the commands behind the steps that reach it.

--- a/skills/writing-style/SKILL.md
+++ b/skills/writing-style/SKILL.md
@@ -6,6 +6,7 @@ license: Unlicense
 metadata:
   author: ssoft
   tier: narrow
+  always: true
   bound-to:
     - universal
   tags:

--- a/templates/SKILL.md
+++ b/templates/SKILL.md
@@ -25,6 +25,10 @@ metadata:
   # gate. A skill whose intent is wider than its files keeps the default: an API is
   # designed before the header exists, and no edit has happened yet to announce it.
   reminder: false
+  # Optional, defaults to false. Set true where the skill governs every task rather
+  # than a kind of one, so it is not a skill the agent chooses between. Nothing reads
+  # it yet — the reminder that will is GH-208.
+  always: true
   # Optional. Skills that always apply alongside this one; the gate names them too.
   with:
     - <skill-name>

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -144,8 +144,8 @@ function skillsDeclaringRubric() {
 }
 
 // Extended by the pass that marks the next skill; every name here is checked below.
-const MARKED_SKILLS = ['comments', 'github-cli', 'gitlab-cli', 'pr-rules', 'skill-authoring',
-  'submodule-sync'];
+const MARKED_SKILLS = ['comments', 'github-cli', 'gitlab-cli', 'pr-rules',
+  'skill-authoring', 'submodule-sync', 'work-sequence'];
 
 function commandFiles() {
   const names = fs.readdirSync(commandsDir).filter(name => name.endsWith('.md'));

--- a/test/skill-catalog.test.js
+++ b/test/skill-catalog.test.js
@@ -112,8 +112,19 @@ test('loadCatalog defaults tier to domain and leaves paths empty', () => {
   try {
     writeSkill(tmp, 'alpha', 'description: Apply when alpha\n');
     assert.deepStrictEqual(loadCatalog(tmp), [
-      { name: 'alpha', description: 'Apply when alpha', tier: 'domain', paths: [], companions: [], boundTo: [], reminder: true },
+      { name: 'alpha', description: 'Apply when alpha', tier: 'domain', paths: [], companions: [], boundTo: [], reminder: true, always: false },
     ]);
+  } finally { rmTmp(tmp); }
+});
+
+test('loadCatalog carries the always declaration, and defaults it to false', () => {
+  const tmp = mkTmp();
+  try {
+    writeSkill(tmp, 'alpha', 'description: d\nmetadata:\n  always: true\n');
+    writeSkill(tmp, 'beta', 'description: d\n');
+    const catalog = loadCatalog(tmp);
+    assert.strictEqual(catalog.find(s => s.name === 'alpha').always, true);
+    assert.strictEqual(catalog.find(s => s.name === 'beta').always, false);
   } finally { rmTmp(tmp); }
 });
 

--- a/tools/skill-catalog.js
+++ b/tools/skill-catalog.js
@@ -110,6 +110,8 @@ function parseFrontmatter(source) {
   if (tier !== undefined) fm.tier = tier;
   const reminder = scalar('reminder');
   if (reminder !== undefined) fm.reminder = reminder !== 'false';
+  const always = scalar('always');
+  if (always !== undefined) fm.always = always === 'true';
   const paths = readSequence(block, 'paths');
   if (paths !== undefined) fm.paths = paths;
   const companions = readSequence(block, 'with');
@@ -140,6 +142,7 @@ function loadCatalog(skillsDir) {
       boundTo: fm.boundTo ?? [],
       // Design work precedes the file it produces, so paths alone never opt a skill out.
       reminder: fm.reminder ?? true,
+      always: fm.always ?? false,
     });
   }
   return catalog;


### PR DESCRIPTION
## Problem

The order of work from a task to a closed issue sat inside `pr-rules`, which declares
`bound-to: [forge]` and owns one artifact. The sequence is neither: it reaches the tracker,
the branch, the commits and the checks, and exists where changes are proposed by other
means than a forge. Two faults sit on the same seam: `writing-style` governs every task and
had no way to say so, and `/review-loop` assumed the work sits in a repository.

## Summary

- `work-sequence` states the eight steps, each with its condition and the skill owning what it produces
- `pr-rules` keeps the pull request alone; `issue-rules` and `commit-rules` route to `work-sequence` for the rest
- Three steps renamed after what they achieve: `Push` to `Publish`, `PR` to `Offer for review`, `Merge commit` to `Integrate`
- `writing-style` declares `always: true`, the key for a skill governing every task
- `/review-loop` takes the place it runs in from its caller, and names no repository

## Implementation

- `skills/work-sequence/SKILL.md` — `bound-to: [universal]`, `rubric: applied`, four marked sections; The Sequence and When a Check Runs moved whole out of `skills/pr-rules/SKILL.md`, which goes from 253 lines to 200 with its four remaining step references re-anchored
- `config/skill-contexts.json` — `tracker` gains `"role": "issue tracker"`, since `test/skill-contexts.test.js` bars a `[universal]` skill from naming an instance-bound one
- `AGENTS.md`, `README.md`, `CONTRIBUTING.md` — the ownership map, the skill table and six lifecycle-map stages renamed to the step names, so every file carries one vocabulary
- `tools/skill-catalog.js`, `skills/writing-style/SKILL.md`, `templates/SKILL.md` — `always` parsed off the frontmatter and defaulted to `false`; nothing consumes it yet, the reminder that will is a change of its own
- `commands/review-loop.md` — `## Where the Loop Runs` takes the place from the caller and asks when none is named; every git and forge name is gone, the command declaring `bound-to: [agent-tool]`
- `test/rubric.test.js`, `test/skill-catalog.test.js`, `CHANGELOG.md` — `MARKED_SKILLS` extended, the `always` default asserted, and one bullet per change

## Test plan

- [x] `npm test` — 691 tests, 691 passing
- [x] Each of the eight steps: a search for its distinguishing phrase returns one file
- [x] `pr-rules` read alone states what a pull request carries and states no order of work
- [x] `work-sequence` followed alone from a task to a closed issue: every step names what to do and which skill states the detail
- [x] `commands/review-loop.md` read alone names no git command, no forge and no path
- [ ] `node install.js` — out of scope here: GH-189 states it as the user's step, run on the merged `main`
