### PR TITLE
GH-150: Declare every skill's relation to project conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- A skill declares its relation to the conventions of the project it is applied in, as `project-relation` in its frontmatter: `overrides` where absent, and `binding` for a skill stating this repository's own conventions, which carries `## Project Binding` in place of `## Project Overrides`
 - What introduces an enumeration names what it holds, and what closes one is the statement that nothing else belongs to it rather than a count announced above it
 - A conversation is written in the personal register and every other text in the impersonal one, which fixes the subject of a sentence as well as the form a prescription takes
 - A word naming what a thing is stands beside its name, wherever a sentence uses that name as a noun
@@ -66,6 +67,7 @@
 - `work-sequence` skill: the eight steps from a task to a closed issue, each with its condition and the skill owning what it produces. Read it rather than `pr-rules` for the order of work and for the moment a check runs at; `pr-rules` now states the pull request alone
 
 ### Changed
+- The `## Project Overrides` section reads the same in every skill, one sentence differing only in the topic it names, and every skill carries one
 - `/review-loop` asks where every pass runs rather than assuming a working directory: it makes no place of its own, moves nothing aside, and states no step that needs a repository
 - `pr-rules` → Pending by Default states its exception per draft: a call sending every draft the caller holds needs an instruction covering each, where one naming a single reply admits the single-draft form
 - `pr-rules` → Merge Strategy 2 answers a command that merges several pull requests at once: the authorisation is per pull request, so such a command needs an instruction naming each of them

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -36,9 +36,10 @@ competing designs, or writing an Architecture Decision Record (ADR).
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its
-own architecture process or ADR location, follow those instead. This skill is the
-fallback for projects that do not specify their own.
+**Must**
+
+Must follow the architecture conventions and the ADR location the repository's
+`AGENTS.md` file or a project skill defines, instead of the rule here.
 
 ---
 

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -24,7 +24,10 @@ Apply when editing `CHANGELOG.md` or asked about changelog format.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own changelog conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the changelog conventions the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ## Format
 

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -28,7 +28,10 @@ that decides whether a change can merge or ship.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own CI/CD stack and gates, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the CI/CD stack and gates the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -28,7 +28,10 @@ around opening/merging the PR the review attaches to → `pr-rules` skill.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own review criteria, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the review criteria the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/comments/SKILL.md
+++ b/skills/comments/SKILL.md
@@ -30,6 +30,13 @@ Apply when writing or reviewing a code comment in any language (inline notes, im
 
 Documentation blocks on a public header → the API-documentation skill of the language being written. This skill covers every other comment, in every language: inside function bodies, in implementation files, in a hook script, a build file or a configuration file. Implementation conventions (types, resource handling, naming) → the coding-conventions skill of the language being written.
 
+## Project Overrides
+
+**Must**
+
+Must follow the comment conventions the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
+
 ---
 
 ## Philosophy

--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -22,7 +22,10 @@ Apply when writing commit messages or reviewing commits.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own commit conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the commit and branch-naming conventions the repository's `AGENTS.md`
+file or a project skill defines, instead of the rule here.
 
 ---
 

--- a/skills/cpp-api-design/SKILL.md
+++ b/skills/cpp-api-design/SKILL.md
@@ -22,6 +22,13 @@ Apply when designing a new C++ API, adding public C++ headers, or reviewing publ
 
 Access-level choice within a single type → `cpp-encapsulation` skill.
 
+## Project Overrides
+
+**Must**
+
+Must follow the C++ API design conventions the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
 ## Structural Rules
 
 - **Namespace hierarchy**: public symbols in consistent `lib::` or `lib::module::` namespace; check project `AGENTS.md` for exact namespace.

--- a/skills/cpp-coding/SKILL.md
+++ b/skills/cpp-coding/SKILL.md
@@ -29,6 +29,13 @@ Scope: project-level implementation conventions (not the C++ standard). Public A
 
 Reference: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#s-philosophy
 
+## Project Overrides
+
+**Must**
+
+Must follow the C++ implementation conventions the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
 ## Philosophy
 
 - **Value semantics over pointers** — prefer values and move semantics; use references for observation, not ownership

--- a/skills/cpp-doxygen/SKILL.md
+++ b/skills/cpp-doxygen/SKILL.md
@@ -29,7 +29,10 @@ Header structure and namespace rules → `cpp-api-design` skill; the header guar
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own documentation conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the Doxygen conventions the repository's `AGENTS.md` file or a project
+skill defines, instead of the rule here.
 
 ## Core Rule — document the type, not its members
 

--- a/skills/cpp-encapsulation/SKILL.md
+++ b/skills/cpp-encapsulation/SKILL.md
@@ -23,6 +23,13 @@ Apply when choosing C++ access specifiers, designing a C++ class's public/protec
 
 Public API structure across headers/modules → `cpp-api-design`. This skill covers access-level choice within a single type.
 
+## Project Overrides
+
+**Must**
+
+Must follow the C++ encapsulation conventions the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
 ---
 
 ## Default Rule

--- a/skills/cpp-testing/SKILL.md
+++ b/skills/cpp-testing/SKILL.md
@@ -21,6 +21,13 @@ Framework choice is project-specific (check `AGENTS.md`). This skill covers prin
 
 - The fail, pass, refactor order these tests are written in → `test-driven-development` skill.
 
+## Project Overrides
+
+**Must**
+
+Must follow the C++ test conventions the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
+
 ---
 
 ## What to Test

--- a/skills/ddd/SKILL.md
+++ b/skills/ddd/SKILL.md
@@ -23,6 +23,13 @@ language being written. This skill covers domain modelling only.
 
 Reference: Eric Evans, *Domain-Driven Design* (2003). Patterns below are the strategic and tactical core.
 
+## Project Overrides
+
+**Must**
+
+Must follow the domain-modelling conventions the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
 ---
 
 ## Ubiquitous Language

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -25,7 +25,10 @@ Apply when investigating a bug, test failure, or unexpected behavior, before pro
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own debugging process, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the debugging process the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -30,7 +30,10 @@ guide for consumers moving off one.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own deprecation policy, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the deprecation and migration policy the repository's `AGENTS.md` file
+or a project skill defines, instead of the rule here.
 
 ---
 

--- a/skills/editing/SKILL.md
+++ b/skills/editing/SKILL.md
@@ -17,6 +17,13 @@ metadata:
 
 Apply when editing any file in the project.
 
+## Project Overrides
+
+**Must**
+
+Must follow the editing workflow the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
+
 ## Re-Read Before Edit
 
 Always issue a fresh `Read` of the target file immediately before editing it — even if it was read earlier in the same session.

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -32,9 +32,8 @@ help is silent or misleading. No rule about *when* an action is allowed lives he
 
 **Must**
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own
-`gh` conventions, follow those instead. This skill is the fallback for projects that do not
-specify their own.
+Must follow the `gh` conventions the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/gitlab-cli/SKILL.md
+++ b/skills/gitlab-cli/SKILL.md
@@ -32,9 +32,8 @@ help is silent or misleading. No rule about *when* an action is allowed lives he
 
 **Must**
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own
-`glab` conventions, follow those instead. This skill is the fallback for projects that do
-not specify their own.
+Must follow the `glab` conventions the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/hook-scripts/SKILL.md
+++ b/skills/hook-scripts/SKILL.md
@@ -13,6 +13,7 @@ metadata:
   paths:
     - "**/hooks/*.js"
     - "**/tools/*.js"
+  project-relation: binding
   with:
     - "comments"
   tags:
@@ -23,6 +24,14 @@ metadata:
 # Skill: Claude Code Hook Scripts
 
 Apply when writing or modifying hook scripts in `~/.claude/hooks/` or `~/.claude/tools/`.
+
+## Project Binding
+
+**Must**
+
+Must apply this skill in the `claude-config` repository alone: it states that
+repository's own conventions, and no project with a different layout takes them as a
+fallback.
 
 ## Hard Rules
 

--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -24,7 +24,10 @@ it to the CLI skill of the issue tracker.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own issue conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the issue conventions the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/node-testing/SKILL.md
+++ b/skills/node-testing/SKILL.md
@@ -12,6 +12,7 @@ metadata:
   reminder: false
   paths:
     - "**/test/*.test.js"
+  project-relation: binding
   with:
     - "test-driven-development"
   tags:
@@ -28,6 +29,14 @@ see `hook-scripts` skill).
 - Writing the hook/tool itself → `hook-scripts` skill.
 - Tests in another language → the testing skill of that language (different runner,
   different conventions — do not mix the two).
+
+## Project Binding
+
+**Must**
+
+Must apply this skill in the `claude-config` repository alone: it states that
+repository's own conventions, and no project with a different layout takes them as a
+fallback.
 
 ---
 

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -28,7 +28,10 @@ visibility, not test assertions or debug-session-only tracing.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own logging/metrics stack and conventions, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the telemetry stack and conventions the repository's `AGENTS.md` file
+or a project skill defines, instead of the rule here.
 
 ---
 

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -27,7 +27,10 @@ them here.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own performance budget or tooling, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the performance process, budget and tooling the repository's `AGENTS.md`
+file or a project skill defines, instead of the rule here.
 
 ---
 

--- a/skills/project-planning/SKILL.md
+++ b/skills/project-planning/SKILL.md
@@ -31,9 +31,10 @@ meant for stakeholders.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its
-own planning process or templates, follow those instead. This skill is the fallback
-for projects that do not specify their own.
+**Must**
+
+Must follow the planning process or templates the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
 
 ---
 

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -21,7 +21,10 @@ Project `AGENTS.md` specifies which files contain version strings.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own release process, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the release process the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ## Step 1 — Decide Version (semver)
 

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -25,9 +25,10 @@ acceptance criteria, or turning a vague ask into a spec before design starts.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its
-own requirements process, follow those instead. This skill is the fallback for projects
-that do not specify their own.
+**Must**
+
+Must follow the requirements process the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -29,7 +29,10 @@ skill is what to design for before those hooks would ever fire.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own security requirements (e.g. a specific compliance regime), follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the security requirements the repository's `AGENTS.md` file or a project
+skill defines, instead of the rule here.
 
 ---
 

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -26,7 +26,10 @@ this skill for whether the release is actually safe to expose to users and how w
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own launch process, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the launch process the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -36,9 +36,11 @@ installs beside every skill. This skill states the author's half.
 
 **Must**
 
-Must follow a rule about a skill file that the repository's `AGENTS.md` file or a project
-skill states, instead of the rule here. The catalog steps `AGENTS.md` states — where a new
-skill is indexed, and how it reaches the config directory — are additional to these.
+Must follow the skill-file and command-marking conventions the repository's
+`AGENTS.md` file or a project skill defines, instead of the rule here.
+
+The catalog steps `AGENTS.md` states — where a new skill is indexed, and how it reaches
+the config directory — are additional to these.
 
 ## One Concern per Skill
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -24,7 +24,10 @@ coverage rules belong to the testing skill of the language being written.
 
 ## Project Overrides
 
-Project-local rules win. If the repository's `AGENTS.md` or a project skill defines its own testing workflow, follow those instead. This skill is the fallback for projects that do not specify their own.
+**Must**
+
+Must follow the test-first order the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
 
 ---
 

--- a/skills/writing-style/SKILL.md
+++ b/skills/writing-style/SKILL.md
@@ -33,9 +33,8 @@ written in, not its shape.
 
 **Must**
 
-Must follow a writing-style convention the repository's `AGENTS.md` file or a project
-skill states, instead of the rule here. This skill applies where a project states none of
-its own.
+Must follow the writing-style conventions the repository's `AGENTS.md` file or a project
+skill defines, instead of the rule here.
 
 ## This Skill Above Any Mode
 

--- a/templates/SKILL.md
+++ b/templates/SKILL.md
@@ -29,6 +29,11 @@ metadata:
   # than a kind of one, so it is not a skill the agent chooses between. Nothing reads
   # it yet — the reminder that will is GH-208.
   always: true
+  # Optional, defaults to overrides, which the Project Overrides section below goes
+  # with. A skill stating the claude-config repository's own conventions, which no
+  # other project takes as a fallback, declares it here and carries a Project Binding
+  # section in place of that one.
+  # project-relation: binding
   # Optional. Skills that always apply alongside this one; the gate names them too.
   with:
     - <skill-name>
@@ -47,6 +52,16 @@ Apply when <trigger condition — one line, specific, actionable>.
 
 <!-- External reference (optional): authoritative source this skill is based on. -->
 <!-- Reference: <Author>, *<Title>* (<Year>). -->
+
+## Project Overrides
+
+**Must**
+
+Must follow the <topic> the repository's `AGENTS.md` file or a project skill defines,
+instead of the rule here.
+
+<!-- The sentence above is fixed but for the topic, which names the subject this skill
+     covers, as a noun phrase with no article. -->
 
 ---
 

--- a/test/project-overrides.test.js
+++ b/test/project-overrides.test.js
@@ -1,0 +1,286 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoDir = path.join(__dirname, '..');
+const skillsDir = path.join(repoDir, 'skills');
+
+// The one place the two wordings are held besides the skills themselves. A skill's own
+// frontmatter names which of the two it carries, so no skill name appears in this file.
+const TEMPLATES = {
+  overrides: {
+    heading: 'Project Overrides',
+    paragraph: "Must follow the <topic> the repository's `AGENTS.md` file or a project" +
+      ' skill defines, instead of the rule here.',
+  },
+  binding: {
+    heading: 'Project Binding',
+    paragraph: 'Must apply this skill in the `claude-config` repository alone: it states' +
+      " that repository's own conventions, and no project with a different layout takes" +
+      ' them as a fallback.',
+  },
+};
+
+// Indented, because every other key the routing reads sits under `metadata:`.
+const RELATION = /^[ \t]+project-relation:[ \t]*(\S+)[ \t]*$/m;
+
+const MARKER_LINE = /^\*\*(?:Must|Should|Recommended|May)\*\*$/;
+const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// `<topic>` stands for any non-empty phrase carrying no angle bracket, so the placeholder
+// the template ships left unfilled is no topic; the rest is matched verbatim.
+const OVERRIDES_PATTERN = new RegExp(
+  '^' + TEMPLATES.overrides.paragraph.split('<topic>').map(escapeRegExp).join('[^<>]+?') + '$');
+
+function matchesTemplate(relation, paragraph) {
+  return relation === 'binding'
+    ? paragraph === TEMPLATES.binding.paragraph
+    : OVERRIDES_PATTERN.test(paragraph);
+}
+
+// The first paragraph of a section body, the marker line removed and line breaks
+// collapsed to single spaces.
+function firstParagraph(bodyLines) {
+  const paragraphs = [];
+  let current = [];
+  for (const line of bodyLines) {
+    if (line.trim() === '') {
+      if (current.length) { paragraphs.push(current); current = []; }
+    } else {
+      current.push(line.trim());
+    }
+  }
+  if (current.length) paragraphs.push(current);
+  for (const paragraph of paragraphs) {
+    if (paragraph.length === 1 && MARKER_LINE.test(paragraph[0])) continue;
+    return paragraph.join(' ');
+  }
+  return '';
+}
+
+function frontmatter(text) {
+  const body = String(text).replace(/\r\n/g, '\n');
+  if (!body.startsWith('---\n')) return '';
+  const closing = body.indexOf('\n---', 4);
+  return closing === -1 ? '' : body.slice(4, closing);
+}
+
+function declaredRelation(text) {
+  return frontmatter(text).match(RELATION)?.[1] ?? 'overrides';
+}
+
+const HEADING = /^##\s+(.*)$/;
+const FENCE = /^\s*(?:```|~~~)/;
+
+// The `##` headings of the file in order, each with its body, a fenced `##` line counted
+// as neither.
+function sections(text) {
+  const found = [];
+  let current = null;
+  let fenced = false;
+  for (const line of String(text).replace(/\r\n/g, '\n').split('\n')) {
+    if (FENCE.test(line)) {
+      fenced = !fenced;
+      if (current) current.body.push(line);
+      continue;
+    }
+    const heading = !fenced && line.match(HEADING);
+    if (heading) {
+      current = { heading: heading[1].trim(), body: [] };
+      found.push(current);
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  return found;
+}
+
+// A presence fault ends the check, since neither position nor wording of a section that
+// is missing, doubled or undeclared could name the real defect.
+function relationFaults(text) {
+  const relation = declaredRelation(text);
+  const template = TEMPLATES[relation];
+  if (!template) {
+    return [`frontmatter declares project-relation: ${relation}, which names no template`];
+  }
+  const all = sections(text);
+  const overrides = all.some(s => s.heading === TEMPLATES.overrides.heading);
+  const binding = all.some(s => s.heading === TEMPLATES.binding.heading);
+  if (!overrides && !binding) {
+    return [`carries neither ## ${TEMPLATES.overrides.heading} nor ## ${TEMPLATES.binding.heading}`];
+  }
+  if (overrides && binding) {
+    return [`carries both ## ${TEMPLATES.overrides.heading} and ## ${TEMPLATES.binding.heading}`];
+  }
+  const carried = overrides ? TEMPLATES.overrides.heading : TEMPLATES.binding.heading;
+  if (carried !== template.heading) {
+    return [`carries ## ${carried} where its frontmatter declares ${relation}`];
+  }
+  const faults = [];
+  if (all[0].heading !== template.heading) {
+    faults.push(`## ${template.heading} is not the first ## heading`);
+  }
+  const section = all.find(s => s.heading === template.heading);
+  if (!matchesTemplate(relation, firstParagraph(section.body))) {
+    faults.push(
+      `the first paragraph under ## ${template.heading} does not match the ${relation} template`);
+  }
+  return faults;
+}
+
+// The frontmatter and body of a skill file, assembled so each fixture states only what
+// its test is about.
+function skillFile(metadataLines, body) {
+  return '---\nname: fixture\nmetadata:\n  tier: narrow\n' + metadataLines +
+    '---\n\n# Skill: Fixture\n\nApply when testing.\n\n' + body;
+}
+
+const OVERRIDES_SECTION = [
+  '## Project Overrides',
+  '',
+  '**Must**',
+  '',
+  "Must follow the widget conventions the repository's `AGENTS.md` file or a project skill",
+  'defines, instead of the rule here.',
+].join('\n');
+
+const BINDING_SECTION = [
+  '## Project Binding',
+  '',
+  '**Must**',
+  '',
+  'Must apply this skill in the `claude-config` repository alone: it states that',
+  "repository's own conventions, and no project with a different layout takes them as a",
+  'fallback.',
+].join('\n');
+
+test('an absent project-relation key reads as overrides', () => {
+  assert.strictEqual(declaredRelation(skillFile('', OVERRIDES_SECTION)), 'overrides');
+});
+
+test('a project-relation key indented under metadata declares its value', () => {
+  assert.strictEqual(
+    declaredRelation(skillFile('  project-relation: binding\n', BINDING_SECTION)),
+    'binding');
+});
+
+test('a top-level project-relation key is not the declared form', () => {
+  const text = '---\nproject-relation: binding\nmetadata:\n  tier: narrow\n---\n\n' +
+    '# Skill: Fixture\n\n' + BINDING_SECTION;
+  assert.strictEqual(declaredRelation(text), 'overrides');
+});
+
+test('names a skill carrying neither section', () => {
+  const faults = relationFaults(skillFile('', '## Some Rule\n\n**Must**\n\nA rule.\n'));
+  assert.deepStrictEqual(faults,
+    ['carries neither ## Project Overrides nor ## Project Binding']);
+});
+
+test('names a skill carrying both sections', () => {
+  const faults = relationFaults(
+    skillFile('', OVERRIDES_SECTION + '\n\n' + BINDING_SECTION + '\n'));
+  assert.deepStrictEqual(faults,
+    ['carries both ## Project Overrides and ## Project Binding']);
+});
+
+test('names a skill carrying the section its frontmatter does not declare', () => {
+  const faults = relationFaults(
+    skillFile('  project-relation: binding\n', OVERRIDES_SECTION + '\n'));
+  assert.deepStrictEqual(faults,
+    ['carries ## Project Overrides where its frontmatter declares binding']);
+});
+
+test('names a skill declaring no relation that carries the binding section', () => {
+  const faults = relationFaults(skillFile('', BINDING_SECTION + '\n'));
+  assert.deepStrictEqual(faults,
+    ['carries ## Project Binding where its frontmatter declares overrides']);
+});
+
+test('accepts an overrides section matching the template with a topic phrase', () => {
+  assert.deepStrictEqual(relationFaults(skillFile('', OVERRIDES_SECTION + '\n')), []);
+});
+
+test('names an overrides paragraph that does not match the template', () => {
+  const reworded = OVERRIDES_SECTION.replace('follow', 'apply');
+  assert.deepStrictEqual(relationFaults(skillFile('', reworded + '\n')),
+    ['the first paragraph under ## Project Overrides does not match the overrides template']);
+});
+
+test('names an overrides sentence whose topic phrase is empty', () => {
+  const emptied = OVERRIDES_SECTION.replace('the widget conventions the', 'the the');
+  assert.deepStrictEqual(relationFaults(skillFile('', emptied + '\n')),
+    ['the first paragraph under ## Project Overrides does not match the overrides template']);
+});
+
+test('names a topic left as the placeholder the template ships', () => {
+  const unfilled = OVERRIDES_SECTION.replace('widget conventions', '<topic>');
+  assert.deepStrictEqual(relationFaults(skillFile('', unfilled + '\n')),
+    ['the first paragraph under ## Project Overrides does not match the overrides template']);
+});
+
+test('collapses line breaks to single spaces before matching', () => {
+  const rewrapped = [
+    '## Project Overrides',
+    '',
+    '**Must**',
+    '',
+    'Must follow the widget',
+    'conventions',
+    "the repository's `AGENTS.md` file or a project skill defines, instead of the rule",
+    'here.',
+  ].join('\n');
+  assert.deepStrictEqual(relationFaults(skillFile('', rewrapped + '\n')), []);
+});
+
+test('accepts a binding section carrying the fixed paragraph verbatim', () => {
+  assert.deepStrictEqual(
+    relationFaults(skillFile('  project-relation: binding\n', BINDING_SECTION + '\n')),
+    []);
+});
+
+test('names a binding paragraph differing from the fixed one', () => {
+  const reworded = BINDING_SECTION.replace('alone', 'only');
+  assert.deepStrictEqual(
+    relationFaults(skillFile('  project-relation: binding\n', reworded + '\n')),
+    ['the first paragraph under ## Project Binding does not match the binding template']);
+});
+
+test('accepts a second paragraph after the canonical first', () => {
+  const followed = OVERRIDES_SECTION +
+    '\n\nThe catalog steps the file states are additional to these.\n';
+  assert.deepStrictEqual(relationFaults(skillFile('', followed)), []);
+});
+
+test('names a section that is not the first ## heading of its file', () => {
+  const displaced = '## Some Rule\n\n**Must**\n\nA rule.\n\n' + OVERRIDES_SECTION + '\n';
+  assert.deepStrictEqual(relationFaults(skillFile('', displaced)),
+    ['## Project Overrides is not the first ## heading']);
+});
+
+test('ignores a ## heading inside a fenced code block', () => {
+  const fenced = '```markdown\n## Not A Section\n```\n\n' + OVERRIDES_SECTION + '\n';
+  assert.deepStrictEqual(relationFaults(skillFile('', fenced)), []);
+});
+
+test('names a project-relation outside the two relations', () => {
+  const faults = relationFaults(
+    skillFile('  project-relation: optional\n', OVERRIDES_SECTION + '\n'));
+  assert.deepStrictEqual(faults,
+    ['frontmatter declares project-relation: optional, which names no template']);
+});
+
+function skillNames() {
+  const names = fs.readdirSync(skillsDir)
+    .filter(name => fs.existsSync(path.join(skillsDir, name, 'SKILL.md')));
+  // A vacuous pass would hide the skills going missing entirely.
+  if (names.length === 0) throw new Error(`no skill files in ${skillsDir}`);
+  return names;
+}
+
+test('every skill carries the one section its project-relation declares, worded to its template', () => {
+  for (const name of skillNames()) {
+    const text = fs.readFileSync(path.join(skillsDir, name, 'SKILL.md'), 'utf8');
+    assert.deepStrictEqual(relationFaults(text), [], `skills/${name}/SKILL.md`);
+  }
+});


### PR DESCRIPTION
## Problem

A skill applied in another project said nothing about whether that project's own
conventions displace it, and the C++ skills - where a project's conventions differ most -
were among the nine carrying no such statement. The skills that did carry it held the
sentence in one copy each, with nothing holding the copies in step, and they had already
drifted into two forms.

## Summary

- Every skill declares `project-relation` in its frontmatter, read as `overrides` where absent
- A skill whose rules another project may displace carries `## Project Overrides`, one fixed sentence differing only in the topic it names
- A skill stating this repository's own conventions declares `project-relation: binding` and carries `## Project Binding` instead: `hook-scripts` and `node-testing`
- `templates/SKILL.md` starts a new skill with the section in place and documents the key
- `test/project-overrides.test.js` holds both wordings and names five faults, with no skill name written into it

## Implementation

- The canonical sentence opens with its force word, as `writing-style` -> Name the Force requires, and replaces the earlier three-sentence form; `pr-rules`, `submodule-sync` and `work-sequence` already carried it and are unchanged
- Each topic names everything its skill owns per the ownership map in `AGENTS.md`: `commit-rules` names branch naming, `deprecation-and-migration` names migration, `skill-authoring` names command marking, `test-driven-development` names the test-first order rather than a testing workflow
- The section is the first `##` heading of its file and carries `**Must**`, which it earns on the three conditions of `skill-authoring` -> Choosing the Marker: it names the artifact settling compliance, the project's own `AGENTS.md`
- The test takes the relation from each skill's own frontmatter, so a skill changing its relation edits its own file and no third one
- The topic pattern rejects an angle bracket, so a skill created from the template with the placeholder left unfilled fails rather than passing
- `skill-authoring` keeps its catalog-steps sentence as a second paragraph, which the fixed first sentence does not carry

## Test plan

- [x] `npm test` - 710 tests, 0 failing
- [x] `node --test test/project-overrides.test.js` over every skill
- [x] Deleting the heading from one skill fails the test and names that skill
- [x] Replacing one word of the fixed sentence fails the test
- [x] Giving one skill both sections fails the test
- [x] A skill declaring no relation that carries `## Project Binding` fails the test
- [x] A topic left as the template placeholder fails the test, and passes under the earlier pattern
- [ ] `node install.js`, which puts the edited files where an agent reads them - the user runs it
