### PR TITLE
GH-147: State when independent work runs in parallel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `observability-and-instrumentation` — telemetry for production visibility.
 - `performance-optimization` — the process around one performance problem.
 - `pr-rules` — the pull request, from opening it to merging it.
-- `project-planning` — stakeholder-facing planning.
+- `project-planning` — stakeholder-facing planning, and whether independent work runs at the same time.
 - `release` — the version number and the mechanical steps to ship it.
 - `requirements` — turning an ask into a requirement.
 - `security-and-hardening` — design-time security.
@@ -153,7 +153,7 @@ stage with no command or persona of its own says so rather than naming the neare
 | Spec | `/spec` → `spec-architect` | `Open`, once it exists | `requirements`, `ddd`, `architecture`, `cpp-api-design` |
 | Scope and issue | — | `Open` | `issue-rules`, `github-cli` / `gitlab-cli` |
 | Branch | — | → `In Progress` | `commit-rules` → Branch Naming |
-| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`, `hook-scripts`, `node-testing`; `debugging` on a fix; `performance-optimization` on a reported performance problem; `deprecation-and-migration` when retiring a public path; `skill-authoring` on a skill or a command file; `commit-rules` per commit |
+| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`, `hook-scripts`, `node-testing`; `debugging` on a fix; `performance-optimization` on a reported performance problem; `deprecation-and-migration` when retiring a public path; `skill-authoring` on a skill or a command file; `project-planning` → Running Independent Work in Parallel on each launch that section names; `commit-rules` per commit |
 | Publish | — | `In Progress` | `work-sequence` → When a Check Runs, `submodule-sync`, `changelog`, `commit-rules` |
 | Offer for review | — | → `In Review` | `pr-rules`, `ci-cd-and-automation`, `github-cli` / `gitlab-cli` |
 | Review | `/review`, or `/review-loop` to iterate → `code-reviewer` | `In Review` | `code-review-and-quality`, `cpp-api-design`, `cpp-encapsulation`, `comments` / `cpp-doxygen`, `pr-rules`; `changelog` when the change touches `CHANGELOG.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Independent work runs at the same time: `project-planning` states when two units are independent, the lowest bound the contended resources put on the degree of parallelism, and when one check runs alone before the rest; a pipeline arranges its jobs so by default
 - The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there
 - A skill declares its relation to the conventions of the project it is applied in, as `project-relation` in its frontmatter: `overrides` where absent, and `binding` for a skill stating this repository's own conventions, which carries `## Project Binding` in place of `## Project Overrides`
 - What introduces an enumeration names what it holds, and what closes one is the statement that nothing else belongs to it rather than a count announced above it

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `observability-and-instrumentation` | Logging, metrics, tracing for production visibility |
 | `performance-optimization` | Profile-measure-optimize workflow for a reported performance problem |
 | `pr-rules` | PR title, description, review comments, merge strategy |
-| `project-planning` | Scoping, estimation, milestones, risk, status updates |
+| `project-planning` | Scoping, estimation, milestones, risk, status updates, and the launch of independent work at once |
 | `release` | Semver release workflow |
 | `requirements` | Requirements gathering, user stories, acceptance criteria |
 | `security-and-hardening` | Trust boundaries, input validation, secrets, least privilege |

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -23,6 +23,8 @@ this file:
 5. `cpp-testing` skill — the structure of the tests the loop produces.
 6. `work-sequence` skill — When a Check Runs, for which checks a round of edits runs and
    which of them belong to a later moment.
+7. `project-planning` skill — Running Independent Work in Parallel, for each launch that
+   section names.
 
 If a step in the spec is ambiguous or missing, stop and surface the gap rather than
 guessing — that gap belongs to `spec-architect`, not to an implementation-time

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -55,6 +55,10 @@ Order pipeline stages from fastest/cheapest to slowest/most expensive (lint befo
 build, unit tests before integration tests, single-platform build before the full
 matrix) so a broken change fails in seconds, not after a 20-minute matrix build.
 
+A stage should launch its independent jobs at once by default. Which jobs qualify, what
+bounds the degree, and how the launch squares with the ordering above are stated in
+`project-planning` → Running Independent Work in Parallel.
+
 ## Matrix Coverage
 
 Run the test matrix across every combination the project actually ships to (compiler
@@ -95,12 +99,14 @@ it locally first.
 ## Keeping the Pipeline Fast
 
 Once a pipeline exceeds a comfortable wait (rule of thumb: ~10 minutes), apply these in
-order of impact before adding more hardware: cache dependencies between runs; split
-independent checks (lint, build, test) into parallel jobs instead of one long sequential
-job; skip jobs a change can't affect (e.g. skip a full matrix build for a docs-only
-change); shard a large test suite across runners; move slow, non-blocking checks to a
-scheduled run instead of every push. Reach for a larger/faster runner last — it hides
-the cost instead of removing it.
+order of impact before adding more hardware: cache dependencies between runs; skip jobs a
+change can't affect (e.g. skip a full matrix build for a docs-only change); shard a large
+test suite across runners; move slow, non-blocking checks to a scheduled run instead of
+every push. Reach for a larger/faster runner last — it hides the cost instead of removing
+it.
+
+The parallel split of independent jobs is the default arrangement rather than a remedy on
+this list; the section Fast Feedback First states it.
 
 ## Someone Owns a Failing Build
 

--- a/skills/project-planning/SKILL.md
+++ b/skills/project-planning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-planning
 version: "1.0.0"
-description: Apply when scoping work, breaking a feature down into tasks, estimating effort, sequencing milestones, identifying risk or dependencies, or writing a project plan or status update
+description: Apply when scoping work, breaking a feature down into tasks, estimating effort, sequencing milestones, identifying risk or dependencies, writing a project plan or status update, or launching a build, a test run, a set of checks or several agents at once
 license: Unlicense
 metadata:
   author: ssoft
@@ -16,14 +16,15 @@ metadata:
 # Skill: Project Planning & Management
 
 Apply when scoping work, breaking a feature into tasks, estimating effort, sequencing
-milestones, identifying risk/dependencies, or writing a project plan or status update
-meant for stakeholders.
+milestones, identifying risk/dependencies, writing a project plan or status update meant
+for stakeholders, or launching a build, a test run, a set of checks or several agents at
+once.
 
-- This is for project-level planning artifacts shared with stakeholders — a roadmap, a
-  scoping doc, a status report. It is not the same thing as Claude's own in-conversation
-  task plan (the `Plan`/writing-plans tooling used to plan a single coding task); don't
-  conflate the two, and don't apply this skill's ceremony to a plan that's just
-  "what I'm about to do this turn."
+- The planning artifacts are the project-level ones shared with stakeholders — a roadmap,
+  a scoping doc, a status report. The ceremony they carry does not reach an
+  in-conversation task plan for a single coding task, which the `Plan` tooling covers.
+  Running Independent Work in Parallel is the exception: it governs a launch whatever the
+  plan behind it.
 - A plan is built from settled requirements — if those don't exist yet, go get them
   first → `requirements` skill.
 - PR Size discipline and the release checklist are the execution-time tail end of a
@@ -76,6 +77,52 @@ work built on top of an assumption that didn't hold.
 A risk worth naming explicitly has: what could go wrong, how you'd notice it happening,
 and what the fallback is if it does. A risk list without those three things is just a
 list of worries, not something the plan can act on.
+
+## Running Independent Work in Parallel
+
+**Should**
+
+Should launch independent units of work at the same time rather than one after another,
+and should treat two units as independent when neither reads what the other writes and
+the two write nothing in common — a file, a database row, a state key, or a path either
+takes from a shared environment variable among them. The path written is what counts, so
+two units contend over a directory only where they create or remove the same entry of it,
+or where one enumerates it while the other adds an entry. Should read the test over every
+pair of the launch, and should run a pair that is not independent in sequence, by the
+dependencies the section Identifying Dependencies and Risk establishes.
+
+Should bound the degree of parallelism by each of the rows below and take the lowest
+bound they give; no bound outside the table applies:
+
+| The resource | The bound it puts on the degree |
+|---|---|
+| the CPU cores no other work holds, for a unit that occupies one while it runs rather than waiting | their number |
+| a resource consumed in a divisible capacity — memory | the free capacity divided by one unit's peak, measured on this unit or on a previous run of it |
+| a resource held one user at a time, a licence and a device only one process may open among them | the number of instances of it |
+| a resource carrying throughput, the disk and the network among them | none, unless the units saturate it, and then the measured degree past which the run stops getting shorter |
+| a quota over units running at once — a rate limit, a runner pool, a platform's own limit on concurrent jobs | the quota |
+
+A split past the lowest of them shortens no run. Each row names instances of its kind
+rather than all of them, and a resource of a kind the table names is bound by that row.
+Should run one unit alone where a row needs a measurement no run has taken yet, and
+should bound the launch by that row once the run has taken it.
+
+Should reconcile a pipeline stage's launch with the cheapest-check-first order of the
+section Fast Feedback First of `ci-cd-and-automation`, by what the stage cancels. A stage
+should launch every independent unit at once where it cancels the rest of that stage on
+the first failure, which the key `fail-fast` of a `strategy` block does at its default of
+`true` over the jobs of one matrix. A stage cancelling nothing should still launch every
+unit at once, except that it should run one check alone first where no other unit of the
+stage can pass if that check fails, taking the one with the shortest recorded run time
+or, where none is recorded, the cheapest to run. The key `cancel-in-progress` of a
+`concurrency` block, which sits at workflow or job level, cancels a run or a job a newer
+one of the same group replaces, and decides nothing here.
+
+The rule reaches a build launched by the commands `make -j`, `cmake --build <dir> -j` or
+`ninja -j`, whose default sits above the bound the table gives; a test run launched by
+`ctest -j`, or by `node --test`, whose degree the flag `--test-concurrency=<n>` sets; a set of checks over one change, whether several tools or
+one tool in several configurations, the jobs of one pipeline stage included; and the
+dispatch of several agents in one message. Nothing else belongs to that list.
 
 ## What a Milestone Plan Should Contain
 


### PR DESCRIPTION
## Problem

One place in the skill set spoke about running work at the same time: `ci-cd-and-automation`
-> Keeping the Pipeline Fast offered a parallel split as one remedy among several, for a
pipeline already too slow. Elsewhere the arrangement was sequential by default and unstated,
and no skill covered a build, a test run, a set of checks or the dispatch of several agents.
The two qualifications that decide whether the rule helps - what bounds the degree, and how
the launch squares with early abort - were stated nowhere.

## Summary

- `project-planning` gains one section, at `**Should**`, holding the rule
- Two units are independent when neither reads what the other writes and the two write nothing in common, read over every pair of the launch
- The degree is bounded by a table of five resource kinds, the lowest bound winning: cores, memory, a resource held one user at a time, a resource carrying throughput, and a quota over units running at once
- Every stage launches its independent units at once; a stage cancelling nothing runs one check alone first where no other unit can pass if that check fails
- `Fast Feedback First` makes that launch the pipeline's default and cites the owner; `Keeping the Pipeline Fast` no longer offers the split as a remedy

## Implementation

- The owner is `project-planning`, where work is already ordered by dependency, and the rule reaches a build, a test run, a set of checks and a set of agents, none of which a pipeline skill covers
- Each row bounds the degree in the unit its resource has: a count for the cores and for a one-at-a-time resource, a divided capacity for memory, a measured degree for throughput, the quota itself for a quota. Where a row needs a measurement no run has taken, one unit runs alone until it has
- The cores bound only a unit that occupies one while it runs rather than waiting, so a dispatch of agents is not capped by the machine they do not run on
- `fail-fast` is named as the key of a `strategy` block, at its default of `true` over the jobs of one matrix, and `cancel-in-progress` as the key of a `concurrency` block that decides nothing here
- Each command of the closed list carries the flag that sets its degree, in the form that runs: `cmake --build <dir> -j`, `ninja -j`, and `node --test` with `--test-concurrency=<n>`
- `agents/implementer.md` names the skill, since neither the every-prompt reminder nor the edit-time gate reaches a persona
- The skill declares no `rubric: applied` and `test/rubric.test.js` is untouched: marking its other sections belongs to that skill's own pass

## Test plan

- [x] `grep -rln "one user at a time" skills/` prints one path, the owner's
- [x] `grep -rn "scarcest"` over the skills and the three index files comes back empty
- [x] Every command and flag named in the closed list was run: `node --test --concurrency` answers `bad option: --concurrency`, `cmake --build -j` prints the usage text, and `ninja -j` reports a default of cores plus two
- [x] Every claim about GitHub Actions checked against the platform rather than the issue's wording: `fail-fast` defaults to `true` over its own matrix, and a `concurrency` block sits at workflow or job level
- [x] Eight cases read out of the text, including this repository's own `.github/workflows/ci.yml`, a build whose peak was never measured, a stage of three separate jobs with no matrix, and the dispatch of ten read-only agents

## Follow-up

Three criteria of GH-147 were corrected against the tree while the work ran, each with the
measurement recorded in the issue: the resource bound, the `grep` naming a word the
corrected rule no longer carries, and the two commands named in forms that do not run. The
criterion asking the ownership map to record the hand-off was corrected too, the map
carrying one concern per skill by its own preamble.
