### PR TITLE
GH-205: State what a stack is on each platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `github-cli` and `gitlab-cli` declare `rubric: applied`: every `##` section carries one of the four binding-force markers, and `test/rubric.test.js` holds them
 - A command carries the caller's text in a final `## The Caller's Text` section, below whose opening paragraph a heading, a marker or a directive confers nothing; `config/claude-config-rules.md` says the same of every text that is the subject of the work
 - A sentence prescribing an action to a person runs force word, action, what it acts on - "should extract the loop", never "the loop should be extracted"
 - A command declares `bound-to` as a skill does, and `test/skill-contexts.test.js` holds both: `/review-loop` states the isolated checkout and the steps that wait without naming one version control system or forge
@@ -37,7 +38,7 @@
 - `AGENTS.md`: an Idea-to-Release Pipeline section describing the `/spec` -> `/build` -> `/ship` flow, each command a wrapper over the personas its own `commands/<name>.md` names
 - `comment-check` tool: a `PostToolUse` reminder when an edit adds a new non-Doxygen comment, pointing back at the `comments` skill; it runs unconditionally, unlike the lint tools
 - `review-publish-guard` tool: a `gh` command that publishes review feedback the moment it runs raises a permission prompt naming the pending-review alternative, while the pending path itself runs unprompted
-- Skills: `github-cli` and `gitlab-cli` - the `gh` and `glab` commands behind the process skills: issues, pull and merge requests, labels, the pending-review and draft-note cycles, and merging. Policy stays in `pr-rules` and `issue-rules`
+- Skills: `github-cli` and `gitlab-cli` - the `gh` and `glab` commands behind the process skills: issues, pull and merge requests, labels, the pending-review and draft-note cycles, stacks, and merging. Policy stays in `pr-rules` and `issue-rules`
 - `/review-loop` command: iterates review -> fix -> re-review until a pass reports no blocking finding, capped at 3 passes, with the depth taken from a `quick`/`light`/`normal`/`thorough`/`ultra` scale. A cap reached still blocking reports as not converging
 - `skill-gate` denies the first `Edit`/`Write`/`MultiEdit`/`NotebookEdit` on a file whose claiming skills are not loaded and warns on a repeat, so an agent that cannot invoke the Skill tool loses one attempt rather than the task. A shell command writing to such a file passes the same check
 - `statusline` tool: renders the line under the prompt - model, effort, context and the two rate-limit windows with their reset times, coloured by how full they are, and the branch. Installing takes over the single `statusLine` slot, which `uninstall` gives back
@@ -48,6 +49,9 @@
 - `skill-authoring` skill: naming a skill after its concern, declaring `bound-to`, marking each `##` section with the force it carries, one file per skill, and the rename. `AGENTS.md` states none of them and keeps this repository's own catalog steps
 
 ### Changed
+- `pr-rules` → Pending by Default states its exception per draft: a call sending every draft the caller holds needs an instruction covering each, where one naming a single reply admits the single-draft form
+- `pr-rules` → Merge Strategy 2 answers a command that merges several pull requests at once: the authorisation is per pull request, so such a command needs an instruction naming each of them
+- The flags, limits and traps of `github-cli` and `gitlab-cli` are tables rather than paragraphs, so what a flag does sits beside what it answers when it goes wrong
 - `/ship` is `/review`, and reports a verdict without preparing anything: the release follows the merge, which is the human's, so `release-manager` is invoked directly at the Release row rather than from a command
 - `/build` is `/implement`, and the pipeline stage it carries is Implement: the command implements one task by TDD, where a build is what a compiler produces
 
@@ -97,6 +101,7 @@
 
 ### Fixed
 
+- `github-cli` had the `merge-async` body at four fields where it takes five, and sent the reader to re-read the pull request for a result the endpoint answers by uuid at `GET .../merge-async/<uuid>`
 - The `git submodule status` prefix `+` reads as a difference in either direction, not as the module being ahead: `submodule-sync` gates `git add` on a containment check against the index, so a module reset to an earlier commit is not written back into the superproject
 - `install` no longer replaces `~/.claude/CLAUDE.md`. This repository's rules install as `~/.claude/claude-config-rules.md`, and `CLAUDE.md` gets one `@claude-config-rules.md` import line, keeping every other byte; `uninstall` subtracts exactly that line
 - Each persona agent carries the `Skill` tool and names the skills it loads, so it follows the skills themselves rather than an abridged copy of them in its own definition

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `debugging` | Root-cause investigation before proposing a fix |
 | `deprecation-and-migration` | Retiring a public API and writing a migration guide |
 | `editing` | File editing workflow (re-read before edit) |
-| `github-cli` | `gh` mechanics — issues, PRs, labels, pending review threads, merges |
-| `gitlab-cli` | `glab` mechanics — issues, MRs, labels, draft notes, merges |
+| `github-cli` | `gh` mechanics — issues, PRs, labels, pending review threads, stacks, merges |
+| `gitlab-cli` | `glab` mechanics — issues, MRs, labels, draft notes, stacks, merges |
 | `hook-scripts` | Writing Claude Code hooks and tools |
 | `issue-rules` | Tracker issue title, description, labels, priority, lifecycle |
 | `node-testing` | Conventions for this repo's `test/*.test.js` (node:test) |

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -6,6 +6,7 @@ license: Unlicense
 metadata:
   author: ssoft
   tier: domain
+  rubric: applied
   bound-to:
     - github
   tags:
@@ -29,6 +30,8 @@ help is silent or misleading. No rule about *when* an action is allowed lives he
 
 ## Project Overrides
 
+**Must**
+
 Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own
 `gh` conventions, follow those instead. This skill is the fallback for projects that do not
 specify their own.
@@ -37,22 +40,28 @@ specify their own.
 
 ## Conventions
 
-- `gh api` typing: `-f name=value` sends a **string**, `-F name=value` infers the type
-  (integer, boolean, `null`, `@file`). An integer through `-f` against an `Int!` variable
-  answers `Variable $n of type Int! was provided invalid value`. Neither flag carries a
-  GraphQL list or input object — see Traps.
-- `gh api graphql --input <file>` sends a request too complex for flags. The file holds
-  `{"query":"query(...){...}","variables":{...}}` — query and variables together; a bare
-  variables object answers `A query attribute must be specified and must be a string.`
-- `--jq <expr>` filters a response client-side; `--json <fields>` on the porcelain commands
-  (`gh issue view`, `gh pr view`) selects fields explicitly and prints JSON.
-- `-R <owner>/<repo>` targets a repository other than the current checkout's.
-- `--body-file <path>` takes a body from a file — the only reliable way to pass a
-  description containing backticks, quotes, or newlines through a shell. `-` reads stdin.
+**Should**
+
+| Flag | What it does |
+|---|---|
+| `--jq <expr>` | filters the response client-side |
+| `--json <fields>` | on a porcelain command (`gh issue view`, `gh pr view`) selects fields and prints JSON |
+| `-R <owner>/<repo>` | targets a repository other than the current checkout's |
+| `--body-file <path>` | takes a body from a file, `-` from stdin — the only reliable way to pass backticks, quotes or newlines through a shell |
+
+Three pass data to `gh api`, and each has a shape it will not carry:
+
+| Flag on `gh api` | Sends | Where it bites |
+|---|---|---|
+| `-f name=value` | a string | an integer against an `Int!` variable answers `Variable $n of type Int! was provided invalid value` |
+| `-F name=value` | the inferred type — integer, boolean, `null`, `@file` | carries no GraphQL list or input object, and neither does `-f` — see Traps |
+| `--input <file>` | a whole request body | for GraphQL the file holds query and variables together, `{"query":"...","variables":{...}}`; a bare variables object answers `A query attribute must be specified and must be a string.` |
 
 ---
 
 ## Issues
+
+**Should**
 
 ```
 # existing labels, before inventing one
@@ -83,6 +92,8 @@ Create the label first rather than retrying without it.
 
 ## Pull Requests
 
+**Should**
+
 ```
 # open
 gh pr create --base <target> --title '<title>' --body-file <path> \
@@ -98,55 +109,104 @@ gh pr merge <n> --merge -t "<subject>" -b "<body>" --delete-branch
 gh api repos/{owner}/{repo}/pulls/<n>/merge-async -X PUT \
   -f merge_method=merge -f sha=<full-head-sha> \
   -f commit_title='<subject>' -f commit_message='<body>'
+
+# its result, by the uuid the call above answered with
+gh api repos/{owner}/{repo}/pulls/<n>/merge-async/<uuid>
 ```
 
-- `--merge` is the `--no-ff` equivalent: it always writes a two-parent merge commit, and
-  `-t`/`-b` set that commit's subject and body. `--delete-branch` removes the head branch
-  and leaves the base alone. `--rebase` ignores `-t`/`-b`: the commits it replays keep the
-  branch's own messages.
-- The merge runs server-side against the pushed branch. A commit amended locally and not
-  pushed takes no part in it, and the merge commit is committed by
-  `GitHub <noreply@github.com>`, not by the local git identity.
-- `PUT /repos/{owner}/{repo}/pulls/{n}/merge-async` is a second merge endpoint `gh` exposes
-  no command for, and it is asynchronous. Its four fields — `merge_method`, `commit_title`,
-  `commit_message` and `sha` — are all strings, so each goes through `-f`, as in the block
-  above. It answers
-  `{"status":"pending","details":{"message":"Merge request enqueued.", ...}}` and returns
-  before the merge happens, so read the pull request back for the merge commit rather than
-  taking the response as the result. The synchronous merge above is the default path — see
-  Stacks for the case that needs this one.
-- `merge-async` needs the **full** head sha. An abbreviated one answers `HTTP 400`,
-  `{"status":"failed","details":{"message":"Pull request head branch was modified."}}` — a
-  message naming a race that did not happen, which sends the reader looking for a push
-  nobody made. Take the sha from `gh pr view <n> --json headRefOid` and pass it whole.
-- Repository settings it depends on: "Allow merge commits" ON, and "Require linear history"
-  OFF. The second is a rule on the branch rather than on a person; what varies by person is
-  `enforce_admins`, which decides whether an administrator is held to it. With
-  `required_linear_history` and `enforce_admins` both on, `--merge` answers
-  `GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)`; with
-  `enforce_admins` off, an administrator's merge commit goes through. Read
-  `required_linear_history` and `enforce_admins` with
-  `gh api repos/{owner}/{repo}/branches/{branch}/protection` before treating that refusal
-  as a fault in the command.
+| Flag on `gh pr merge` | What it does |
+|---|---|
+| `--merge` | the `--no-ff` equivalent: always a two-parent merge commit, whose subject and body are `-t`/`-b` |
+| `--rebase` | ignores `-t`/`-b`; the commits it replays keep the branch's own messages |
+| `--delete-branch` | removes the head branch and leaves the base alone. Where an open pull request targets that head branch, read Stacks before passing it |
+
+The merge runs server-side against the pushed branch, so a commit amended locally and not
+pushed takes no part in it, and `GitHub <noreply@github.com>` commits the merge rather
+than the local git identity.
+
+`merge-async` is a second merge endpoint `gh` exposes no command for, and the one a
+registered stack takes — see Stacks. The synchronous merge above is the default path.
+
+| Of `merge-async` | What it is |
+|---|---|
+| its body | `merge_method`, `commit_title`, `commit_message` and `sha`, all strings and so all through `-f`; a fifth, `merge_action`, is optional and defaults to `default` |
+| its answer | `{"status":"pending","details":{"message":"Merge request enqueued.","uuid":"<uuid>","expected_head_sha":"<sha>"}}`, before the merge happens |
+| its result | `GET .../merge-async/<uuid>`, answering `{"status":"merged","details":{"message":"Pull request was merged.","sha":"<merge-sha>"}}` — not the enqueue response |
+| an abbreviated `sha` | `HTTP 400`, `{"status":"failed","details":{"message":"Pull request head branch was modified."}}`, naming a race that did not happen. Take the sha whole from `gh pr view <n> --json headRefOid`; passed whole, that message reports the race it names |
+
+`--merge` needs "Allow merge commits" on and "Require linear history" off. The refusal
+`GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)` names a
+repository setting rather than a fault in the command, and which one takes a read of
+`gh api repos/{owner}/{repo}/branches/{branch}/protection`:
+
+| The refusal comes from | Refused for |
+|---|---|
+| "Allow merge commits" off | everyone |
+| `required_linear_history` on, `enforce_admins` on | everyone |
+| `required_linear_history` on, `enforce_admins` off | everyone but an administrator |
 
 ---
 
 ## Stacks
 
-A pull request opened with `--base` set to another pull request's head branch chains the
-two, and GitHub holds the chain as a **stack**. On such a chain:
+**Should**
 
-- A merge refused with a pointer to `PUT /repos/{owner}/{repo}/pulls/{n}/merge-async` goes
-  through that endpoint instead of through `gh pr merge` — its arguments and its full-sha
-  requirement are under Pull Requests above.
-- When the base merges, the dependent pull request may be retargeted and its head
-  force-pushed, the same tree under a new sha. Read the head sha again with
-  `gh pr view <n> --json headRefOid` before passing it to `merge-async`: one held from
-  before the base merged names a commit that is no longer the head.
+A **stack** is a chain of pull requests, each targeting the head branch of the one below,
+registered with GitHub as an object of its own. Public preview since 30 July 2026. Opening
+one with `--base` on another's head branch builds the chain and nothing else; registering
+it is a separate act:
+
+```
+# once per machine, writing an executable under the user's home
+gh extension install github/gh-stack --pin <commit-sha>
+
+# register open pull requests, bottom first, with no local tracking
+gh stack link <bottom> <next> <top>
+
+# the same over HTTP, the body carrying the whole ordered membership
+gh api repos/{owner}/{repo}/stacks -X POST \
+  -F 'pull_requests[]=<bottom>' -F 'pull_requests[]=<next>' -F 'pull_requests[]=<top>'
+```
+
+Registration decides how the bottom is merged, and what becomes of the rest:
+
+| The chain | Merging the bottom | The pull request that targeted its head branch | The rest above |
+|---|---|---|---|
+| unregistered | `gh pr merge <bottom> --merge --delete-branch` | closes on the deletion, whether it rides the merge or follows it, and while its base ref stays deleted it is neither reopened nor retargeted — the retargeting GitHub documents for a deleted head branch reaches no unregistered chain | untouched: each still targets a branch that is still there |
+| a registered stack | `merge-async` on the bottom, or `gh stack merge <n> --merge --yes` | retargeted onto the merged base and force-pushed by the cascading rebase: `automatic_base_change_succeeded`, then `head_ref_force_pushed` | each keeps the target it had, and the rebase force-pushes both its refs: `base_ref_force_pushed`, `head_ref_force_pushed` |
+
+| Refusal or limit | What it takes |
+|---|---|
+| the synchronous merge on a pull request of a stack | refused: `This pull request is part of a stack and must be merged using the asynchronous merge REST API` |
+| a chain across a fork | cannot be registered at all: every branch of a stack lives in one repository |
+| a history that is not linear | the merge is refused, until `gh stack checkout <stack-number>` then `gh stack rebase` and `gh stack push`, or **Rebase stack** in the merge box, server-side |
+| no branch-deletion parameter on either stack merge | the bottom's head branch goes once `gh pr view <n> --json baseRefName` shows the dependent moved; `merge-async` answers before the merge happens, so its response names no state to act on |
+| "Automatically delete head branches" on | the branch goes with the merge, so an unregistered dependent closes whatever else is done |
+
+`merge-async` merges the one pull request named. `gh stack merge` merges it and every one
+below, and the authorisation that needs is `pr-rules` → Merge Strategy 2; it also takes the
+merge method last used unless `--merge` is given, which is a squash or a rebase where that
+ran last, both forbidden by `pr-rules` → Merge Strategy 4.
+
+The cascading rebase moves every head above the merged pull request and leaves every tree,
+so read the head sha again with `gh pr view <n> --json headRefOid` — full, per Pull
+Requests above — since `merge-async` refuses a stale one.
+
+REST creates and modifies a stack; GraphQL only reads one.
+
+| Call | Effect |
+|---|---|
+| `POST /repos/{owner}/{repo}/stacks`, body `{"pull_requests":[...]}` | creates a stack from an ordered list |
+| `POST /repos/{owner}/{repo}/stacks/{stack_number}/add`, same body | appends onto the top of one |
+| `POST /repos/{owner}/{repo}/stacks/{stack_number}/unstack` | returns the unmerged pull requests to an unregistered chain, where the `unregistered` row above applies to them again. Answers 200 where the stack survives and 204 where it dissolves, which `gh api` tells apart only under `--include` |
+| `GET /repos/{owner}/{repo}/stacks`, `GET .../stacks/{stack_number}` | read |
+| `stack` and `stackEntry` on the GraphQL `PullRequest` | read |
 
 ---
 
 ## Review Threads
+
+**Must**
 
 The GraphQL mutations below keep feedback in a pending review. Sending has one
 granularity, the whole pending review: `submitPullRequestReview` sends every thread hanging
@@ -198,38 +258,35 @@ gh api graphql -f query='mutation($rev:ID!,$thread:ID!,$body:String!){addPullReq
 gh api graphql -f query='mutation($rev:ID!){deletePullRequestReview(input:{pullRequestReviewId:$rev}){pullRequestReview{state}}}' -f rev=<review-id>
 ```
 
-Two variants of the thread mutation reach a line the plain form does not. `side:LEFT` with
-the old file's line number places a finding on a line the branch deletes, and `startLine`
-and `startSide` beside `line` and `side` place one across a range. Neither leaves the
-pending review.
+Two variants of the thread mutation reach a line the plain form does not, and neither
+leaves the pending review:
 
-The discard takes its own threads with it, but not at once: a `reviewThreads` read straight
-after it can still list them. Confirm against the ids `addPullRequestReviewThread` returned
-for that review, not against the connection's size — `reviewThreads` answers every thread
-on the pull request, a submitted review's included, so the count has no zero to reach.
+| To place a finding on | Add to `addPullRequestReviewThread` |
+|---|---|
+| a line the branch deletes | `side:LEFT`, with the old file's line number |
+| a range | `startLine` and `startSide` beside `line` and `side` |
+
+The discard takes its own threads with it, but not at once: a `reviewThreads` read
+straight after it can still list them. Confirm against the ids
+`addPullRequestReviewThread` returned for that review, not against the connection's
+size — `reviewThreads` answers every thread on the pull request, a submitted review's
+included, so the count has no zero to reach.
 
 ### Traps
 
 What the CLI help does not state:
 
-1. One pending review per user per PR. A second `addPullRequestReview` answers
-   `User can only have one pending review per pull request` (`type: UNPROCESSABLE`) — look
-   for an open one and reuse it rather than creating a second.
-2. A typed GraphQL variable cannot go through `-f`/`-F`: the `threads` list on
-   `addPullRequestReview` is a list of input objects, and both flags produce scalars. The
-   JSON arrives as a string and the server answers
-   `Variable $threads of type [DraftPullRequestReviewThread!] was provided invalid value`,
-   `Expected ... to be a key-value object`. Add threads one at a time with
-   `addPullRequestReviewThread`, or send the whole request with `gh api graphql --input
-   <file>` (see Conventions).
-3. `reviewThreads` pages 50 at a time. On a PR carrying more, `first:50` answers
-   `hasNextPage: true` and the rest arrive only on a re-run with `-f after=<endCursor>`.
-   Page while `hasNextPage` is true, or a long PR's later threads are invisible to the
-   lookup.
+| The limit | It answers | The way round it |
+|---|---|---|
+| one pending review per user per pull request | `User can only have one pending review per pull request` (`type: UNPROCESSABLE`) | look for an open one and reuse it |
+| `-f`/`-F` produce scalars, so a typed GraphQL variable cannot go through them — `threads` on `addPullRequestReview` is a list of input objects | `Variable $threads of type [DraftPullRequestReviewThread!] was provided invalid value`, `Expected ... to be a key-value object` | one thread at a time with `addPullRequestReviewThread`, or the whole request through `gh api graphql --input <file>` (Conventions) |
+| `reviewThreads` pages 50 at a time | `hasNextPage: true` on a longer pull request | page while `hasNextPage` is true, or later threads stay invisible to the lookup |
 
 ---
 
 ## Cross-References
+
+**Recommended**
 
 - `pr-rules` — PR title, description, review comment wording, merge strategy, and the
   rules governing which of these commands may be run.

--- a/skills/gitlab-cli/SKILL.md
+++ b/skills/gitlab-cli/SKILL.md
@@ -6,6 +6,7 @@ license: Unlicense
 metadata:
   author: ssoft
   tier: domain
+  rubric: applied
   bound-to:
     - gitlab
   tags:
@@ -29,6 +30,8 @@ help is silent or misleading. No rule about *when* an action is allowed lives he
 
 ## Project Overrides
 
+**Must**
+
 Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own
 `glab` conventions, follow those instead. This skill is the fallback for projects that do
 not specify their own.
@@ -37,37 +40,36 @@ not specify their own.
 
 ## Conventions
 
-- `glab api` types its fields the way `gh api` does: `-F/--field` infers the type,
-  `-f/--raw-field` sends a string. Neither flag parses a JSON array or object — see Draft
-  Notes → Traps for what that costs.
-- **There is no `--jq` flag.** `glab api` filters nothing client-side: it prints JSON
-  (`--output json`, the default) or one object per line (`--output ndjson`, one line per
-  array element), and any filtering is a separate step in the pipe. Copying a
-  `gh api --jq` line over answers `Unknown flag: --jq.`
-- `--input <file>` (`-` for stdin) sends a raw body, and is the only way to send nested
-  JSON. It sets no `Content-Type` of its own: without `-H 'Content-Type: application/json'`
-  GitLab answers `HTTP 415`, `{"error":"The provided content-type '' is not supported."}`
-- Paths take placeholders expanded from the current checkout's project — `:id`,
-  `:fullpath`, `:namespace`, `:repo`, `:branch`, `:user`. Outside a checkout whose remotes
-  reach GitLab they are not expanded but refused, with
-  `Unable to expand placeholder in path`. Pass `--hostname <host>` and the numeric project
-  id or the full path URL-encoded (`group%2Fsubgroup%2Fproject`) instead.
-- `-f` means different things in different commands: a string field on `glab api`, but
-  `--fill` on `glab mr create`, which takes no value — `glab mr create -f title=x` answers
-  `Accepts 0 arg(s), received 1.`
-- **Only `-F/--field` expands `@<path>` into the file's contents.** `-f/--raw-field` sends
-  the literal string `@C:/path/to/file`, and the API accepts it: the issue is created with
-  the path as its description, with no error to notice. A body read from a file therefore
-  goes through `-F description=@<path>`.
-- `:iid` on an issue or MR path is the per-project number shown in the UI, not the
-  instance-wide `id` the same object also carries. The `id` in that position answers
-  `{"message":"404 Not found"}` rather than reaching the object. The numbers that do
-  collide are across types: `projects/:id/issues/1` and `projects/:id/merge_requests/1` are
-  two unrelated objects, since `iid` is numbered per type.
+**Should**
+
+| Flag on `glab api` | Sends | Where it bites |
+|---|---|---|
+| `-F/--field` | the inferred type, and `@<path>` expanded into the file's contents | a body read from a file goes through it, `-F description=@<path>` |
+| `-f/--raw-field` | a string, `@<path>` included | the API accepts the literal `@C:/path/to/file` as the description, with no error to notice |
+| `--input <file>`, `-` for stdin | a raw body — the only way to send nested JSON | sets no `Content-Type`, so without `-H 'Content-Type: application/json'` GitLab answers `HTTP 415`, `{"error":"The provided content-type '' is not supported."}` |
+
+Neither `-F` nor `-f` parses a JSON array or object; Draft Notes → Traps states what that
+costs.
+
+Three more, each of which reads as a `gh` habit that does not carry over:
+
+| Expectation from `gh` | What `glab` does |
+|---|---|
+| `--jq <expr>` filters client-side | there is no such flag: `Unknown flag: --jq.` `glab api` prints JSON (`--output json`, the default) or one object per line (`--output ndjson`), and filtering is a separate step in the pipe |
+| `-f` is a field everywhere | on `glab mr create` it is `--fill` and takes no value: `glab mr create -f title=x` answers `Accepts 0 arg(s), received 1.` |
+| a path placeholder always expands | `:id`, `:fullpath`, `:namespace`, `:repo`, `:branch` and `:user` expand from the current checkout's project. Outside a checkout whose remotes reach GitLab they are refused — `Unable to expand placeholder in path` — and the way round is `--hostname <host>` with the numeric id or the URL-encoded full path (`group%2Fsubgroup%2Fproject`) |
+
+`:iid` on an issue or merge request path is the per-project number the interface shows,
+not the instance-wide `id` the same object also carries; that `id` answers
+`{"message":"404 Not found"}` rather than reaching the object. What does collide is one
+number across two types: `projects/:id/issues/1` and `projects/:id/merge_requests/1` are
+unrelated objects, `iid` being numbered per type.
 
 ---
 
 ## Issues
+
+**Should**
 
 ```
 # existing labels
@@ -105,6 +107,8 @@ glab issue update <iid> --label '<label>' --unlabel '<label>'
 
 ## Merge Requests
 
+**Should**
+
 ```
 # open
 glab mr create --source-branch <branch> --target-branch <target> \
@@ -123,23 +127,30 @@ glab mr merge <iid> --message '<subject>
   does not stand in for them: outside a checkout whose remotes reach GitLab it refuses with
   `None of the git remotes configured for this repository point to a known GitLab host`.
   Run it from the checkout.
-- There is no `--no-ff` flag. Whether the merge produces a merge commit is the project's
-  **Merge method** setting (Settings → Merge requests). The API takes exactly three values
-  on `merge_method` — `merge` (merge commit), `rebase_merge` (semi-linear, still a merge
-  commit), `ff` (fast-forward, which never writes one) — and answers `HTTP 400`,
-  `{"error":"merge_method does not have a valid value"}` for anything else. Read it with
-  `glab api projects/<id>` and set it with
+- There is no `--no-ff` flag: the shape of the merge is the project's **Merge method**
+  (Settings → Merge requests), read with `glab api projects/<id>` and set with
   `glab api projects/<id> -X PUT -f merge_method=merge`, which answers with the updated
-  project. On `merge_method=merge`, the merge above produces a two-parent commit carrying
-  the `--message` text and removes the source branch.
-- `--auto-merge` defaults to on, so the command looks for a pipeline before merging: with
-  one running the merge is queued behind it rather than performed now, and with none on the
-  project it reports `! No pipeline running on <branch>` and merges immediately.
-- `--squash` and `--rebase` change what the source commits look like, not whether a merge
-  commit is written: on `merge_method=merge`, `--squash` collapses the branch into one
-  commit and `--rebase` replays it onto the target (`✓ Rebase successful!`), and either
-  merge still produces a two-parent commit. The shape stays the project's `merge_method`;
-  whether either flag may be used at all is `pr-rules` → Merge Strategy.
+  project. The API takes three values and
+  answers `HTTP 400`, `{"error":"merge_method does not have a valid value"}` for anything
+  else:
+
+| `merge_method` | The merge |
+|---|---|
+| `merge` | a two-parent commit, carrying the `--message` text |
+| `rebase_merge` | semi-linear, still a two-parent commit |
+| `ff` | fast-forward; no merge commit is ever written |
+
+- `--squash` and `--rebase` change the source commits, not that shape: on
+  `merge_method=merge` either still produces a two-parent commit. Whether either may be
+  used at all is `pr-rules` → Merge Strategy.
+
+| Flag | What it does | Default |
+|---|---|---|
+| `--squash` | collapses the branch into one commit | off |
+| `--rebase` | replays the branch onto the target, `✓ Rebase successful!` | off |
+| `--auto-merge` | looks for a pipeline first: with one running the merge queues behind it, with none it reports `! No pipeline running on <branch>` and merges at once | **on** |
+| `--remove-source-branch` | removes the source branch — where another merge request targets it, see Stacks | the project's setting |
+
 - The REST equivalent, when the flag names on the installed `glab` do not match, and the
   form that keeps `--auto-merge` out of the picture entirely:
 
@@ -152,7 +163,33 @@ glab api projects/:id/merge_requests/<iid>/merge -X PUT \
 
 ---
 
+## Stacks
+
+**Should**
+
+A **stack** is a chain of merge requests, each targeting the source branch of the one
+below, which GitLab forms itself: a merge request joins one by targeting another open
+merge request's source branch, or by another targeting its own. Generally available since
+GitLab 19.1, on every tier, up to 20 merge requests, past which the stack control is not
+shown.
+
+| Subject | Rule |
+|---|---|
+| What registers a stack | nothing: no documented API manages one, and a merge request carries no stack field in the API response — the chain is the target branches and nothing else |
+| Which merge request is the bottom | the one whose target branch is no open merge request's source branch, whatever branch that is |
+| What retargets | the merge: it moves the open merge requests targeting its source branch onto its own target, so a stack merges bottom up. At most four move per merge, a cap only a fan-out reaches, one merge request targeting any one branch of a chain |
+| Removing the source branch in the same merge | `--remove-source-branch`, or `should_remove_source_branch=true` on the REST form under Merge Requests, does not stop the retarget |
+| Removing it later | triggers none of its own, GitLab documenting the retarget as working "only when a merge request is merged", so it strands whatever still targets that branch |
+
+`glab stack` drives local stacked diffs rather than linking merge requests already open,
+and is marked experimental and not ready for production; a chain built by targeting
+branches needs none of it.
+
+---
+
 ## Draft Notes
+
+**Must**
 
 A draft written through `POST .../merge_requests/:iid/draft_notes` is absent from both
 `notes` and `discussions`, and shows up only under `draft_notes`. Sending comes in two
@@ -192,7 +229,7 @@ glab api projects/:id/merge_requests/<iid>/draft_notes -X POST \
 glab api projects/:id/merge_requests/<iid>/discussions
 
 # reply into an existing discussion, still a draft - a scalar, so a plain field
-# works; the discussion has to be one a person started - see trap 6
+# works; the discussion has to be one a person started - see the in_reply_to rows of Traps
 glab api projects/:id/merge_requests/<iid>/draft_notes -X POST \
   -f note='<reply>' -f in_reply_to_discussion_id=<discussion-id>
 
@@ -205,42 +242,26 @@ there: an instance older than the release that added `draft_notes` answers `404`
 is `pr-rules` → Pending by Default's "no draft mechanism" row.
 
 Confirm an inline draft landed inline before moving on: the response carries a non-null
-`line_code` and a filled `position`. A null `line_code` means the note was accepted as an
-overall comment — see trap 1.
+`line_code` and a filled `position`. A null `line_code`
+means the note was accepted as an overall comment — see the `position[...]` row of Traps.
 
 ### Traps
 
-1. **`position[...]` bracket fields are accepted and silently dropped.** Passing
-   `-f 'position[new_line]=2'` and friends answers `HTTP 201` with a draft whose
-   `position` fields are all null and whose `line_code` is null: the finding is created,
-   but as an overall comment on the MR, not on the line it names. `-f`/`-F` cannot express
-   a nested object, and nothing in the response says the position was lost. Use `--input`.
-2. **`--input` without a `Content-Type` header is rejected**: `HTTP 415`,
-   `{"error":"The provided content-type '' is not supported."}` Always pass
-   `-H 'Content-Type: application/json'` alongside it.
-3. **`diff_refs` can be null for the first moments after an MR is created**, while
-   `detailed_merge_status` is `preparing`, and it can also arrive already filled, so
-   neither state can be relied on. Re-read it, or take `base_commit_sha`,
-   `head_commit_sha` and `start_commit_sha` from `GET .../merge_requests/:iid/versions`,
-   which is populated while `diff_refs` is still null.
-4. **A stale `head_sha` is not rejected, and not corrected either.** Posting a draft with
-   the refs read before a force-push answers `HTTP 201`, and the stored
-   `position.head_sha` is the one sent, while the MR's own `diff_refs.head_sha` has already
-   moved to the new head. Re-read `diff_refs` after any push.
-5. **Draft notes are not GitHub's single pending review.** There is no review object
-   holding them and no per-user limit: several drafts by one author on one MR are all
-   accepted, where GitHub refuses a second pending review.
-6. **`in_reply_to_discussion_id` needs a discussion a person started.** The field is
-   resolved against the MR before anything is written, and the error names the thread
-   rather than the field carrying its id: an id belonging to no discussion gives
-   `{"message":{"base":["Thread to reply to cannot be found"]}}`, and GitLab's own system
-   note ("added 1 commit" after a push) gives
-   `{"message":{"base":["Replies to system notes are not allowed"]}}`. A merge request that
-   has attracted nothing but system notes has no thread to reply into yet.
+| Doing this | Answers | The way round it |
+|---|---|---|
+| `-f 'position[new_line]=2'` and friends | `HTTP 201`, and a draft whose `position` fields and `line_code` are all null — the finding lands as an overall comment on the merge request, not on the line it names, with nothing in the response saying so | `--input`, `-f`/`-F` expressing no nested object |
+| `--input` with no `Content-Type` | `HTTP 415`, `{"error":"The provided content-type '' is not supported."}` | the flag sets none of its own, so `-H 'Content-Type: application/json'` goes beside it |
+| reading `diff_refs` once, straight after the merge request is created | null, while `detailed_merge_status` is `preparing` — or a filled value, so neither state can be relied on | re-read it, or take `base_commit_sha`, `head_commit_sha` and `start_commit_sha` taken from `GET .../merge_requests/:iid/versions`, which is populated while `diff_refs` is still null |
+| posting a draft with refs read before a force-push | `HTTP 201`, storing the stale `position.head_sha` while the merge request's `diff_refs.head_sha` has already moved | a stale sha is neither rejected nor corrected, so re-read `diff_refs` after any push |
+| expecting one pending review per author | several drafts by one author on one merge request, all accepted | nothing: there is no review object holding them and no per-user limit, where GitHub refuses a second pending review |
+| `in_reply_to_discussion_id` naming no discussion | `{"message":{"base":["Thread to reply to cannot be found"]}}` | the field is resolved against the merge request before anything is written, and the error names the thread rather than the field carrying its id |
+| `in_reply_to_discussion_id` naming a system note — "added 1 commit" after a push | `{"message":{"base":["Replies to system notes are not allowed"]}}` | a merge request that has attracted nothing but system notes has no thread to reply into yet |
 
 ---
 
 ## Cross-References
+
+**Recommended**
 
 - `pr-rules` — MR title, description, review comment wording, merge strategy, and the
   rules governing which of these commands may be run.

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -157,7 +157,10 @@ None of these runs for review feedback:
   `addPullRequestReviewThreadReply` without a `pullRequestReviewId`.
 
 The one exception is an explicit instruction naming the act on that artifact
-("approve it", "post that reply now"), and it does not carry to the next PR. The issue
+("approve it", "post that reply now"), and it does not carry to the next PR. It is per
+draft, not per pull request: a call that sends every draft the caller holds needs an
+instruction covering each of them, and the single-draft form is what an instruction
+naming one reply admits. The issue
 comments the Scope and issue, Pre-merge issue check and Close issue steps require are
 published as usual (`issue-rules` → Progress Comments).
 
@@ -211,7 +214,8 @@ of them names a moment.
 
 1. **Checklist gate.** Merge only after the Pre-Merge Checklist passes.
 2. **The human authorises the merge.** An agent merges on an explicit instruction
-   naming this PR, which does not carry to the next one.
+   naming this PR, which does not carry to the next one: the authorisation is per pull
+   request, so a command merging several needs an instruction naming each of them.
 3. **Rebase before merge.** `git rebase <target>`, then merge from the current target
    tip; the rebase moves the head, so it returns to the push moment and the checks of
    that moment run again.

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -144,7 +144,8 @@ function skillsDeclaringRubric() {
 }
 
 // Extended by the pass that marks the next skill; every name here is checked below.
-const MARKED_SKILLS = ['comments', 'pr-rules', 'skill-authoring', 'submodule-sync'];
+const MARKED_SKILLS = ['comments', 'github-cli', 'gitlab-cli', 'pr-rules', 'skill-authoring',
+  'submodule-sync'];
 
 function commandFiles() {
   const names = fs.readdirSync(commandsDir).filter(name => name.endsWith('.md'));


### PR DESCRIPTION
## Problem

`github-cli` → Stacks opened with a statement that is false: that opening a pull request
with `--base` on another's head branch makes GitHub hold the two as a stack. It does not.
A stack is a registered object, and only a registered one keeps its dependents open when
the bottom merges.

It cost a pull request. #201 was such a chain; merging its base #199 with `--delete-branch`
— the flag the skill's own canonical merge line carried unconditionally — produced
`base_ref_deleted` then `closed` in #201's timeline, one second apart, with no retarget
anywhere. A closed pull request whose base ref is gone can be neither reopened nor
retargeted, so the work moved to #204.

`gitlab-cli` said nothing about stacks at all, though GitLab has had them generally
available since 19.1 and forms them by the opposite rule. Resolves GH-205.

## Summary

- `github-cli` → Stacks states what a stack is, both ways to register one, and what
  registration changes when the bottom merges.
- The `--delete-branch` bullet under Pull Requests carries the caveat where the flag is.
- `gitlab-cli` gains a Stacks section: GitLab's chain forms itself from the target branch.
- `README.md` and `CHANGELOG.md` name stacks in both skills' coverage.

## Implementation

- **Measured, not read.** Every behavioural claim was run against the live API in
  `ssoft-hub/claude-config-sandbox` and `ssoft-lab/claude-config-sandbox`, because the
  documentation turned out to be wrong about the case that matters:
  - A five-deep registered stack (#21..#25, stack #26), bottom merged with `merge-async`:
    the pull request that targeted its head branch moved to `main` and was force-pushed
    (`automatic_base_change_succeeded`, `head_ref_force_pushed`); every one above kept its
    base and had **both** refs force-pushed (`base_ref_force_pushed`,
    `head_ref_force_pushed`). Every tree survived.
  - `gh pr merge` on a stacked pull request answers `This pull request is part of a stack
    and must be merged using the asynchronous merge REST API` — quoted verbatim.
  - An unregistered chain's dependent closes whether the branch deletion rides the merge
    or follows it as a separate step. GitHub documents a retarget on head-branch deletion
    since 2020; it reaches no unregistered chain, and the section says so as a trap.
  - On GitLab, merging the bottom with `should_remove_source_branch=true` still retargets
    the dependent, so the caution drafted around a supposed documentation gap was dropped.
- `-F 'pull_requests[]=<n>'` registers a stack over HTTP. The `-f`/`-F` limitation the
  skill states elsewhere is GraphQL's, not REST's.
- The merge grain is stated as a mechanic: `merge-async` merges the one pull request
  named; `gh stack merge` covers several merges in one call, where `pr-rules` → Merge
  Strategy 2 authorises at the grain of one.
- Both sections state what the platform's own documentation does not, and name their
  source where they quote it.
- The sandbox is left as it was found: no branch but `main`, no open pull request, every
  probe closed with what it established.

## Test plan

- [x] `npm test` — 690 pass, 0 fail
- [x] Six review passes, `code-reviewer` + `security-auditor`: 11 blocking findings across
      passes 1-5, none surviving pass 6
- [x] Registration over HTTP with `-F 'pull_requests[]='` — stack #12 and #26 created
- [x] Synchronous merge refused on a stacked pull request — refusal captured verbatim
- [x] Registered stack, five deep: base, head and timeline read for every member before
      and after the bottom's merge; trees compared
- [x] Unregistered chain, deletion riding the merge (#13/#14) and following it (#15/#16) —
      dependent closed both times
- [x] GitLab: bottom merged with `should_remove_source_branch=true` (!9), branch gone,
      dependent (!10) open and retargeted onto `main`
- [x] Every cross-reference resolves, and every quoted string is from a live response or a
      named document
