### PR TITLE
GH-150: Add artifact-placement, the owner of where a result goes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ meets it. A rule belongs to exactly one line — a second statement is not empha
 a copy that drifts, and the agent reading both has nothing telling it which one wins.
 
 - `architecture` — how modules, services and processes fit together.
+- `artifact-placement` — where an artifact a rule produces is put.
 - `changelog` — the `CHANGELOG.md` file.
 - `ci-cd-and-automation` — the pipeline producing the checks-passed signal.
 - `code-navigation` — where an answer about a symbol comes from.
@@ -88,7 +89,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `ddd` — modelling inside one bounded context.
 - `debugging` — the investigation that precedes a fix.
 - `deprecation-and-migration` — retiring a public path.
-- `editing` — the guard against a stale reading of a file, of a tracker or forge artifact, and of the branch head at a merge.
+- `editing` — the guard against a stale reading of a file, of a tracker or forge artifact and of the branch head at a merge.
 - `github-cli` — `gh` mechanics.
 - `gitlab-cli` — `glab` mechanics.
 - `hook-scripts` — writing this repository's hooks and tools.
@@ -171,6 +172,7 @@ missing value.
 
 | Skill | Stage | Trigger | Input | Output | Entry criterion | Exit criterion |
 |-------|-------|---------|-------|--------|------------------|-----------------|
+| `artifact-placement` | cross-cutting | a rule produces an artifact a reader outside the code will open | the artifact, and the conventions the project states for a record of its kind | the location the artifact is written to | the requirement `artifact-placement` → The Requirement, Not the Path names for a location | the location traced to a stated convention or to an answer, per `artifact-placement` → Where the Place Comes From |
 | `code-navigation` | cross-cutting | an edit or a verdict turning on a symbol's callers, its implementations, its definition, what a bare name refers to, or whether the symbol has any user left | the symbol, at the file path, line and character it stands at, or the name a workspace-wide query carries | the set of sites the operation returns | the source `code-navigation` → Where the Answer Comes From names for the language | the answer naming the operation that produced it, per `code-navigation` → Naming the Operation |
 | `deprecation-and-migration` | Implement | retiring a public API, planning a breaking change, or writing a migration guide | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
 | `editing` | cross-cutting | a write to a file, a tracker issue body or a PR description, and a merge | the artifact as it stands before the write | the artifact as it stands after the write | a reading of the artifact, per `editing` → Guard Against a Stale Reading | the checks a round of edits runs, per `work-sequence` → When a Check Runs |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `artifact-placement` skill: where an artifact a rule produces is put is the project's to decide, and the skill producing it states the requirement its location meets rather than a path, asking where the project is silent; a path an external convention or a tool fixes names its basis instead
 - `code-navigation` skill: the questions a text search does not answer about a symbol - its callers, implementations, definition, a bare name's referent and the symbol's remaining users - the rule that an answer names the operation producing it, and `test/code-navigation.test.js` over the example
 - Independent work runs at the same time: `project-planning` states when two units are independent, the lowest bound the contended resources put on the degree of parallelism, and when one check runs alone before the rest; a pipeline arranges its jobs so by default
 - The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | Skill | Description |
 |-------|-------------|
 | `architecture` | System/module architecture design, ADRs, tradeoffs |
+| `artifact-placement` | Where an artifact a rule produces is put: the requirement its location meets, and who chose it |
 | `changelog` | Keep a Changelog format |
 | `ci-cd-and-automation` | CI/CD pipeline design and quality gates |
 | `code-navigation` | Where an answer about a symbol comes from, and what a text search does not answer |
@@ -99,7 +100,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `ddd` | Domain-Driven Design patterns in C++ |
 | `debugging` | Root-cause investigation before proposing a fix |
 | `deprecation-and-migration` | Retiring a public API and writing a migration guide |
-| `editing` | Guard against a stale reading of a file, of a tracker or forge artifact, and of a branch head |
+| `editing` | Guard against a stale reading of a file, of a tracker or forge artifact and of a branch head |
 | `github-cli` | `gh` mechanics — issues, PRs, labels, pending review threads, stacks, merges |
 | `gitlab-cli` | `glab` mechanics — issues, MRs, labels, draft notes, stacks, merges |
 | `hook-scripts` | Writing Claude Code hooks and tools |

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -73,20 +73,9 @@ downsides — an ADR that only lists upsides reads as advocacy, not a decision r
 and won't help the next person who hits the downside in production.
 ```
 
-Where a decision record goes is a requirement rather than a path. It has to carry a
-stable reference a commit or a pull request description can point at (`ADR-0007`, a wiki
-permalink, an issue id), be reachable by everyone who will read it, and outlive the
-decision it records. A file in the repository meets that, and so does a wiki page, a
-tracker issue, or a page in Confluence or Notion; which of them applies comes from the
-project's own conventions — its `AGENTS.md`, or wherever else that project keeps them.
-
-Where the project states none, ask where the record goes and whether this project keeps
-such records at all, and choose neither silently. When Architecture Work Is Warranted
-above answers whether the decision is worth recording; only the project answers where the
-record lives. What a reader checks is the record's location against the two things allowed
-to have chosen it — a stated project convention, or an answer to that question in the
-thread the decision came out of. A record sitting somewhere neither of those names was
-placed by the agent, which is what this rule forbids.
+Where a decision record goes: `artifact-placement` → Where the Place Comes From. The section
+When Architecture Work Is Warranted above answers whether the decision needs a record of
+its own.
 
 ## Quality Priorities
 

--- a/skills/artifact-placement/SKILL.md
+++ b/skills/artifact-placement/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: artifact-placement
+version: "1.0.0"
+description: Apply when a rule produces an artifact a reader outside the code will open - a decision record, a requirement, a plan, a migration guide, a measurement, a rollback plan, a record of a weakness
+license: Unlicense
+metadata:
+  author: ssoft
+  tier: narrow
+  bound-to:
+    - universal
+  rubric: applied
+  tags:
+    - artifact
+    - placement
+---
+
+# Skill: Artifact Placement
+
+Apply when a rule produces an artifact a reader outside the code will open - a decision
+record, a requirement, a plan, a migration guide, a measurement, a rollback plan, a
+record of a weakness.
+
+- What the artifact carries, and whether it is owed at all, belongs to the skill whose
+  rule produces it.
+
+## Project Overrides
+
+**Must**
+
+Must follow the artifact-placement conventions the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
+---
+
+## The Requirement, Not the Path
+
+**Must**
+
+A skill producing an artifact must state the requirement its location has to meet and
+must state no path. Three requirements, each with what a reader looks at to establish it:
+
+| The location must | What establishes it |
+|---|---|
+| carry a reference that stays valid | a commit message, an issue or a pull request description can name it: `ADR-0007`, a wiki permalink, an issue identifier |
+| be open to the reader the artifact is written for | that reader opens it with the access they already hold, without asking for more |
+| outlive what it records | it is neither a scratch directory, nor a chat message, nor a branch the merge deletes |
+
+A file of the repository meets all three. So does a wiki page, a tracker issue, and a
+page in Confluence or Notion. Which of them applies is the project's to say, never the
+skill's.
+
+## Where the Place Comes From
+
+**Must**
+
+Must take the location from the conventions of the project - the repository's `AGENTS.md`
+file, or whatever other source the project keeps its conventions in. Where the project
+states none, must ask where to form the artifact and whether the project keeps such a
+record at all, and must choose neither of the two silently.
+
+A reader checks the location against the two things allowed to have chosen it:
+
+| Chose the location | Where a reader reads it |
+|---|---|
+| a stated convention of the project | the source the project keeps its conventions in |
+| an answer to the question above | the thread the work came out of |
+
+A location that traces to neither was chosen by whoever wrote the artifact, which is what
+this rule forbids.
+
+## A Path Fixed Outside the Project
+
+**Must**
+
+A path an external convention fixes, or one a tool derives when it loads the file, stands
+outside this rule, and the text claiming that path must name the basis that fixed it. The
+bases the catalog names today:
+
+| The path | Its basis |
+|---|---|
+| `CHANGELOG.md` | the Keep a Changelog format the skill `changelog` names |
+| the hook and tool directories under the configuration directory | how Claude Code loads them, the directory itself set by the environment variable `CLAUDE_CONFIG_DIR` |
+| a file matching `test/*.test.js` | how the command `node --test` walks the tree |
+| `skills/<name>/SKILL.md` | the path install writes and the Skill tool loads |
+
+A path with no such basis is not exempt, whatever its history.
+
+## What This Reaches
+
+**Must**
+
+The rule reaches an artifact whose location no rule of the skill producing it already
+fixes. The artifacts the catalog states one for today, each beside the skill it is
+produced under:
+
+| Artifact | Produced under |
+|---|---|
+| a decision record | `architecture` |
+| a written requirement | `requirements` |
+| a plan or a status update | `project-planning` |
+| a migration guide | `deprecation-and-migration` |
+| a before-and-after measurement of a hot path | `performance-optimization` |
+| a rollback plan | `shipping-and-launch` |
+| the record of a class of weakness | `security-and-hardening` |
+
+Two kinds of artifact stand outside the rule rather than below the table: one the layout
+of the code places, since the code's own structure chose it - a fix, a test, a log line -
+and one whose path an external convention or a tool fixes, per A Path Fixed Outside the
+Project.
+
+## Cross-References
+
+**Recommended**
+
+- `editing` - the guard against writing over a reading of the artifact that has gone stale.
+- `writing-style` - the register the artifact is written in.

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -92,6 +92,8 @@ case, and what silently changes behavior (not just signature) if anything does. 
 migration guide that only shows the new signature, without a behavior diff, misses the
 cases that compile after migration but behave differently.
 
+Where the guide goes: `artifact-placement` → Where the Place Comes From.
+
 ## Coexistence During the Grace Period
 
 The deprecated and replacement paths must both work correctly during the grace period —

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -70,6 +70,8 @@ don't assume" spirit applied to performance instead of correctness.
 - Bad: "this should be faster because it avoids a copy" (no measurement)
 - Good: "p99 latency for a 10k-row export dropped from 480ms to 95ms (benchmark: `export_bench`, 20 runs)"
 
+Where the before-and-after measurement goes: `artifact-placement` → Where the Place Comes From.
+
 ## Common Sources, in Order of Likely Impact
 
 | Source | What to check |

--- a/skills/project-planning/SKILL.md
+++ b/skills/project-planning/SKILL.md
@@ -25,6 +25,7 @@ once.
   in-conversation task plan for a single coding task, which the `Plan` tooling covers.
   Running Independent Work in Parallel is the exception: it governs a launch whatever the
   plan behind it.
+- Where a plan or a status update goes: `artifact-placement` → Where the Place Comes From.
 - A plan is built from settled requirements — if those don't exist yet, go get them
   first → `requirements` skill.
 - PR Size discipline and the release checklist are the execution-time tail end of a

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -40,6 +40,8 @@ with their own assumption. Writing it down once, in a shared format, means every
 fills the gaps the same way, and disagreements surface before code is written instead
 of in review.
 
+Where the written requirement goes: `artifact-placement` → Where the Place Comes From.
+
 ## Structure of a Requirement
 
 Every requirement should make these explicit, even briefly:

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -224,3 +224,5 @@ regression test. What is specific to a vulnerability: fix the class of weakness 
 than the exploit string that revealed it, and document that class. A silently patched
 security bug leaves the next instance of the same weakness, in a different location,
 undiscovered.
+
+Where the record of the class goes: `artifact-placement` → Where the Place Comes From.

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -81,6 +81,8 @@ plan discovered under incident pressure is not a plan; if reverting is not
 straightforward (irreversible migration, external side effects), say so explicitly
 before launch, not after something goes wrong.
 
+Where the plan goes: `artifact-placement` → Where the Place Comes From.
+
 ## Feature Flags
 
 For a change too risky to expose to everyone at once but also not practical to hold in

--- a/test/artifact-placement.test.js
+++ b/test/artifact-placement.test.js
@@ -1,0 +1,270 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoDir = path.join(__dirname, '..');
+const skillsDir = path.join(repoDir, 'skills');
+
+// The headings the owning skill carries and the phrase its ownership-map line states.
+// The citation heading identifies the owner; No skill name is written into this file:
+// which skill owns the statement is read off the catalog.
+const SECTION = 'Where the Place Comes From';
+const TABLE_SECTION = 'What This Reaches';
+const CONCERN = 'where an artifact a rule produces is put';
+const OWNERSHIP_MAP = 'Skill ownership map';
+
+const HEADING = /^##\s+(.*)$/;
+const FENCE = /^\s*(?:```|~~~)/;
+
+// The `##` headings of a file in order, each with its body, a fenced `##` line counted
+// as neither.
+function sections(text) {
+  const found = [];
+  let current = null;
+  let fenced = false;
+  for (const line of String(text).replace(/\r\n/g, '\n').split('\n')) {
+    if (FENCE.test(line)) {
+      fenced = !fenced;
+      if (current) current.body.push(line);
+      continue;
+    }
+    const heading = !fenced && line.match(HEADING);
+    if (heading) {
+      current = { heading: heading[1].trim(), body: [] };
+      found.push(current);
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  return found;
+}
+
+function carriesSection(text) {
+  return sections(text).some(section => section.heading === SECTION);
+}
+
+function tableRows(bodyLines) {
+  return bodyLines
+    .filter(line => /^\s*\|.*\|\s*$/.test(line))
+    .map(line => line.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map(c => c.trim()))
+    .filter(cells => !cells.every(cell => /^:?-+:?$/.test(cell)));
+}
+
+// The artifact kinds the statement ranges over, taken from the table it carries itself.
+function producers(text) {
+  const section = sections(text).find(entry => entry.heading === TABLE_SECTION);
+  if (!section) return [];
+  return tableRows(section.body)
+    .map(cells => ({ artifact: cells[0], skill: (cells[1] ?? '').match(/^`([^`]+)`$/)?.[1] }))
+    .filter(row => row.skill !== undefined);
+}
+
+// A citation resolves against the heading, so it carries the owning skill and that text.
+const CITATION = new RegExp('`([a-z0-9]+(?:-[a-z0-9]+)*)`\\s*(?:→|->)\\s*' + SECTION, 'g');
+
+function citations(text) {
+  const flat = String(text).replace(/\s+/g, ' ');
+  return [...new Set([...flat.matchAll(CITATION)].map(match => match[1]))];
+}
+
+function staleCitations(owningSkill, text) {
+  return citations(text).filter(name => name !== owningSkill);
+}
+
+function strayCiters(named, citing) {
+  return citing.filter(name => !named.includes(name));
+}
+
+// One entry per bullet of the map, a wrapped line joined to the bullet it continues.
+function mapEntries(mapText) {
+  const entries = [];
+  for (const line of String(mapText).replace(/\r\n/g, '\n').split('\n')) {
+    if (/^-\s/.test(line)) entries.push(line);
+    else if (entries.length > 0 && /^\s+\S/.test(line)) {
+      entries[entries.length - 1] += ' ' + line.trim();
+    }
+  }
+  return entries;
+}
+
+function ownersNaming(concern, mapText) {
+  const phrase = concern.toLowerCase();
+  return mapEntries(mapText)
+    .filter(entry => entry.toLowerCase().includes(phrase))
+    .map(entry => entry.match(/^-\s+`([^`]+)`/)?.[1])
+    .filter(name => name !== undefined);
+}
+
+function ownershipMap() {
+  const text = fs.readFileSync(path.join(repoDir, 'AGENTS.md'), 'utf8');
+  const map = sections(text).find(entry => entry.heading === OWNERSHIP_MAP);
+  if (!map) throw new Error(`AGENTS.md carries no ## ${OWNERSHIP_MAP} heading`);
+  return map.body.join('\n');
+}
+
+// Every file of this repository that routes a reader to a skill.
+function corpusFiles() {
+  const under = (dir, keep) => fs.readdirSync(path.join(repoDir, dir))
+    .filter(keep)
+    .map(name => path.join(repoDir, dir, name));
+  return [
+    ...under('skills', name => fs.existsSync(path.join(skillsDir, name, 'SKILL.md')))
+      .map(dir => path.join(dir, 'SKILL.md')),
+    ...under('commands', name => name.endsWith('.md')),
+    ...under('agents', name => name.endsWith('.md')),
+    ...under('templates', name => name.endsWith('.md')),
+    path.join(repoDir, 'AGENTS.md'),
+    path.join(repoDir, 'README.md'),
+  ];
+}
+
+function skillNames() {
+  const names = fs.readdirSync(skillsDir)
+    .filter(name => fs.existsSync(path.join(skillsDir, name, 'SKILL.md')));
+  // A vacuous pass would hide the skills going missing entirely.
+  if (names.length === 0) throw new Error(`no skill files in ${skillsDir}`);
+  return names;
+}
+
+function readSkill(name) {
+  return fs.readFileSync(path.join(skillsDir, name, 'SKILL.md'), 'utf8');
+}
+
+function skillsCarryingSection() {
+  return skillNames().filter(name => carriesSection(readSkill(name)));
+}
+
+// Every check below reads the statement off its owner, so a missing or doubled one throws
+// rather than resolving to a file nobody wrote the rule in.
+function owningSkill() {
+  const carrying = skillsCarryingSection();
+  if (carrying.length !== 1) {
+    throw new Error(`## ${SECTION} stands in ${carrying.length} skills: ${carrying.join(', ')}`);
+  }
+  return carrying[0];
+}
+
+test('carriesSection finds the section under its own heading', () => {
+  assert.strictEqual(carriesSection(`## ${SECTION}\n\n**Must**\n\nA rule.\n`), true);
+});
+
+test('carriesSection ignores the heading inside a fenced block', () => {
+  assert.strictEqual(carriesSection(`\`\`\`markdown\n## ${SECTION}\n\`\`\`\n`), false);
+});
+
+test('carriesSection ignores a deeper heading of the same text', () => {
+  assert.strictEqual(carriesSection(`### ${SECTION}\n\nA rule.\n`), false);
+});
+
+test('exactly one skill states where a produced artifact goes', () => {
+  const carrying = skillsCarryingSection();
+  assert.strictEqual(carrying.length, 1,
+    `## ${SECTION} stands in ${carrying.length} skills: ${carrying.join(', ') || 'none'}`);
+});
+
+test('producers reads an artifact kind and the skill producing it off the table', () => {
+  const text = `## ${TABLE_SECTION}\n\n**Must**\n\n| Artifact | Produced under |\n` +
+    '|---|---|\n| a decision record | `architecture` |\n';
+  assert.deepStrictEqual(producers(text),
+    [{ artifact: 'a decision record', skill: 'architecture' }]);
+});
+
+test('producers drops a row whose second cell names no skill', () => {
+  const text = `## ${TABLE_SECTION}\n\n**Must**\n\n| Artifact | Produced under |\n` +
+    '|---|---|\n| a decision record | the architecture skill |\n';
+  assert.deepStrictEqual(producers(text), []);
+});
+
+test('producers reads no table of another section', () => {
+  const text = '## Some Rule\n\n| Artifact | Produced under |\n|---|---|\n' +
+    `| a decision record | \`architecture\` |\n\n## ${TABLE_SECTION}\n\n**Must**\n\nA rule.\n`;
+  assert.deepStrictEqual(producers(text), []);
+});
+
+test('the statement names the artifacts it ranges over', () => {
+  const named = producers(readSkill(owningSkill()));
+  assert.ok(named.length > 0, `## ${TABLE_SECTION} names no artifact and no skill producing one`);
+});
+
+test('every skill the statement names is one of the catalog', () => {
+  const known = skillNames();
+  const unknown = producers(readSkill(owningSkill()))
+    .filter(row => !known.includes(row.skill))
+    .map(row => `${row.artifact}: ${row.skill}`);
+  assert.deepStrictEqual(unknown, []);
+});
+
+test('citations reads the skill a citation names', () => {
+  assert.deepStrictEqual(citations(`Where it goes: \`editing\` → ${SECTION}.`), ['editing']);
+});
+
+test('citations reads a citation broken across lines', () => {
+  const wrapped = `\`editing\` →\n${SECTION.replace(' Comes', '\nComes')}.`;
+  assert.deepStrictEqual(citations(wrapped), ['editing']);
+});
+
+test('citations reads nothing from a mention carrying no arrow', () => {
+  assert.deepStrictEqual(citations(`See \`editing\`, which states ${SECTION}.`), []);
+});
+
+test('staleCitations names a citation pointing at another skill', () => {
+  assert.deepStrictEqual(staleCitations('editing', `\`architecture\` → ${SECTION}`),
+    ['architecture']);
+});
+
+test('staleCitations passes a citation pointing at the skill carrying the statement', () => {
+  assert.deepStrictEqual(staleCitations('editing', `\`editing\` → ${SECTION}`), []);
+});
+
+test('every citation in the repository names the skill carrying the statement', () => {
+  const owner = owningSkill();
+  const faults = [];
+  for (const file of corpusFiles()) {
+    const relative = path.relative(repoDir, file).replace(/\\/g, '/');
+    for (const name of staleCitations(owner, fs.readFileSync(file, 'utf8'))) {
+      faults.push(`${relative}: cites ${name}, which carries no ## ${SECTION}`);
+    }
+  }
+  assert.deepStrictEqual(faults, [], faults.join('\n'));
+});
+
+test('every skill producing an artifact cites the statement', () => {
+  const owner = owningSkill();
+  const silent = producers(readSkill(owner))
+    .map(row => row.skill)
+    .filter(name => name !== owner && !citations(readSkill(name)).includes(owner));
+  assert.deepStrictEqual(silent, []);
+});
+
+test('strayCiters names a citing skill the statement leaves unnamed', () => {
+  assert.deepStrictEqual(strayCiters(['architecture'], ['architecture', 'debugging']),
+    ['debugging']);
+});
+
+test('strayCiters passes a citing skill the statement names', () => {
+  assert.deepStrictEqual(strayCiters(['architecture'], ['architecture']), []);
+});
+
+test('every skill citing the statement is one the statement names', () => {
+  const owner = owningSkill();
+  const named = producers(readSkill(owner)).map(row => row.skill);
+  const citing = skillNames()
+    .filter(name => name !== owner && citations(readSkill(name)).includes(owner));
+  assert.deepStrictEqual(strayCiters(named, citing), []);
+});
+
+test('ownersNaming reads the skill whose line carries the concern', () => {
+  const map = '- `artifact-placement` — where an artifact a rule\n' +
+    '  produces is put.\n- `comments` — a comment in any language.\n';
+  assert.deepStrictEqual(ownersNaming(CONCERN, map), ['artifact-placement']);
+});
+
+test('ownersNaming reads no line that leaves the concern unnamed', () => {
+  assert.deepStrictEqual(ownersNaming(CONCERN, '- `editing` — a stale reading.\n'), []);
+});
+
+test('the ownership map carries the concern on the line of the skill stating it', () => {
+  assert.deepStrictEqual(ownersNaming(CONCERN, ownershipMap()), [owningSkill()]);
+});

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -144,7 +144,8 @@ function skillsDeclaringRubric() {
 }
 
 // Extended by the pass that marks the next skill; every name here is checked below.
-const MARKED_SKILLS = ['code-navigation', 'comments', 'editing', 'github-cli',
+const MARKED_SKILLS = ['artifact-placement', 'code-navigation', 'comments', 'editing',
+  'github-cli',
   'gitlab-cli', 'pr-rules', 'skill-authoring', 'submodule-sync', 'work-sequence',
   'writing-style'];
 


### PR DESCRIPTION
## Problem

Six skills named a path for what they themselves produce, and none asked where it should
go. A default carries three silent assumptions - that the result is a file, that the file
is in this repository, and that the only source of a project's conventions is its
`AGENTS.md` - while the skill states the requirement the path merely serves: `architecture`
asked for a stable reference a commit or a pull request can point at, and `docs/adr/` is
one way to meet it, not the requirement.

## Summary

- A new skill `artifact-placement` owns where an artifact a rule produces is put, and states the requirement its location meets rather than a path
- Where the project's conventions state no location, the rule is to ask where to form the artifact and whether the project keeps such a record at all
- A location that traces neither to a stated convention nor to an answer in the thread was chosen by whoever wrote the artifact, which the rule forbids
- A path an external convention fixes, or one a tool derives when it loads the file, stands outside the rule and names the basis that fixed it
- Seven skills producing an artifact cite the owner and restate none of it

## Implementation

- `bound-to: universal`, the context all seven citing skills declare: `bound-to` names the readers whose rules these are, and a property of a location is nobody's tool-specific rule
- Each of the three requirements a location must meet carries what a reader looks at to establish it, so the section stands under `**Must**` by naming an artifact rather than a property nobody counts
- The exemption is a table of the paths the catalog fixes today beside the basis of each - a published format, how a tool loads a file, what install writes
- What the rule reaches is an artifact whose location the producing skill's own rules do not fix; the two kinds standing outside it are named rather than left to the reader
- `test/artifact-placement.test.js` reads the owner off the catalog rather than naming it, so a rename of the section, a second copy of the rule, a dropped citation or a citation pointed elsewhere each fail the run

## Test plan

- [x] `npm test` passes
- [x] Every guard of the test measured against its own subject: the owning heading renamed, a second copy added to another skill, a citation dropped, a citation pointed at a skill carrying no such section, and the ownership-map line reverted
- [x] The exemption checked across the catalog: every skill fixing a path already names its basis
- [ ] The user runs `node install.js`, which is the step that puts the edited files where an agent reads them

## Review

The first pass of `code-reviewer` rejected the earlier shape of this change, which parked
the rule in `editing`: that skill declares `bound-to: agent-tool` while all seven citing
skills declare `universal`, so a rule that held for any reader was re-declared as a rule
for an agent working through tools of its own. The rule now stands in a skill of its own,
and the reviewer's other findings - the ADR location left in two files, the four
declarations of `editing`'s identity left stale, an inanimate subject naming a basis, the
requirements stripped of their examples - fall away with it. This shape has not been
reviewed yet.
