### PR TITLE
GH-209: State what a merge leaves of the branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@
 
 ### Fixed
 
+- `github-cli` had `--delete-branch` removing the head branch unconditionally, where a worktree can stop it after the merge has gone through with an exit status of 1 - a merge that landed reading as one that failed; the section now carries the refusals and the recovery, measured
+- `gitlab-cli` had `--remove-source-branch` as an act of the command, where it is the merge request's own attribute, which GitLab acts on at the merge, the local branch surviving every merge
 - `github-cli` had the `merge-async` body at four fields where it takes five, and sent the reader to re-read the pull request for a result the endpoint answers by uuid at `GET .../merge-async/<uuid>`
 - The `git submodule status` prefix `+` reads as a difference in either direction, not as the module being ahead: `submodule-sync` gates `git add` on a containment check against the index, so a module reset to an earlier commit is not written back into the superproject
 - `install` no longer replaces `~/.claude/CLAUDE.md`. This repository's rules install as `~/.claude/claude-config-rules.md`, and `CLAUDE.md` gets one `@claude-config-rules.md` import line, keeping every other byte; `uninstall` subtracts exactly that line

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -118,11 +118,39 @@ gh api repos/{owner}/{repo}/pulls/<n>/merge-async/<uuid>
 |---|---|
 | `--merge` | the `--no-ff` equivalent: always a two-parent merge commit, whose subject and body are `-t`/`-b` |
 | `--rebase` | ignores `-t`/`-b`; the commits it replays keep the branch's own messages |
-| `--delete-branch` | removes the head branch and leaves the base alone. Where an open pull request targets that head branch, read Stacks before passing it |
+| `--delete-branch` | deletes the local and the remote head branch, and no base branch. Where an open pull request targets that head branch, the caller should read Stacks before passing the flag |
 
 The merge runs server-side against the pushed branch, so a commit amended locally and not
 pushed takes no part in it, and `GitHub <noreply@github.com>` commits the merge rather
 than the local git identity.
+
+Where the tree `gh pr merge --delete-branch` runs in holds the head branch, the command
+switches that tree to the base branch before deleting the head branch; where that tree
+holds another branch, the command goes straight to the deletion. What comes back from each
+run, by what the tree the command runs in and any other worktree hold:
+
+| The command runs | What comes back |
+|---|---|
+| in a tree that does not hold the head branch, with no worktree holding it | nothing: both deletions run |
+| in the tree holding the head branch, with the base branch held by no other worktree | nothing: that tree switches to the base branch and both deletions run |
+| in a tree that does not hold the head branch, while a worktree holds it | `failed to delete local branch <name>: failed to run git: error: cannot delete branch '<name>' used by worktree at '<path>'` |
+| in the tree holding the head branch, while another worktree holds the base branch | `failed to run git: fatal: '<base>' is already used by worktree at '<path>'` |
+
+The merge has gone through before either refusal, the local head branch stands after both
+of them, and the exit status is 1 either way — a caller reading the status alone takes a
+merge that landed for one that failed. The remote head branch stands too, unless the
+repository setting "Automatically delete head branches" is on, which takes it with the
+merge.
+
+The recovery frees the branch the refusal named — `git -C <path> switch <other>` in the
+worktree holding it, `git -C <path> switch --detach` where that worktree has nowhere else to
+stand, or `git worktree remove <path>` for a linked worktree that is finished with — and
+then what is left takes one command each:
+
+| What is left | What it takes |
+|---|---|
+| the local head branch | the same `gh pr merge <n> --merge --delete-branch` again, after either refusal: it answers `! Pull request <owner>/<repo>#<n> was already merged` with an exit status of 0, switches a tree still holding the head branch onto the base branch, deletes the head branch, and reaches no remote branch. `git branch -d <name>` deletes it too, and, run from the base branch, answers `error: the branch '<name>' is not fully merged` until that branch carries the merge |
+| the remote head branch | `git push origin --delete <name>`, which answers `error: unable to delete '<name>': remote ref does not exist` where the branch went with the merge |
 
 `merge-async` is a second merge endpoint `gh` exposes no command for, and the one a
 registered stack takes — see Stacks. The synchronous merge above is the default path.

--- a/skills/gitlab-cli/SKILL.md
+++ b/skills/gitlab-cli/SKILL.md
@@ -149,7 +149,13 @@ glab mr merge <iid> --message '<subject>
 | `--squash` | collapses the branch into one commit | off |
 | `--rebase` | replays the branch onto the target, `✓ Rebase successful!` | off |
 | `--auto-merge` | looks for a pipeline first: with one running the merge queues behind it, with none it reports `! No pipeline running on <branch>` and merges at once | **on** |
-| `--remove-source-branch` | removes the source branch — where another merge request targets it, see Stacks | the project's setting |
+| `--remove-source-branch` | sets the merge request's own attribute, which GitLab acts on at the merge: the source branch is deleted on the server. Where another merge request targets it, see Stacks | the project's setting |
+
+- `glab mr merge` deletes no local branch and says nothing about one, so the local branch
+  survives the merge and goes with `git branch -d <name>` — refused by git while a worktree
+  holds that branch, and, run from the target branch, refused as not fully merged until that
+  branch carries the merge. A worktree stops the merge itself no more than it stops any
+  other request over the API.
 
 - The REST equivalent, when the flag names on the installed `glab` do not match, and the
   form that keeps `--auto-merge` out of the picture entirely:


### PR DESCRIPTION
## Problem

`gh pr merge <n> --merge --delete-branch` is the merge command `github-cli` states, and the
skill described `--delete-branch` as removing the head branch and leaving the base alone.
A worktree holding a branch makes that impossible, and the command reports the failure with
an exit status of 1, so a caller reading the status alone takes a merge that landed for one that failed.
Neither platform skill said anything about it, and the two platforms differ in where the
removal is even decided.

## Summary

- `github-cli` states which working-tree layouts stop `--delete-branch`, with the refusal each one answers, and what the recovery takes
- The exit status is 1 after either refusal while the merge has landed, which the skill now names
- `gitlab-cli` states that `--remove-source-branch` is the merge request's own attribute, carried out by GitLab, so no local branch is ever deleted and a worktree stops nothing

## Implementation

- `skills/github-cli/SKILL.md` — the flag row drops the claim that the base branch is left alone in favour of what is deleted; a four-row table maps the working-tree layout to the refusal or its absence; a second table maps what survives to the command that removes it, including the `error: the branch '<name>' is not fully merged` a premature `git branch -d` answers
- `skills/gitlab-cli/SKILL.md` — the `--remove-source-branch` row names the attribute rather than an act of the client, and one bullet states that the local branch survives every merge
- Every statement was measured in `ssoft-hub/claude-config-sandbox` and `ssoft-lab/claude-config-sandbox` over five rounds of probes, recorded in the comments on GH-209; the second round overturned the axis the first had inferred, and the fifth overturned the exit status the first three had read through a pipe - it is 1 after either refusal, not 0. Both sandboxes were restored
- No statement of order between the local and the remote deletion is made: no probe establishes one, and the recovery does not need it

## Test plan

- [x] `npm test`
- [x] The refusal of each layout reproduced in the sandbox, with its message and exit status
- [x] `delete_branch_on_merge=true` measured and put back
- [x] Six review passes at depth `high` across the two runs, every finding fixed; the last pass's fixes are unreviewed
- [ ] `node install.js`, which is the step that puts the edited files where an agent reads them

