### PR TITLE
GH-198: Declare the readers a command's instructions are for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - A sentence prescribing an action to a person runs force word, action, what it acts on - "should extract the loop", never "the loop should be extracted"
+- A command declares `bound-to` as a skill does, and `test/skill-contexts.test.js` holds both: `/review-loop` states the isolated checkout and the steps that wait without naming one version control system or forge
 
 - A skill ships with the whole of its directory, so data a reader consults rather than obeys - a vocabulary, a table of values - sits beside `SKILL.md` and is read when the skill sends them to it, instead of loading with every application
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Slash commands orchestrating the agents above into the idea-to-release pipeline.
 | `/spec <idea>` | `spec-architect` — produces a specification (and ADR when warranted) |
 | `/build <task>` | `implementer` — implements one task by TDD from an existing spec |
 | `/ship [scope]` | `code-reviewer` + `security-auditor` in parallel → go/no-go → `release-manager` on go |
-| `/review-loop <tool(s)> [quick..ultra] [scope]` | caller-chosen tool(s) at a tool-agnostic depth, review → fix → re-review until clean or 3 passes, in the current checkout or an isolated worktree |
+| `/review-loop <tool(s)> [quick..ultra] [scope]` | caller-chosen tool(s) at a tool-agnostic depth, review → fix → re-review until clean or 3 passes, in the current checkout or an isolated one |
 
 ## Installation
 

--- a/commands/build.md
+++ b/commands/build.md
@@ -4,6 +4,8 @@ argument-hint: <task to implement>
 license: Unlicense
 metadata:
   author: ssoft
+  bound-to:
+    - agent-tool
   tags:
     - pipeline
     - implementation

--- a/commands/review-loop.md
+++ b/commands/review-loop.md
@@ -4,6 +4,8 @@ argument-hint: <tool(s)> [quick|light|normal|thorough|ultra] [scope] — e.g. "c
 license: Unlicense
 metadata:
   author: ssoft
+  bound-to:
+    - agent-tool
   tags:
     - pipeline
     - review
@@ -21,15 +23,14 @@ this run.
 
 Pick where every pass of this loop runs, once, before the first pass: the current
 working directory, when it is already checked out to the requested scope and carries no
-uncommitted change or unrelated in-progress work the review would disturb. Otherwise use
-an isolated worktree checked out to the requested scope — except when that scope *is*
-what the current directory already has checked out and the only problem is an
-uncommitted change; git refuses to check out the same branch into a second worktree, so
-there stash the change instead and review in the current directory, popping the stash
-back once the loop ends so nothing stays hidden in it. When a worktree was created for
-this run, remove it (`git worktree remove`) once the loop ends, whichever way it ends,
-after every fix from this run is committed (step 3) — the branch's commits live in the
-shared repo regardless of the worktree directory, so removing it loses nothing.
+uncommitted change or unrelated in-progress work the review would disturb. Otherwise
+take a second, isolated checkout of that scope — except when the scope *is* what the
+current directory already has and the only problem is an uncommitted change; a second
+checkout of the same branch is commonly refused, so set the change aside instead,
+review in the current directory, and restore it once the loop ends so nothing stays
+hidden in it. Discard a checkout taken for this run once the loop ends, whichever way
+it ends, after every fix from this run is committed (step 3) — the commits live in the
+repository, not in the directory they were made from, so discarding it loses nothing.
 
 Loop, for up to 3 passes:
 
@@ -60,11 +61,11 @@ and any nit/question resolved along the way) and what is still open (only possib
 pass found what, so the report reads as a history. Do not report the loop as clean when
 a blocking finding is still open.
 
-Local edits and fixes proceed automatically. What waits, and under which rule: `git push`,
-which a round of this loop does not reach (`pr-rules` → When a Check Runs); `gh issue edit` and
-`gh pr edit`, for the review wording they can put in front of a reader (`pr-rules` →
-Pending by Default); and the merge, which is the human's (`pr-rules` → Merge Strategy 2).
-This command fixes code; it does not publish or merge on its own.
+Local edits and fixes proceed automatically. What waits, and under which rule: the push,
+which a round of this loop does not reach (`pr-rules` → When a Check Runs); editing an
+issue or the pull request, for the review wording it can put in front of a reader
+(`pr-rules` → Pending by Default); and the merge, which is the human's (`pr-rules` →
+Merge Strategy 2). This command fixes code; it does not publish or merge on its own.
 
 This does not replace `/ship`: `/ship` stays a single-pass go/no-go with a fixed
 reviewer pair. Use this command instead when the change needs iteration, a different

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -4,6 +4,8 @@ argument-hint: [optional scope, defaults to the current diff/branch]
 license: Unlicense
 metadata:
   author: ssoft
+  bound-to:
+    - agent-tool
   tags:
     - pipeline
     - ship

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -4,6 +4,8 @@ argument-hint: <idea or task description>
 license: Unlicense
 metadata:
   author: ssoft
+  bound-to:
+    - agent-tool
   tags:
     - pipeline
     - spec

--- a/templates/COMMAND.md
+++ b/templates/COMMAND.md
@@ -4,6 +4,8 @@ argument-hint: <what $ARGUMENTS represents, e.g. "<task to implement>" or "[opti
 license: Unlicense
 metadata:
   author: <author or team name>
+  bound-to:
+    - <context from config/skill-contexts.json>
   tags:
     - pipeline
     - <stage-tag>
@@ -22,6 +24,8 @@ $ARGUMENTS
 
 <!-- Adding a command:
      1. Copy this file to commands/<name>.md and fill in the frontmatter and the prompt
-        above.
+        above. `bound-to` names the readers these instructions are for; name a tool or
+        a skill outside them by role instead - skills/skill-authoring/SKILL.md →
+        Contexts a Skill Is Bound To, Naming Another Skill.
      2. Add a row to the commands table in README.md.
      3. Run `node install.js`, which copies it to ~/.claude/commands/<name>.md. -->

--- a/test/skill-contexts.test.js
+++ b/test/skill-contexts.test.js
@@ -7,6 +7,7 @@ const { parseFrontmatter } = require('../tools/skill-catalog');
 
 const repoDir = path.join(__dirname, '..');
 const skillsDir = path.join(repoDir, 'skills');
+const commandsDir = path.join(repoDir, 'commands');
 const vocabularyFile = path.join(repoDir, 'config', 'skill-contexts.json');
 
 // An empty vocabulary would resolve every declaration against nothing, so it throws.
@@ -30,8 +31,12 @@ function chain(contexts, name) {
   return seen;
 }
 
+function read(file) {
+  return fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+}
+
 function readSkill(name) {
-  return fs.readFileSync(path.join(skillsDir, name, 'SKILL.md'), 'utf8').replace(/\r\n/g, '\n');
+  return read(path.join(skillsDir, name, 'SKILL.md'));
 }
 
 function skillCatalogue() {
@@ -61,6 +66,20 @@ function reaches(contexts, own, required) {
 // Read through the parser the gate and the reminder read, so all three agree.
 function boundTo(name) {
   return parseFrontmatter(readSkill(name)).boundTo ?? [];
+}
+
+// A command installs into another project exactly as a skill does and states rules there
+// the same way, so both answer for the declaration and for the routing built on it.
+function documents() {
+  const entries = [...skillCatalogue()]
+    .map(name => ({ what: `skill "${name}"`, skill: name, text: readSkill(name) }));
+  const files = fs.readdirSync(commandsDir).filter(name => name.endsWith('.md'));
+  // A vacuous pass would hide the commands going missing entirely.
+  if (files.length === 0) throw new Error(`no command files in ${commandsDir}`);
+  for (const name of files) {
+    entries.push({ what: `command "${name}"`, skill: null, text: read(path.join(commandsDir, name)) });
+  }
+  return entries.map(entry => ({ ...entry, own: parseFrontmatter(entry.text).boundTo ?? [] }));
 }
 
 test('every context names a parent the vocabulary defines', () => {
@@ -101,28 +120,27 @@ test('every context says what it means', () => {
   }
 });
 
-test('every skill declares a context its rules are bound to', () => {
-  for (const name of skillCatalogue()) {
-    assert.ok(boundTo(name).length > 0,
-      `skill "${name}" declares no bound-to, so nothing says which readers its rules are for`);
+test('every skill and command declares a context its rules are bound to', () => {
+  for (const { what, own } of documents()) {
+    assert.ok(own.length > 0,
+      `${what} declares no bound-to, so nothing says which readers its rules are for`);
   }
 });
 
-test('every context a skill declares is one the vocabulary defines', () => {
+test('every context declared is one the vocabulary defines', () => {
   const contexts = readVocabulary();
-  for (const name of skillCatalogue()) {
-    for (const context of boundTo(name)) {
+  for (const { what, own } of documents()) {
+    for (const context of own) {
       assert.ok(context in contexts,
-        `skill "${name}" declares context "${context}", which the vocabulary does not define`);
+        `${what} declares context "${context}", which the vocabulary does not define`);
     }
   }
 });
 
-test('a skill declaring universal declares nothing beside it', () => {
-  for (const name of skillCatalogue()) {
-    const declared = boundTo(name);
-    assert.ok(!declared.includes('universal') || declared.length === 1,
-      `skill "${name}" declares universal alongside ${declared.filter(c => c !== 'universal').join(', ')}`);
+test('declaring universal declares nothing beside it', () => {
+  for (const { what, own } of documents()) {
+    assert.ok(!own.includes('universal') || own.length === 1,
+      `${what} declares universal alongside ${own.filter(c => c !== 'universal').join(', ')}`);
   }
 });
 
@@ -141,12 +159,12 @@ function roleNouns(contexts) {
 test('every role phrase names a context the vocabulary carries', () => {
   const nouns = roleNouns(readVocabulary());
   const unresolved = [];
-  for (const name of skillCatalogue()) {
+  for (const { what, text } of documents()) {
     // Only the definite form names a context; "of that language" carries it from before.
-    const text = readSkill(name).replace(/\s+/g, ' ');
-    for (const [, tail] of text.matchAll(ROLE_PHRASE)) {
+    const flat = text.replace(/\s+/g, ' ');
+    for (const [, tail] of flat.matchAll(ROLE_PHRASE)) {
       if (!nouns.some(({ noun }) => tail === noun || tail.startsWith(`${noun} `))) {
-        unresolved.push(`${name}: "the ... skill of the ${tail.slice(0, 40)}"`);
+        unresolved.push(`${what}: "the ... skill of the ${tail.slice(0, 40)}"`);
       }
     }
   }
@@ -156,19 +174,18 @@ test('every role phrase names a context the vocabulary carries', () => {
 });
 
 // A backticked skill name here is a routing, never an illustration: the ban is flat.
-test('no skill names a skill bound to an instance its own context does not reach', () => {
+test('nothing names a skill bound to an instance its own context does not reach', () => {
   const contexts = readVocabulary();
   const catalogue = skillCatalogue();
   const forbidden = [];
-  for (const name of catalogue) {
-    const own = boundTo(name);
-    for (const named of skillsNamed(readSkill(name), catalogue)) {
-      if (named === name) continue;
+  for (const { what, skill, own, text } of documents()) {
+    for (const named of skillsNamed(text, catalogue)) {
+      if (named === skill) continue;
       const out = boundTo(named).filter(context => !reaches(contexts, own, context));
-      if (out.length > 0) forbidden.push(`${name} [${own}] names ${named} [${out}]`);
+      if (out.length > 0) forbidden.push(`${what} [${own}] names ${named} [${out}]`);
     }
   }
   assert.deepStrictEqual(forbidden, [],
-    'a skill naming one bound to an instance its own reader may not be in routes by ' +
+    'a file naming a skill bound to an instance its own reader may not be in routes by ' +
     'role — "the API-design skill of the language being written" — and names no skill');
 });


### PR DESCRIPTION
## Problem

`install.js` copies `commands/*.md` into the config directory, so a command reaches every
project the way a skill does. A skill says which readers its rules are for in `bound-to`
and `test/skill-contexts.test.js` holds that declaration; a command declares nothing and
the check reads `skills/` only. `/review-loop` therefore instructs by name a version
control system and a forge the reader may not have — `git worktree remove`, `git push`,
`gh issue edit`, `gh pr edit`. Resolves GH-198.

## Summary

- Every command declares `bound-to: [agent-tool]`.
- `/review-loop` states the isolated checkout, the push and the issue/PR edit without
  naming git or `gh`.
- `test/skill-contexts.test.js` reads `commands/` beside `skills/`.
- `templates/COMMAND.md` carries the key and the step that fills it.

## Implementation

- `commands/*.md` — `bound-to` sits under `metadata:`, where the routing keys of a skill
  sit, so `parseFrontmatter` reads it unchanged.
- `commands/review-loop.md` — `[agent-tool]`, not `[agent-tool, git]`: a general command
  narrowing its declaration to legitimise a tool name is the defect, not the fix.
- `commands/review-loop.md` — the second-checkout paragraph keeps its substance (why the
  same branch is not checked out twice, what to do instead, when to discard) with the
  mechanics left to the reader.
- `test/skill-contexts.test.js` — `documents()` yields skills and commands as one list,
  and the five per-file assertions iterate it; `skillCatalogue()` still resolves a
  backticked name, since only a skill can be named.
- `templates/COMMAND.md` — the step points at `skill-authoring` for the vocabulary and
  the role rule rather than restating either.
- `agents/*.md` is untouched: no persona names a tool, and the `cpp-` routing they do
  carry is GH-182.

## Test plan

- [x] `npm test` — 683 pass, 0 fail
- [x] Removing `bound-to` from `commands/build.md` fails assertion 5:
      `command "build.md" declares no bound-to`
- [x] Naming `` `cpp-coding` `` from `commands/build.md` fails assertion 9:
      `command "build.md" [agent-tool] names cpp-coding [cpp]`
- [x] `grep -nE '\b(gh|glab|git|worktree|stash)\b' commands/*.md` comes back empty
