### PR TITLE
GH-148: Add code-navigation, the owner of symbol questions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `architecture` — how modules, services and processes fit together.
 - `changelog` — the `CHANGELOG.md` file.
 - `ci-cd-and-automation` — the pipeline producing the checks-passed signal.
+- `code-navigation` — where an answer about a symbol comes from.
 - `code-review-and-quality` — what a review looks for.
 - `comments` — a comment in any language, whatever marker opens it.
 - `commit-rules` — the commit message and the branch name.
@@ -170,6 +171,7 @@ missing value.
 
 | Skill | Stage | Trigger | Input | Output | Entry criterion | Exit criterion |
 |-------|-------|---------|-------|--------|------------------|-----------------|
+| `code-navigation` | cross-cutting | an edit or a verdict turning on a symbol's callers, its implementations, its definition, what a bare name refers to, or whether the symbol has any user left | the symbol, at the file path, line and character it stands at, or the name a workspace-wide query carries | the set of sites the operation returns | the source `code-navigation` → Where the Answer Comes From names for the language | the answer naming the operation that produced it, per `code-navigation` → Naming the Operation |
 | `deprecation-and-migration` | Implement | retiring a public API, planning a breaking change, or writing a migration guide | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
 | `editing` | cross-cutting | a write to a file, a tracker issue body or a PR description, and a merge | the artifact as it stands before the write | the artifact as it stands after the write | a reading of the artifact, per `editing` → Guard Against a Stale Reading | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
 | `hook-scripts` | Implement | writing or modifying a file under `hooks/` or `tools/` | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `commit-rules` → Branch Naming | the test file `node-testing` covers for the tool, `test/<name>.test.js` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `code-navigation` skill: the questions a text search does not answer about a symbol - its callers, implementations, definition, a bare name's referent and the symbol's remaining users - the rule that an answer names the operation producing it, and `test/code-navigation.test.js` over the example
 - Independent work runs at the same time: `project-planning` states when two units are independent, the lowest bound the contended resources put on the degree of parallelism, and when one check runs alone before the rest; a pipeline arranges its jobs so by default
 - The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there
 - A skill declares its relation to the conventions of the project it is applied in, as `project-relation` in its frontmatter: `overrides` where absent, and `binding` for a skill stating this repository's own conventions, which carries `## Project Binding` in place of `## Project Overrides`
@@ -69,6 +70,7 @@
 - `work-sequence` skill: the eight steps from a task to a closed issue, each with its condition and the skill owning what it produces. Read it rather than `pr-rules` for the order of work and for the moment a check runs at; `pr-rules` now states the pull request alone
 
 ### Changed
+- `code-reviewer`, `implementer` and `spec-architect` load `code-navigation` and declare the `LSP` tool its operations belong to, so a rule about a symbol's callers reaches an operation wherever the environment offers one
 - The `## Project Overrides` section reads the same in every skill, one sentence differing only in the topic it names, and every skill carries one
 - `/review-loop` asks where every pass runs rather than assuming a working directory: it makes no place of its own, moves nothing aside, and states no step that needs a repository
 - `pr-rules` → Pending by Default states its exception per draft: a call sending every draft the caller holds needs an instruction covering each, where one naming a single reply admits the single-draft form

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `architecture` | System/module architecture design, ADRs, tradeoffs |
 | `changelog` | Keep a Changelog format |
 | `ci-cd-and-automation` | CI/CD pipeline design and quality gates |
+| `code-navigation` | Where an answer about a symbol comes from, and what a text search does not answer |
 | `code-review-and-quality` | Review substance — correctness, readability, architecture, security, performance |
 | `comments` | Code comment style in any language, Doxygen aside (brief, general, no fix narration) |
 | `commit-rules` | Conventional Commits format and branch naming |

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Use to review a diff or PR for correctness, readability, architecture fit, security, and performance before merge. Invoke once implementation is complete and tests pass.
-tools: Skill, Read, Grep, Glob, Bash
+tools: Skill, Read, Grep, Glob, Bash, LSP
 license: Unlicense
 metadata:
   author: ssoft
@@ -18,14 +18,16 @@ this file:
 
 1. `code-review-and-quality` skill — what counts as a finding, and which axis is worth
    checking before which.
-2. `cpp-encapsulation` skill — the access level of anything the change adds to a type.
-3. `cpp-api-design` skill — the shape of a changed public surface, and whether the change
+2. `code-navigation` skill — where an answer about a symbol's callers, implementations or
+   definition comes from.
+3. `cpp-encapsulation` skill — the access level of anything the change adds to a type.
+4. `cpp-api-design` skill — the shape of a changed public surface, and whether the change
    breaks the callers of it.
-4. `comments` / `cpp-doxygen` skills — the comments the change leaves behind, and the
+5. `comments` / `cpp-doxygen` skills — the comments the change leaves behind, and the
    documentation a new public header owes.
-5. `pr-rules` skill — how a finding is worded, and where review feedback may be published
+6. `pr-rules` skill — how a finding is worded, and where review feedback may be published
    at all.
-6. `changelog` skill — on a change that touches `CHANGELOG.md`. The entry is part of the
+7. `changelog` skill — on a change that touches `CHANGELOG.md`. The entry is part of the
    diff under review, and `pr-rules` → Pre-Merge Checklist expects one for every
    user-visible change.
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 description: Use to implement a single planned task by TDD. Invoke once a spec exists (see spec-architect) and it's time to write code for one task from it.
-tools: Skill, Read, Edit, Write, Grep, Glob, Bash
+tools: Skill, Read, Edit, Write, Grep, Glob, Bash, LSP
 license: Unlicense
 metadata:
   author: ssoft
@@ -20,10 +20,12 @@ this file:
 3. `ddd` skill — the vocabulary the spec already fixed, carried into the code unchanged.
 4. `cpp-encapsulation` skill — the access level of every member the task adds, justified
    against the spec rather than an anticipated caller.
-5. `cpp-testing` skill — the structure of the tests the loop produces.
-6. `work-sequence` skill — When a Check Runs, for which checks a round of edits runs and
+5. `code-navigation` skill — where an answer about a symbol's callers or definition comes
+   from.
+6. `cpp-testing` skill — the structure of the tests the loop produces.
+7. `work-sequence` skill — When a Check Runs, for which checks a round of edits runs and
    which of them belong to a later moment.
-7. `project-planning` skill — Running Independent Work in Parallel, for each launch that
+8. `project-planning` skill — Running Independent Work in Parallel, for each launch that
    section names.
 
 If a step in the spec is ambiguous or missing, stop and surface the gap rather than

--- a/agents/spec-architect.md
+++ b/agents/spec-architect.md
@@ -1,7 +1,7 @@
 ---
 name: spec-architect
 description: Use to turn an idea into a written specification and, when the change touches system or module structure, an architecture decision. Invoke at the start of new work, before any implementation code is written.
-tools: Skill, Read, Grep, Glob, Write, Edit
+tools: Skill, Read, Grep, Glob, Write, Edit, LSP
 license: Unlicense
 metadata:
   author: ssoft
@@ -23,6 +23,7 @@ this file:
    a new architectural pattern; it decides whether an ADR is warranted and what goes in it.
 4. `cpp-api-design` skill — when the spec implies a new or changed public surface, so the
    implementer isn't guessing at the API while writing the first test.
+5. `code-navigation` skill — the set of users a renamed or removed public symbol breaks.
 
 Stop once the spec is concrete enough that `implementer` could write the first failing
 test from it without asking a clarifying question. Do not write implementation code —

--- a/skills/code-navigation/SKILL.md
+++ b/skills/code-navigation/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: code-navigation
+version: "1.0.0"
+description: Apply when an edit or a verdict turns on a symbol's callers, its implementations, its definition, what a bare name refers to, or whether the symbol has any user left
+license: Unlicense
+metadata:
+  author: ssoft
+  tier: narrow
+  bound-to:
+    - language
+  rubric: applied
+  tags:
+    - navigation
+    - symbols
+---
+
+# Skill: Code Navigation
+
+Apply when an edit or a verdict turns on a symbol's callers, its implementations, its
+definition, what a bare name refers to, or whether the symbol has any user left.
+
+- What is decided on the answer — an access level, a removal, a review finding, a fix —
+  belongs to the skill whose rule asked the question.
+
+## Project Overrides
+
+**Must**
+
+Must follow the code-navigation conventions the repository's `AGENTS.md` file or a project
+skill defines, instead of the rule here.
+
+---
+
+## Questions a Text Search Does Not Answer
+
+**Must**
+
+A reader must not answer a question below by matching text over the source. A text search
+reports a match inside a string, a comment or an unrelated identifier, and misses an
+overload, a template instantiation, a macro expansion and a call through a pointer.
+
+| # | Question |
+|---|---|
+| 1 | which code calls a symbol |
+| 2 | what implements an interface or overrides a method |
+| 3 | where a symbol is defined |
+| 4 | what a bare name refers to across the workspace |
+| 5 | whether a symbol has any user left |
+
+Nothing else belongs to the list. A call path is question 1 asked again at each site the
+answer names. The symbol of every question is one a program declares in its source, so a
+name standing in prose or in a document falls outside the five.
+
+## Where the Answer Comes From
+
+**Must**
+
+The questions stand unchanged in every language, and the prerequisite alone differs. An
+answer must come from a language server configured for the file type, reading the project
+model the table below names for the language the question is asked in:
+
+| Language | What the server reads |
+|---|---|
+| C++ | the compilation database `compile_commands.json` |
+| JavaScript | the file `jsconfig.json`, or the project's own `package.json` file |
+| any other language | the project model that language's server names |
+
+## Naming the Operation
+
+**Must**
+
+An answer to one of those questions (Questions a Text Search Does Not Answer) must name
+the operation that produced it, and a run of the `grep` or `rg` command is not such an
+operation. Where the reader holds no such operation, the answer must say so, and the
+reader must not settle for a text search — the rule turning on that answer stands
+unresolved until the reader holds such an operation. The word-boundary form and the
+substring form of one search over this repository:
+
+```sh
+$ grep -rilw "AST" skills/   # this file alone, which prints the term
+$ grep -ril  "AST" skills/   # and every file it adds, where the term sits inside a longer word
+```
+
+Neither run answers whether a rule about an AST exists. The word-boundary hit is this
+file's own example, and the term sits inside a longer word in every file the substring
+form adds — `cast`, `fast` and `infrastructure` among those words. The same false match
+and the same miss reach a symbol question, where the answer decides an edit.
+
+## The Operations in This Environment
+
+**May**
+
+A reader offered the tool `LSP` may call it for one of those questions (Questions a Text
+Search Does Not Answer), each operation addressed by a file path and a one-based line and
+character.
+
+The tool reaches only a file type a server is configured for, answering
+`No LSP server available for file type: <ext>` for any other, whatever row it takes in
+the table of Where the Answer Comes From. Where the tool answers so, the reader holds no
+operation for that question, as does a reader not offered the tool at all, and Naming the
+Operation states the answer both owe.
+
+The table below is this environment's own, carrying the numbers of Questions a Text
+Search Does Not Answer; another environment names operations of its own for the same
+questions.
+
+| # | Operation |
+|---|---|
+| 1 | `findReferences` |
+| 2 | `goToImplementation` |
+| 3 | `goToDefinition` |
+| 4 | `workspaceSymbol`, which takes a query string, leaves the position unread and reads the path only to select the server |
+| 5 | the operation of question 1, answering an empty set |
+
+A reader may walk the call path reaching a site with `prepareCallHierarchy`, then
+`incomingCalls` on each step `prepareCallHierarchy` answers, and may ask a question of the
+same kind that no rule of this catalog turns on — the type an expression has with `hover`,
+what a file declares with `documentSymbol`.
+
+## A Rename and a Removal Are Edits
+
+**Must**
+
+A rename and a removal are edits made against the set question 1 returns (Questions a
+Text Search Does Not Answer). Where the environment offers no operation performing
+either, as this one does not, a skill needing one of the two must ask that question first
+and edit afterwards.

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -112,6 +112,8 @@ After a change removes the last caller of a function, type, or constant, check w
 anything is now unreachable. Point it out explicitly rather than letting it linger — a
 change that leaves dead code behind isn't finished, even if what it added is correct.
 
+Whether a symbol has a caller left is a question the `code-navigation` skill owns.
+
 ## Performance
 
 - A change on a hot path (per-request, per-frame, per-iteration of a large loop) gets

--- a/skills/cpp-api-design/SKILL.md
+++ b/skills/cpp-api-design/SKILL.md
@@ -61,6 +61,8 @@ meeting it is owned elsewhere:
 
 - Avoid one unless it is necessary — an addition beside the existing symbol is almost
   always available.
+- The set of the public symbol's users, which a removal or a rename breaks →
+  `code-navigation` skill.
 - Retiring the old path (deprecate before removing, grace period, migration guide) →
   `deprecation-and-migration` skill.
 - The version bump it forces → `release` skill → Step 1 — Decide Version.

--- a/skills/cpp-encapsulation/SKILL.md
+++ b/skills/cpp-encapsulation/SKILL.md
@@ -39,7 +39,7 @@ project skill defines, instead of the rule here.
 - **`public`** — only members actually used from outside the class: the genuine external contract.
 - **`protected`** — only members actually used by derived classes (extension points, never a substitute for `public` "just in case"). Prefer `protected` virtual methods over `protected` data members — derived classes should go through behavior, not touch raw state.
 - **`private`** — everything else, including implementation helpers and internals derived classes don't need.
-- **Reviewing existing code** — a `public` method with no external caller demotes to `private`; one only called by derived classes demotes to `protected`.
+- **Reviewing existing code** — a `public` method with no external caller demotes to `private`; one only called by derived classes demotes to `protected`. Where the set of callers deciding that comes from → `code-navigation` skill.
 - **`friend`** — only for tightly-coupled pairs (e.g. a builder and its product), never as a shortcut to avoid picking the right access level.
 
 **Why:** every `public` member is a promise to every caller — widening later is free, narrowing is a breaking change. Defaulting to `private` keeps that promise as small as possible until proven otherwise.

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -17,6 +17,7 @@ metadata:
 
 Apply when investigating a bug, test failure, or unexpected behavior, before proposing a fix.
 
+- Where the call path reaching the failing site comes from → `code-navigation` skill.
 - Once the cause is understood and a fix is being written → the coding-conventions skill
   of the language being written.
 - The fix needs a test that fails before it and passes after → `test-driven-development` skill.

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -134,3 +134,6 @@ Open an issue for the actual removal at the same time the deprecation ships, tar
 at the release where the grace period ends (`issue-rules` → Milestone), so the removal
 isn't forgotten and doesn't slip indefinitely once the deprecation notice stops being
 visible in day-to-day work.
+
+The set of the deprecated symbol's users, which the removal is planned against, is a
+question the `code-navigation` skill owns.

--- a/test/code-navigation.test.js
+++ b/test/code-navigation.test.js
@@ -1,0 +1,72 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoDir = path.join(__dirname, '..');
+const skillFile = path.join(repoDir, 'skills', 'code-navigation', 'SKILL.md');
+
+function readSkill() {
+  return fs.readFileSync(skillFile, 'utf8');
+}
+
+// The two commands the skill prints carry the term and the directory they run over, so
+// the test measures the example the reader is shown rather than a copy of it.
+function printedSearch() {
+  const text = readSkill();
+  const boundary = text.match(/\$ grep -rilw "([^"]+)" (\S+)/);
+  const substring = text.match(/\$ grep -ril\s+"([^"]+)" (\S+)/);
+  assert.ok(boundary && substring, 'the skill prints no word-boundary and substring pair');
+  assert.strictEqual(boundary[1], substring[1], 'the two runs search different terms');
+  assert.strictEqual(boundary[2], substring[2], 'the two runs search different directories');
+  return { term: boundary[1], dir: boundary[2].replace(/\/$/, '') };
+}
+
+function filesUnder(dir) {
+  const found = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...filesUnder(full));
+    else found.push(full);
+  }
+  return found;
+}
+
+function matching(term, dir, wordBoundary) {
+  const pattern = new RegExp(wordBoundary ? `\\b${term}\\b` : term, 'i');
+  return filesUnder(path.join(repoDir, dir))
+    .filter(file => pattern.test(fs.readFileSync(file, 'utf8')))
+    .map(file => path.relative(repoDir, file).split(path.sep).join('/'));
+}
+
+test('the word-boundary run matches the owner of the example alone', () => {
+  const { term, dir } = printedSearch();
+  assert.deepStrictEqual(matching(term, dir, true), ['skills/code-navigation/SKILL.md']);
+});
+
+test('every file the substring run adds holds the term inside a longer word', () => {
+  const { term, dir } = printedSearch();
+  const boundary = new Set(matching(term, dir, true));
+  const added = matching(term, dir, false).filter(file => !boundary.has(file));
+  assert.ok(added.length > 0, 'the substring run adds no file, so the example shows nothing');
+  const pattern = new RegExp(`\\b${term}\\b`, 'i');
+  for (const file of added) {
+    assert.ok(!pattern.test(fs.readFileSync(path.join(repoDir, file), 'utf8')),
+      `${file} holds ${term} on a word boundary, so it is not a longer-word match`);
+  }
+});
+
+test('every word the skill names as a longer-word match is one', () => {
+  const { term, dir } = printedSearch();
+  const sentence = readSkill().match(/form adds —([\s\S]*?)among those words/);
+  const words = sentence ? [...sentence[1].matchAll(/`([A-Za-z]+)`/g)].map(hit => hit[1]) : [];
+  const added = new Set(matching(term, dir, false).filter(file => !matching(term, dir, true).includes(file)));
+  const corpus = [...added].map(file => fs.readFileSync(path.join(repoDir, file), 'utf8')).join('\n');
+  for (const word of words) {
+    assert.ok(new RegExp(`\\b${word}\\b`, 'i').test(corpus),
+      `the skill names ${word} as a longer-word match, and no file the run adds holds it`);
+    assert.ok(new RegExp(term, 'i').test(word) && !new RegExp(`^${term}$`, 'i').test(word),
+      `${word} does not hold ${term} inside a longer word`);
+  }
+});

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -144,8 +144,9 @@ function skillsDeclaringRubric() {
 }
 
 // Extended by the pass that marks the next skill; every name here is checked below.
-const MARKED_SKILLS = ['comments', 'editing', 'github-cli', 'gitlab-cli', 'pr-rules',
-  'skill-authoring', 'submodule-sync', 'work-sequence', 'writing-style'];
+const MARKED_SKILLS = ['code-navigation', 'comments', 'editing', 'github-cli',
+  'gitlab-cli', 'pr-rules', 'skill-authoring', 'submodule-sync', 'work-sequence',
+  'writing-style'];
 
 function commandFiles() {
   const names = fs.readdirSync(commandsDir).filter(name => name.endsWith('.md'));


### PR DESCRIPTION
## Problem

No skill named a semantic tool for navigating code, and five rules of the catalog turn on
a set a text search returns wrongly: the last caller of a symbol, the users a breaking
change affects, the users a removal waits on, the callers deciding an access level, and
the call path reaching a root cause. A text search matches inside a string or a comment
and misses an overload, a template instantiation, a macro expansion and a pointer call.

## Summary

- A new skill `code-navigation` owns the five questions as a closed table, the per-language prerequisite, and the threshold an answer meets
- The operation names appear once, in a section declared as this environment's own and marked `**May**`
- A rename and a removal are stated as edits decided on the set the first question returns, since the environment performs neither
- The five skills whose rules need such an answer name the owner and restate neither the questions nor the threshold
- The three personas whose skills hand that question over load the skill and declare the tool its operations belong to

## Implementation

- `bound-to: language`, a category, which is what lets all five name the skill in backticks: three of them are bound to `universal`, and an instance context would force the role form on those three
- The symbol of every question is one a program declares in its source, which keeps the skill-rename grep of `skill-authoring`, the version-string grep of `release` and the persisted-format gate of `deprecation-and-migration` outside the threshold
- Where a reader holds no such operation the answer says so, and the reader must not settle for a text search; the rule turning on that answer stands unresolved until the reader holds one
- The tool's own limit is stated where it falls: it reaches only a file type a server is configured for, whatever row that type takes in the per-language table
- Neither the every-prompt reminder nor the edit-time gate reaches a persona, so each of the three names the skill in its own body
- Its row in the lifecycle map declares `cross-cutting`: the questions arise at the Implement and the Review stage, so no single stage row holds it

## Test plan

- [x] `npm test` passes
- [x] `grep -rln "findReferences" skills/` prints one path, the owner's
- [x] `test/code-navigation.test.js` holds the worked example against the corpus: it parses both commands out of the printed block, then checks that the word-boundary run matches the owner alone, that every file the substring run adds carries the term inside a longer word, and that each word the prose names is such a match
- [x] That test measured against its own subject: `AST` written as a word in another skill fails it, restoring that file passes it
- [x] Every operation name resolved against the schema of the tool `LSP`, and `workspaceSymbol` called with a dummy line and character to establish that its query leaves both unread
- [x] The tool called over a `.js` file of this repository and over a C++ file of a project carrying `compile_commands.json`: `No LSP server available for file type: .js` against a real answer, which is what the file-type limit above is measured on
- [x] Each index measured against its own file: the name removed from the marked list, the lifecycle row deleted, one word of the fixed sentence changed
- [ ] Out of scope - test-plan item 4 of the issue asks a reviewer to name the `LSP` operation answering which modules call `runAsScript` of `tools/guard.js`. No server serves `.js` here and installing one is out of scope by the issue's own statement, so following the skill yields the answer it prescribes instead: no operation is held, and the rule stands unresolved
