### PR TITLE
GH-196: Open a prescribing sentence with its force word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- A sentence prescribing an action to a person runs force word, action, what it acts on - "should extract the loop", never "the loop should be extracted"
+
 - A skill ships with the whole of its directory, so data a reader consults rather than obeys - a vocabulary, a table of values - sits beside `SKILL.md` and is read when the skill sends them to it, instead of loading with every application
 
 - Hook dispatch system: `PreToolUse`, `PostToolUse`, `Stop`, `UserPromptSubmit` event handlers

--- a/skills/writing-style/SKILL.md
+++ b/skills/writing-style/SKILL.md
@@ -64,11 +64,10 @@ now, and say what changed only when the reader has to act on the change.
 
 ## Name the Force, Not Just the Action
 
-Where text addressed to a person prescribes an action - a review comment or reply, a
-comment in an issue or a thread, a message - the sentence carries the word naming its
-binding force - must, should, recommended or may, one to one with the four markers. The
-bare infinitive and the bare noun phrase name no force: not "Extract the loop" but "the
-loop should be extracted". The words each force is stated with:
+A sentence prescribing an action to a person - in a review comment or reply, an issue or
+thread comment, a message - runs force word, action, what it acts on: "should extract the
+loop", never "the loop should be extracted", since the force word addresses whoever will
+act. The force is one of the four markers, and the words it is stated with are in
 `writing-language/<language>.json`, beside this file.
 ## No Figures That Go Stale
 


### PR DESCRIPTION
## Problem
The rule required a prescribing sentence to carry the word naming its force and
said nothing about where it sits. An agent writing review comments put it after
the subject - "Метод следует перенести", "Текст должен называть заголовок" - and
each sentence stated a property of the thing acted on rather than a task for the
reader. The rule's own contrast pair showed that same form. (GH-196)

## Summary
- A prescribing sentence runs force word, action, then what it acts on.
- The contrast pair no longer shows the form the rule forbids.

## Implementation
- `skills/writing-style/SKILL.md` → Name the Force, Not Just the Action: the order is fixed, with the reason it is that order - the force word is addressed to whoever will act - and the pair reads "should extract the loop", not "Extract the loop" and not "the loop should be extracted".
- `CHANGELOG.md`: one bullet under `### Added`.

## Test plan
- [x] `npm test` green.
- [x] The rule's own example satisfies the rule it states.
- [ ] `node install.js` puts the edited files where an agent reads them - the user's step.
