### PR TITLE
GH-151: Give skills a row in the lifecycle map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ stage with no command or persona of its own says so rather than naming the neare
 | Spec | `/spec` → `spec-architect` | `Open`, once it exists | `requirements`, `ddd`, `architecture`, `cpp-api-design` |
 | Scope and issue | — | `Open` | `issue-rules`, `github-cli` / `gitlab-cli` |
 | Branch | — | → `In Progress` | `commit-rules` → Branch Naming |
-| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`; `debugging` on a fix; `commit-rules` per commit |
+| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`, `hook-scripts`, `node-testing`; `debugging` on a fix; `performance-optimization` on a reported performance problem; `deprecation-and-migration` when retiring a public path; `skill-authoring` on a skill or a command file; `commit-rules` per commit |
 | Publish | — | `In Progress` | `work-sequence` → When a Check Runs, `submodule-sync`, `changelog`, `commit-rules` |
 | Offer for review | — | → `In Review` | `pr-rules`, `ci-cd-and-automation`, `github-cli` / `gitlab-cli` |
 | Review | `/review`, or `/review-loop` to iterate → `code-reviewer` | `In Review` | `code-review-and-quality`, `cpp-api-design`, `cpp-encapsulation`, `comments` / `cpp-doxygen`, `pr-rules`; `changelog` when the change touches `CHANGELOG.md` |
@@ -162,6 +162,22 @@ stage with no command or persona of its own says so rather than naming the neare
 | Integrate | — | `In Review` | `pr-rules` → Merge Strategy, `commit-rules`, `github-cli` / `gitlab-cli` |
 | Close issue | — | issue closed; not `Done` until deployed (`issue-rules` → Lifecycle), or left `In Review` with a follow-up linked | `issue-rules` → Lifecycle, `github-cli` / `gitlab-cli` |
 | Release | — (`release-manager` directly) | → `Done` | `changelog`, `release`, `shipping-and-launch`, `submodule-sync` |
+
+A second table follows, one row for each skill named in no `Skills` cell above. Its
+`Stage` cell holds a stage name of the table above, or the word `cross-cutting` — itself
+a declaration that the skill fires at more than one stage of the table above, not a
+missing value.
+
+| Skill | Stage | Trigger | Input | Output | Entry criterion | Exit criterion |
+|-------|-------|---------|-------|--------|------------------|-----------------|
+| `deprecation-and-migration` | Implement | retiring a public API, planning a breaking change, or writing a migration guide | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
+| `editing` | cross-cutting | an Edit or Write tool call on a file in the project | the file's content before the call | the file's content after the call | the file in scope for the task, per `editing` → Edit Scope | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
+| `hook-scripts` | Implement | writing or modifying a file under `hooks/` or `tools/` | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `commit-rules` → Branch Naming | the test file `node-testing` covers for the tool, `test/<name>.test.js` |
+| `node-testing` | Implement | writing or reviewing a file under `test/*.test.js` | the pure logic exported by the hook or tool under test | a test file asserting that logic's behaviour | the tool's exported logic, per `hook-scripts` → Tool Skeleton | the tool covered and `npm test` run, per `hook-scripts` → Adding or Retiring a Tool |
+| `observability-and-instrumentation` | cross-cutting | adding logging, metrics, or tracing, or checking a running system's reported behaviour | the question an on-call engineer needs answered | a structured log line, metric, or trace answering it | the non-functional requirement `requirements` → Functional vs Non-Functional records | the Readiness Checklist item `shipping-and-launch` → Readiness Checklist for monitoring |
+| `performance-optimization` | Implement | diagnosing a reported performance problem, or evaluating a change's performance cost | a profiler or benchmark baseline for the hot path | a measured before/after comparison for the fix | the symptom and cost the bug template of `issue-rules` → Description Template asks for | the hot-path check `code-review-and-quality` → Performance runs before merge |
+| `skill-authoring` | Implement | adding, marking, renaming or retiring a skill, or marking a command | the skill or command file and its frontmatter | a skill or command file matching the rubric, or its removal | the tracked issue's title naming the skill, per `issue-rules` → Title | the `### Changed` or `### Removed` entry `changelog` → Subsections requires |
+| `writing-style` | cross-cutting | writing documentation, an issue, a PR, a commit, or any text artifact | a draft sentence or document | prose in the technical register with its force word named | the draft of the artifact whose structure `issue-rules`, `pr-rules` or `commit-rules` fixes | the re-read `writing-style` → Self-Check Before Sending requires before the text is sent |
 
 No row assigns an issue-state transition to a role: `issue-rules` → Lifecycle defines each
 state by a condition rather than by an act with an actor. The acts reserved to the human

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there
 - A skill declares its relation to the conventions of the project it is applied in, as `project-relation` in its frontmatter: `overrides` where absent, and `binding` for a skill stating this repository's own conventions, which carries `## Project Binding` in place of `## Project Overrides`
 - What introduces an enumeration names what it holds, and what closes one is the statement that nothing else belongs to it rather than a count announced above it
 - A conversation is written in the personal register and every other text in the impersonal one, which fixes the subject of a sentence as well as the form a prescription takes

--- a/test/lifecycle-map.test.js
+++ b/test/lifecycle-map.test.js
@@ -1,0 +1,144 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoDir = path.join(__dirname, '..');
+const agentsPath = path.join(repoDir, 'AGENTS.md');
+const skillsDir = path.join(repoDir, 'skills');
+
+const COLUMNS = ['Skill', 'Stage', 'Trigger', 'Input', 'Output',
+  'Entry criterion', 'Exit criterion'];
+
+function isSeparatorRow(row) {
+  return row.length > 0 && row.every(cell => /^:?-+:?$/.test(cell));
+}
+
+function parseRow(line) {
+  return line.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map(c => c.trim());
+}
+
+// The two markdown tables sitting under the "### Lifecycle map" heading, up to the next
+// heading of level 1-3. Each is returned as { header, rows }, the separator row dropped.
+function lifecycleMapTables() {
+  const text = fs.readFileSync(agentsPath, 'utf8').replace(/\r\n/g, '\n');
+  const lines = text.split('\n');
+  const start = lines.findIndex(l => l.trim() === '### Lifecycle map');
+  assert.notStrictEqual(start, -1, 'AGENTS.md carries no ### Lifecycle map heading');
+  let end = lines.findIndex((l, i) => i > start && /^#{1,3}\s/.test(l));
+  if (end === -1) end = lines.length;
+
+  const blocks = [];
+  let current = null;
+  for (const line of lines.slice(start + 1, end)) {
+    if (/^\s*\|.*\|\s*$/.test(line)) {
+      if (!current) { current = []; blocks.push(current); }
+      current.push(parseRow(line));
+    } else {
+      current = null;
+    }
+  }
+  assert.strictEqual(blocks.length, 2,
+    `### Lifecycle map carries ${blocks.length} table(s) below its heading, expected 2`);
+
+  return blocks.map(rawRows => {
+    const [header, ...rest] = rawRows;
+    return { header, rows: rest.filter(r => !isSeparatorRow(r)) };
+  });
+}
+
+function columnIndex(header, name) {
+  const idx = header.indexOf(name);
+  assert.notStrictEqual(idx, -1, `column ${name} is missing from header ${JSON.stringify(header)}`);
+  return idx;
+}
+
+function namesSkill(cellText, skillName) {
+  return cellText.includes('`' + skillName + '`');
+}
+
+// A vacuous pass would hide the skills going missing entirely.
+function skillDirectories() {
+  const names = fs.readdirSync(skillsDir)
+    .filter(name => fs.existsSync(path.join(skillsDir, name, 'SKILL.md')));
+  if (names.length === 0) throw new Error(`no skill directories found in ${skillsDir}`);
+  return names;
+}
+
+test('every directory under skills/ is named in the stage table or the second table', () => {
+  const [stageTable, secondTable] = lifecycleMapTables();
+  const stageSkillsCol = columnIndex(stageTable.header, 'Skills');
+  const secondSkillCol = columnIndex(secondTable.header, 'Skill');
+
+  const stageText = stageTable.rows.map(r => r[stageSkillsCol]).join(' ');
+  const secondText = secondTable.rows.map(r => r[secondSkillCol]).join(' ');
+
+  const missing = skillDirectories().filter(
+    name => !namesSkill(stageText, name) && !namesSkill(secondText, name));
+  assert.deepStrictEqual(missing, []);
+});
+
+test('the second table carries the seven columns in order', () => {
+  const [, secondTable] = lifecycleMapTables();
+  assert.deepStrictEqual(secondTable.header, COLUMNS);
+});
+
+test('every row of the second table holds one cell per column', () => {
+  const [, secondTable] = lifecycleMapTables();
+  const skillCol = columnIndex(secondTable.header, 'Skill');
+  const wrong = secondTable.rows
+    .filter(row => row.length !== secondTable.header.length)
+    .map(row => `${row[skillCol] || '(unnamed row)'}: ${row.length} cells`);
+  assert.deepStrictEqual(wrong, []);
+});
+
+test('every cell of the second table is filled', () => {
+  const [, secondTable] = lifecycleMapTables();
+  const skillCol = columnIndex(secondTable.header, 'Skill');
+
+  const empty = [];
+  for (const row of secondTable.rows) {
+    row.forEach((cell, i) => {
+      if (cell.trim() === '') empty.push(`${row[skillCol] || '(unnamed row)'}.${secondTable.header[i]}`);
+    });
+  }
+  assert.deepStrictEqual(empty, []);
+});
+
+test('every Stage cell in the second table names a stage of the table above or cross-cutting', () => {
+  const [stageTable, secondTable] = lifecycleMapTables();
+  const stageCol = columnIndex(stageTable.header, 'Stage');
+  const stageNames = stageTable.rows.map(r => r[stageCol]);
+
+  const secondStageCol = columnIndex(secondTable.header, 'Stage');
+  const secondSkillCol = columnIndex(secondTable.header, 'Skill');
+
+  const invalid = secondTable.rows
+    .filter(r => r[secondStageCol] !== 'cross-cutting' && !stageNames.includes(r[secondStageCol]))
+    .map(r => `${r[secondSkillCol]}: ${r[secondStageCol]}`);
+  assert.deepStrictEqual(invalid, []);
+});
+
+test('a second-table row naming a stage is named in that stage row\'s Skills cell', () => {
+  const [stageTable, secondTable] = lifecycleMapTables();
+  const stageCol = columnIndex(stageTable.header, 'Stage');
+  const stageSkillsCol = columnIndex(stageTable.header, 'Skills');
+  const secondStageCol = columnIndex(secondTable.header, 'Stage');
+  const secondSkillCol = columnIndex(secondTable.header, 'Skill');
+
+  const disagreements = [];
+  for (const row of secondTable.rows) {
+    const stageName = row[secondStageCol];
+    if (stageName === 'cross-cutting') continue;
+    // A stage name absent from the table above is caught by the previous test; nothing
+    // here can be checked against a row that does not exist.
+    const stageRow = stageTable.rows.find(r => r[stageCol] === stageName);
+    if (!stageRow) continue;
+    const skillName = row[secondSkillCol].replace(/`/g, '');
+    if (!namesSkill(stageRow[stageSkillsCol], skillName)) {
+      disagreements.push(`${skillName} -> ${stageName}`);
+    }
+  }
+  assert.deepStrictEqual(disagreements, []);
+});


### PR DESCRIPTION
## Problem

The lifecycle map lines the pipeline stage, the command or persona carrying it and the
issue state against each other, and eight skills stood in no cell of it:
`deprecation-and-migration`, `editing`, `hook-scripts`, `node-testing`,
`observability-and-instrumentation`, `performance-optimization`, `skill-authoring` and
`writing-style`. For those eight nothing stated what fires them, what they read, what they
leave behind and when they are finished, and two of them apply more widely than any skill
that did have a row.

## Summary

- A second table under `### Lifecycle map` carries one row per skill the stage table names in no `Skills` cell, with the columns `Skill`, `Stage`, `Trigger`, `Input`, `Output`, `Entry criterion` and `Exit criterion`
- `Stage` holds a stage name of the table above, or `cross-cutting` for a skill firing at more than one: `editing`, `observability-and-instrumentation` and `writing-style`
- The `Implement` row of the stage table gains the five skills whose rows name it, so the two tables agree in both directions
- `test/lifecycle-map.test.js` holds the map against the skill catalog and against itself

## Implementation

- The prose introducing the section states that the second table covers what the stage table does not, and that `cross-cutting` is a declaration rather than a missing value
- No stage name is written into the prose or into the test: both read the closed list out of the first column of the stage table, so a stage renamed there renames nothing else - measured by renaming `Implement` and watching the suite stay green
- Every `Entry criterion` and `Exit criterion` names an artifact, a file, a command or a checklist item of another skill, and every one of those citations resolves to a real heading of the skill it names
- `skill-authoring` is filed under `Implement` rather than `cross-cutting`: the changelog entry its rename step names is `changelog`'s to word, the same hand-off `deprecation-and-migration` makes from the same stage
- The test also holds the seven columns in order and one cell per column, since a row short of a cell carries no empty cell to find

## Test plan

- [x] `npm test` - 716 tests, 0 failing
- [x] `node --test test/lifecycle-map.test.js` over the map and every skill
- [x] Deleting one skill's row fails the test and names that skill
- [x] Emptying one cell fails the test and names the skill and the column
- [x] A `Stage` cell holding a value that is no stage name and not `cross-cutting` fails the test
- [x] Renaming a stage in the stage table and in every `Stage` cell naming it leaves the test passing
- [x] A skill directory with no row in either table fails the test and names it
- [ ] `node install.js`, which puts the edited files where an agent reads them - the user runs it
