### PR TITLE
GH-146: Guard a stale reading beyond a file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `ddd` — modelling inside one bounded context.
 - `debugging` — the investigation that precedes a fix.
 - `deprecation-and-migration` — retiring a public path.
-- `editing` — the edit mechanic itself.
+- `editing` — the guard against a stale reading of a file, of a tracker or forge artifact, and of the branch head at a merge.
 - `github-cli` — `gh` mechanics.
 - `gitlab-cli` — `glab` mechanics.
 - `hook-scripts` — writing this repository's hooks and tools.
@@ -171,7 +171,7 @@ missing value.
 | Skill | Stage | Trigger | Input | Output | Entry criterion | Exit criterion |
 |-------|-------|---------|-------|--------|------------------|-----------------|
 | `deprecation-and-migration` | Implement | retiring a public API, planning a breaking change, or writing a migration guide | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
-| `editing` | cross-cutting | an Edit or Write tool call on a file in the project | the file's content before the call | the file's content after the call | the file in scope for the task, per `editing` → Edit Scope | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
+| `editing` | cross-cutting | a write to a file, a tracker issue body or a PR description, and a merge | the artifact as it stands before the write | the artifact as it stands after the write | a reading of the artifact, per `editing` → Guard Against a Stale Reading | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
 | `hook-scripts` | Implement | writing or modifying a file under `hooks/` or `tools/` | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `commit-rules` → Branch Naming | the test file `node-testing` covers for the tool, `test/<name>.test.js` |
 | `node-testing` | Implement | writing or reviewing a file under `test/*.test.js` | the pure logic exported by the hook or tool under test | a test file asserting that logic's behaviour | the tool's exported logic, per `hook-scripts` → Tool Skeleton | the tool covered and `npm test` run, per `hook-scripts` → Adding or Retiring a Tool |
 | `observability-and-instrumentation` | cross-cutting | adding logging, metrics, or tracing, or checking a running system's reported behaviour | the question an on-call engineer needs answered | a structured log line, metric, or trace answering it | the non-functional requirement `requirements` → Functional vs Non-Functional records | the Readiness Checklist item `shipping-and-launch` → Readiness Checklist for monitoring |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - The `security-and-hardening` containment and overflow rules state the control and the input classes a guard must answer, in terms tied to no language. The code examples are gone, and with them the advice they carried: a string comparison of resolved paths, and a check reading the sum
 - Renamed three steps of the order of work after what they achieve: `Push` is now `Publish`, `PR` is `Offer for review`, and `Merge commit` is `Integrate`; `AGENTS.md` -> Lifecycle map carries the same names
 - `AGENTS.md` states the project, the two maps and one pointer per mechanism. Writing a hook or a tool, and adding or retiring one, is read from `hook-scripts`; what each dispatcher routes where from `README.md` -> Hooks; adding a persona or a command from its template
+- `editing` now covers a tracker issue's body and checklist, a PR description, a review thread and a merge, naming the guard or the re-read procedure for each; `pr-rules` gains the review-thread box of its Pre-Merge Checklist and the read Merge Strategy owes before the merge command
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `ddd` | Domain-Driven Design patterns in C++ |
 | `debugging` | Root-cause investigation before proposing a fix |
 | `deprecation-and-migration` | Retiring a public API and writing a migration guide |
-| `editing` | File editing workflow (re-read before edit) |
+| `editing` | Guard against a stale reading of a file, of a tracker or forge artifact, and of a branch head |
 | `github-cli` | `gh` mechanics — issues, PRs, labels, pending review threads, stacks, merges |
 | `gitlab-cli` | `glab` mechanics — issues, MRs, labels, draft notes, stacks, merges |
 | `hook-scripts` | Writing Claude Code hooks and tools |

--- a/skills/editing/SKILL.md
+++ b/skills/editing/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: editing
 version: "1.0.0"
-description: Apply when editing any file in the project
+description: Apply when writing a file, a tracker issue body or a PR description, and when a merge turns on a review thread or the branch head
 license: Unlicense
 metadata:
   author: ssoft
   tier: domain
+  rubric: applied
   bound-to:
     - agent-tool
   tags:
@@ -13,26 +14,46 @@ metadata:
     - editing
 ---
 
-# Skill: File Editing Workflow
+# Skill: Editing an Artifact
 
-Apply when editing any file in the project.
+Apply when writing a file, a tracker issue body or a PR description, and when a merge
+turns on a review thread or the branch head. The section Guard Against a Stale Reading
+names every artifact and what guards it.
 
 ## Project Overrides
 
 **Must**
 
-Must follow the editing workflow the repository's `AGENTS.md` file or a project skill
-defines, instead of the rule here.
+Must follow the guard against a stale reading the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
+## Guard Against a Stale Reading
+
+**Must**
+
+| Artifact | Guard | What the reader owes |
+|---|---|---|
+| A file | Only the exact-string match of the tool `Edit`, which returns an error and writes nothing. The tool `Write` replaces the file whole and carries no such match | Re-Read Before Edit |
+| The body of a tracker issue, with its checklist boxes | None: the command the CLI skill of the issue tracker gives for writing a body replaces it whole | Must build the write from the body fetched immediately before it, checklist boxes included |
+| The description of a PR | None, for the same reason, with the command named by the CLI skill of the hosting platform | As for the issue body |
+| A review thread | Partial: where the repository or the target branch requires every thread resolved, the platform refuses a merge leaving one unresolved. It refuses neither a thread opened and resolved between the two reads nor a merge an administrator forces | Must read the thread list again immediately before the merge command runs, and must match it against the list read when the review was last addressed. A thread appearing between the two reads blocks the merge until an instruction from the human names that thread. Where no earlier read exists, every unresolved thread blocks it |
+| A merge | Partial: the head guard the CLI skill of the hosting platform names refuses the merge once the head no longer matches the SHA that guard is given, and refuses nothing where the merge runs without it | Must pass that guard the head SHA read after the last rebase, or after the review where the rebase moved nothing. Where the merge runs through a path taking no such argument, must read the head SHA immediately before the merge command and refuse the merge where it differs from that baseline |
+
+Nothing else belongs to the table. The rest of the merge gate: `pr-rules` → Merge Strategy.
 
 ## Re-Read Before Edit
 
-Always issue a fresh `Read` of the target file immediately before editing it — even if it was read earlier in the same session.
+**Must**
+
+Must issue a fresh `Read` of the target file immediately before editing it — even if it was read earlier in the same session.
 
 **Why:** The user edits files directly between Claude interactions (build error fixes, manual corrections, formatting). A cached read from earlier in the session may be stale; editing from stale state overwrites user changes silently.
 
 **Rule:** One `Read` → one `Edit` block. If multiple edits to the same file are needed in one turn, read once, then apply all edits. Do not re-read between edits within the same turn.
 
 ## Edit Scope
+
+**Should**
 
 - Edit only files explicitly in scope for the current task.
 - Do not touch adjacent files unless the user requested it.

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -181,6 +181,10 @@ of them names a moment.
 - [ ] Every module reference the branch records satisfies the merge order the module-sync skill of the version control system fixes
 - [ ] Every test-plan box in the PR description is checked, or the item is named out of scope with a reason
 - [ ] A comment is added to the issue recording which PR/MR resolves which item (`issue-rules` → Progress Comments)
+- [ ] No review thread of the pull request stands unresolved, unless `editing` → Guard Against a Stale Reading admits the merge
+
+The head guard the CLI skill of the hosting platform names does not cover the
+review-thread box: a thread opened after the thread list was last read moves no commit.
 
 ## Merge Strategy
 
@@ -191,8 +195,9 @@ of them names a moment.
    naming this PR, which does not carry to the next one: the authorisation is per pull
    request, so a command merging several needs an instruction naming each of them.
 3. **Rebase before merge.** `git rebase <target>`, then merge from the current target
-   tip; the rebase moves the head, so it returns to the Publish step and the checks of
-   that moment run again (`work-sequence` → When a Check Runs).
+   tip; the rebase moves the head, so the branch returns to the Publish step and the
+   checks of that moment run again (`work-sequence` → When a Check Runs). The merge is
+   guarded with the head SHA read afterwards (`editing` → Guard Against a Stale Reading).
 4. **`--no-ff` only.** No fast-forward merge, no squash merge.
 5. **Merge subject:** `Merge PR #<pr-number>: <pr subject>`, the PR subject verbatim
    and never re-prefixed with `type(scope):`, so a tracker ID in the title leaves both
@@ -206,6 +211,9 @@ of them names a moment.
    before the branch is sent, never at merge time: a rewrite afterwards takes a
    force-push and owes every check that step ran.
 10. **Rewrite squashed commit bodies** per `commit-rules` → Fixup / Squash Merges.
+11. **Read the thread list before the merge command.** Immediately before it, read the review
+    threads again and match them against the list read when the review was addressed
+    (`editing` → Guard Against a Stale Reading).
 
 The command performing the merge, and the repository settings it depends on, belong to
 the CLI skill of the hosting platform.
@@ -226,6 +234,7 @@ is split before review.
 - `issue-rules` — the issue this PR resolves: title, templates, labels, lifecycle, progress comments.
 - `commit-rules` — commit message format and branch naming on the PR's branch.
 - `code-review-and-quality` — what a review looks for, where this skill states how a finding is worded.
+- `editing` — the head-SHA read Merge Strategy turns on, the thread-list read it owes before the merge command, and the thread state the Pre-Merge Checklist reads.
 - `writing-style` — prose register in the description and in the review threads.
 - `ci-cd-and-automation` — the pipeline answering the checks reported on the pull request.
 - The module-sync skill of the version control system — the pre-PR check and the merge order the checklists gate on.

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -144,7 +144,7 @@ function skillsDeclaringRubric() {
 }
 
 // Extended by the pass that marks the next skill; every name here is checked below.
-const MARKED_SKILLS = ['comments', 'github-cli', 'gitlab-cli', 'pr-rules',
+const MARKED_SKILLS = ['comments', 'editing', 'github-cli', 'gitlab-cli', 'pr-rules',
   'skill-authoring', 'submodule-sync', 'work-sequence', 'writing-style'];
 
 function commandFiles() {


### PR DESCRIPTION
## Problem

The skill `editing` required a fresh read before an edit and stated it for files alone,
where a stale reading costs least: `Edit` matches an exact string, so it fails loudly and
changes nothing. The artifacts where it costs most stood outside the rule: `gh issue edit
--body-file` replaces an issue body in full, so an edit a person made in between
disappears with no diff and no local copy, and a thread opened before a merge blocks it not.

## Summary

- `editing` states the rule for five artifacts: a file, a tracker issue body with its checklist boxes, a PR description, a review thread, and a merge
- One row per artifact names the guard the platform offers and the procedure standing in where it does not hold
- `pr-rules` -> Pre-Merge Checklist gains one box: every thread opened since the review was last addressed is named in a confirmation authorising the merge
- `pr-rules` -> Merge Strategy 3 states that the head SHA the merge is guarded with is read after the rebase
- The skill declares `rubric: applied`, every section carries one of the four markers, and `test/rubric.test.js` holds it

## Implementation

- The guard column carries only what a platform actually refuses, measured against `gh pr merge --help`, `gh issue edit --help`, `gh pr edit --help` and the branch-protection API: a branch requiring every thread resolved refuses an unresolved thread, not one opened and resolved between the two reads, so the thread row names no guard
- The procedure column tells the reader what to do, opening with its force word; the two CLI-specific commands are named beside the role phrase of the tracker and of the hosting platform, since the skill is bound to `agent-tool` rather than to one forge
- The thread rule is stated once, in `editing`: the box in `pr-rules` states the readable state, which is what lets it sit in a section whose items are read off the issue and the pull request rather than run
- `Edit Scope`, the one-read-per-turn paragraph and the rationale keep their wording: the agreement between the heading, the rationale and the exception is GH-162's
- The ownership-map line, the `README.md` row and the lifecycle-map row name the widened concern without borrowing `tracker` for a forge artifact

## Test plan

- [x] `grep -rn "stale reading" skills/` prints lines from `skills/editing/SKILL.md` only
- [x] `grep -n "any file in the project" skills/editing/SKILL.md` returns nothing
- [x] `node --test test/rubric.test.js` passes with `editing` in the marked list, and fails when the name is removed or a marker line dropped
- [x] Every guard named exists, checked against the CLI help and the branch-protection API rather than the documentation
- [x] Every file the change touches carries one line ending throughout

## Follow-up

GH-160 records what each platform file states about these mechanisms, which this change
leaves to it: the head guard of each CLI, and the setting requiring every thread resolved.
