### PR TITLE
GH-162: Shorten a text by what it says, not by its words

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `ddd` — modelling inside one bounded context.
 - `debugging` — the investigation that precedes a fix.
 - `deprecation-and-migration` — retiring a public path.
-- `editing` — the edit mechanic itself.
+- `editing` — the guard against a stale reading of a file, of a tracker or forge artifact, and of the branch head at a merge.
 - `github-cli` — `gh` mechanics.
 - `gitlab-cli` — `glab` mechanics.
 - `hook-scripts` — writing this repository's hooks and tools.
@@ -171,7 +171,7 @@ missing value.
 | Skill | Stage | Trigger | Input | Output | Entry criterion | Exit criterion |
 |-------|-------|---------|-------|--------|------------------|-----------------|
 | `deprecation-and-migration` | Implement | retiring a public API, planning a breaking change, or writing a migration guide | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
-| `editing` | cross-cutting | an Edit or Write tool call on a file in the project | the file's content before the call | the file's content after the call | the file in scope for the task, per `editing` → Edit Scope | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
+| `editing` | cross-cutting | a write to a file, a tracker issue body or a PR description, and a merge | the artifact as it stands before the write | the artifact as it stands after the write | a reading of the artifact taken immediately before the write, per `editing` → Guard Against a Stale Reading | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
 | `hook-scripts` | Implement | writing or modifying a file under `hooks/` or `tools/` | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `commit-rules` → Branch Naming | the test file `node-testing` covers for the tool, `test/<name>.test.js` |
 | `node-testing` | Implement | writing or reviewing a file under `test/*.test.js` | the pure logic exported by the hook or tool under test | a test file asserting that logic's behaviour | the tool's exported logic, per `hook-scripts` → Tool Skeleton | the tool covered and `npm test` run, per `hook-scripts` → Adding or Retiring a Tool |
 | `observability-and-instrumentation` | cross-cutting | adding logging, metrics, or tracing, or checking a running system's reported behaviour | the question an on-call engineer needs answered | a structured log line, metric, or trace answering it | the non-functional requirement `requirements` → Functional vs Non-Functional records | the Readiness Checklist item `shipping-and-launch` → Readiness Checklist for monitoring |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - The `security-and-hardening` containment and overflow rules state the control and the input classes a guard must answer, in terms tied to no language. The code examples are gone, and with them the advice they carried: a string comparison of resolved paths, and a check reading the sum
 - Renamed three steps of the order of work after what they achieve: `Push` is now `Publish`, `PR` is `Offer for review`, and `Merge commit` is `Integrate`; `AGENTS.md` -> Lifecycle map carries the same names
 - `AGENTS.md` states the project, the two maps and one pointer per mechanism. Writing a hook or a tool, and adding or retiring one, is read from `hook-scripts`; what each dispatcher routes where from `README.md` -> Hooks; adding a persona or a command from its template
+- `editing` now covers a tracker issue's body and checklist, a PR description, a review thread and a merge, naming the guard or the re-read procedure for each; `pr-rules` -> Pre-Merge Checklist gains the review-thread box
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- A text is shortened by cutting what carries no meaning of its own, and what survives stays whole: a full sentence, no word shortened, no structure dropped. Fewer words is not the aim
 - The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there
 - A skill declares its relation to the conventions of the project it is applied in, as `project-relation` in its frontmatter: `overrides` where absent, and `binding` for a skill stating this repository's own conventions, which carries `## Project Binding` in place of `## Project Overrides`
 - What introduces an enumeration names what it holds, and what closes one is the statement that nothing else belongs to it rather than a count announced above it

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `ddd` | Domain-Driven Design patterns in C++ |
 | `debugging` | Root-cause investigation before proposing a fix |
 | `deprecation-and-migration` | Retiring a public API and writing a migration guide |
-| `editing` | File editing workflow (re-read before edit) |
+| `editing` | Guard against a stale reading of a file, of a tracker or forge artifact, and of a branch head |
 | `github-cli` | `gh` mechanics — issues, PRs, labels, pending review threads, stacks, merges |
 | `gitlab-cli` | `glab` mechanics — issues, MRs, labels, draft notes, stacks, merges |
 | `hook-scripts` | Writing Claude Code hooks and tools |

--- a/skills/editing/SKILL.md
+++ b/skills/editing/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: editing
 version: "1.0.0"
-description: Apply when editing any file in the project
+description: Apply before writing a file, a tracker issue body or a PR description, and before a merge, which reads the pull request's review threads again first
 license: Unlicense
 metadata:
   author: ssoft
   tier: domain
+  rubric: applied
   bound-to:
     - agent-tool
   tags:
@@ -13,26 +14,45 @@ metadata:
     - editing
 ---
 
-# Skill: File Editing Workflow
+# Skill: Editing an Artifact
 
-Apply when editing any file in the project.
+Apply before writing a file, a tracker issue body or a PR description, and before a
+merge. Guard Against a Stale Reading names each one.
 
 ## Project Overrides
 
 **Must**
 
-Must follow the editing workflow the repository's `AGENTS.md` file or a project skill
-defines, instead of the rule here.
+Must follow the guard against a stale reading the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
+## Guard Against a Stale Reading
+
+**Must**
+
+| Artifact | Guard | Procedure where the guard does not hold |
+|---|---|---|
+| A file | Only the exact-string match of the tool `Edit`, which fails loudly | Re-Read Before Edit |
+| The body of a tracker issue, with its checklist boxes | None: the command that writes the body — `gh issue edit --body-file`, and its equivalent on the CLI skill of the issue tracker — replaces it whole | Must build the write from the body fetched immediately before it, checklist boxes included |
+| The description of a PR | None, for the same reason: the command `gh pr edit --body-file`, and its equivalent on the CLI skill of the hosting platform, replaces the description whole | As for the issue body |
+| A review thread | None: a branch requiring every thread resolved refuses an unresolved one, not one opened and resolved between the two reads, and an administrator can bypass even that | Must read the thread list again immediately before the merge command runs, and must match it against the list read when the review was last addressed. A thread appearing between the two reads blocks the merge until a confirmation of its own names it; where no earlier read exists, every unresolved thread blocks it |
+| A merge | Must pass the head SHA read after the last rebase to the merge command — the flag `--match-head-commit <sha>` of the command `gh pr merge`, and its equivalent on the CLI skill of the hosting platform — which then refuses the merge once that head has moved | Where a CLI offers no such flag, must read the head SHA immediately before the merge command and refuse the merge where it differs from the one read after the rebase |
+
+Nothing else belongs to the table. The rest of the merge gate: `pr-rules` → Merge Strategy.
 
 ## Re-Read Before Edit
 
-Always issue a fresh `Read` of the target file immediately before editing it — even if it was read earlier in the same session.
+**Must**
+
+Must issue a fresh `Read` of the target file immediately before editing it — even if it was read earlier in the same session.
 
 **Why:** The user edits files directly between Claude interactions (build error fixes, manual corrections, formatting). A cached read from earlier in the session may be stale; editing from stale state overwrites user changes silently.
 
 **Rule:** One `Read` → one `Edit` block. If multiple edits to the same file are needed in one turn, read once, then apply all edits. Do not re-read between edits within the same turn.
 
 ## Edit Scope
+
+**Should**
 
 - Edit only files explicitly in scope for the current task.
 - Do not touch adjacent files unless the user requested it.

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -181,6 +181,11 @@ of them names a moment.
 - [ ] Every module reference the branch records satisfies the merge order the module-sync skill of the version control system fixes
 - [ ] Every test-plan box in the PR description is checked, or the item is named out of scope with a reason
 - [ ] A comment is added to the issue recording which PR/MR resolves which item (`issue-rules` → Progress Comments)
+- [ ] Every review thread opened since the review was last addressed is named in a confirmation authorising the merge; where no earlier read exists, every unresolved thread is (`editing` → Guard Against a Stale Reading)
+
+The flag `--match-head-commit <sha>` does not cover the review-thread box: a thread
+opened after the thread list was last read moves no commit
+(`editing` → Guard Against a Stale Reading).
 
 ## Merge Strategy
 
@@ -191,8 +196,9 @@ of them names a moment.
    naming this PR, which does not carry to the next one: the authorisation is per pull
    request, so a command merging several needs an instruction naming each of them.
 3. **Rebase before merge.** `git rebase <target>`, then merge from the current target
-   tip; the rebase moves the head, so it returns to the Publish step and the checks of
-   that moment run again (`work-sequence` → When a Check Runs).
+   tip; the rebase moves the head, so it returns to the Publish step, the checks of
+   that moment run again (`work-sequence` → When a Check Runs), and the head SHA the
+   merge is guarded with is read after it (`editing` → Guard Against a Stale Reading).
 4. **`--no-ff` only.** No fast-forward merge, no squash merge.
 5. **Merge subject:** `Merge PR #<pr-number>: <pr subject>`, the PR subject verbatim
    and never re-prefixed with `type(scope):`, so a tracker ID in the title leaves both
@@ -226,6 +232,7 @@ is split before review.
 - `issue-rules` — the issue this PR resolves: title, templates, labels, lifecycle, progress comments.
 - `commit-rules` — commit message format and branch naming on the PR's branch.
 - `code-review-and-quality` — what a review looks for, where this skill states how a finding is worded.
+- `editing` — the re-read this skill's two checklists and merge strategy turn on, for a description, a review thread and the branch head.
 - `writing-style` — prose register in the description and in the review threads.
 - `ci-cd-and-automation` — the pipeline answering the checks reported on the pull request.
 - The module-sync skill of the version control system — the pre-PR check and the merge order the checklists gate on.

--- a/skills/writing-style/SKILL.md
+++ b/skills/writing-style/SKILL.md
@@ -56,6 +56,17 @@ step. Neither spoken register, nor marketing tone, nor the slang of a chat.
 | hedging padding | "I think maybe", "possibly" |
 | a pleasantry carrying no information | "great question", "happy to help" |
 
+## Cut What Carries No Meaning, Not Words
+
+**Should**
+
+Should cut every part of a text carrying no meaning of its own: what the reader already
+knows, what the text has said once, a quotation of what the reader can open, and a
+retelling of what a named artifact states. Should keep whole whatever survives that cut —
+a full sentence, no word shortened, no structure dropped to save room. Brevity is what a
+text has left once the meaningless is gone, never what it has left once the words are
+counted down.
+
 ## State the Result, Not the Process
 
 **Should**

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -144,7 +144,7 @@ function skillsDeclaringRubric() {
 }
 
 // Extended by the pass that marks the next skill; every name here is checked below.
-const MARKED_SKILLS = ['comments', 'github-cli', 'gitlab-cli', 'pr-rules',
+const MARKED_SKILLS = ['comments', 'editing', 'github-cli', 'gitlab-cli', 'pr-rules',
   'skill-authoring', 'submodule-sync', 'work-sequence', 'writing-style'];
 
 function commandFiles() {


### PR DESCRIPTION
## Problem

The skill forbade a repeat and forbade process narration, and named no test for length
itself. A text could therefore be shortened by dropping a word, abbreviating one or leaving
a fragment, which reads as brevity and costs the reader a rereading.

## Summary

- `writing-style` gains one section: a text is shortened by cutting what carries no meaning of its own, and what survives stays whole
- The kinds it names to cut: what the reader already knows, what the text has said once, a quotation of what the reader can open, a retelling of what a named artifact states
- Fewer words is not the aim, and no word is shortened and no structure dropped to save room

## Implementation

- The section sits between `Match the Technical Register` and `State the Result, Not the Process`, the general test before the two specific ones
- `**Should**`, since no statement in it names a quantity to count (`skill-authoring` -> Choosing the Marker)
- The two existing sections keep their own subjects: this one states the test, and a repeat is one kind of what it cuts

## Test plan

- [x] `npm test` - 716 tests, 0 failing
- [x] `node --test test/rubric.test.js` passes over the new section's marker and modal
- [ ] `node install.js`, which puts the edited file where an agent reads it - the user runs it
