### PR TITLE
GH-151: Settle the criteria table of the lifecycle map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,30 +164,44 @@ stage with no command or persona of its own says so rather than naming the neare
 | Close issue | — | issue closed; not `Done` until deployed (`issue-rules` → Lifecycle), or left `In Review` with a follow-up linked | `issue-rules` → Lifecycle, `github-cli` / `gitlab-cli` |
 | Release | — (`release-manager` directly) | → `Done` | `changelog`, `release`, `shipping-and-launch`, `submodule-sync` |
 
-A second table follows, one row for each skill named in no `Skills` cell above. Its
-`Stage` cell holds a stage name of the table above, or the word `cross-cutting` — itself
-a declaration that the skill fires at more than one stage of the table above, not a
-missing value.
+Where each skill of the catalog stands, the table above being the stage table and the one
+below it the criteria table:
 
-| Skill | Stage | Trigger | Input | Output | Entry criterion | Exit criterion |
-|-------|-------|---------|-------|--------|------------------|-----------------|
-| `code-navigation` | cross-cutting | an edit or a verdict turning on a symbol's callers, its implementations, its definition, what a bare name refers to, or whether the symbol has any user left | the symbol, at the file path, line and character it stands at, or the name a workspace-wide query carries | the set of sites the operation returns | the source `code-navigation` → Where the Answer Comes From names for the language | the answer naming the operation that produced it, per `code-navigation` → Naming the Operation |
-| `deprecation-and-migration` | Implement | retiring a public API, planning a breaking change, or writing a migration guide | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
-| `editing` | cross-cutting | a write to a file, a tracker issue body or a PR description, and a merge | the artifact as it stands before the write | the artifact as it stands after the write | a reading of the artifact, per `editing` → Guard Against a Stale Reading | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
-| `hook-scripts` | Implement | writing or modifying a file under `hooks/` or `tools/` | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `commit-rules` → Branch Naming | the test file `node-testing` covers for the tool, `test/<name>.test.js` |
-| `node-testing` | Implement | writing or reviewing a file under `test/*.test.js` | the pure logic exported by the hook or tool under test | a test file asserting that logic's behaviour | the tool's exported logic, per `hook-scripts` → Tool Skeleton | the tool covered and `npm test` run, per `hook-scripts` → Adding or Retiring a Tool |
-| `observability-and-instrumentation` | cross-cutting | adding logging, metrics, or tracing, or checking a running system's reported behaviour | the question an on-call engineer needs answered | a structured log line, metric, or trace answering it | the non-functional requirement `requirements` → Functional vs Non-Functional records | the Readiness Checklist item `shipping-and-launch` → Readiness Checklist for monitoring |
-| `performance-optimization` | Implement | diagnosing a reported performance problem, or evaluating a change's performance cost | a profiler or benchmark baseline for the hot path | a measured before/after comparison for the fix | the symptom and cost the bug template of `issue-rules` → Description Template asks for | the hot-path check `code-review-and-quality` → Performance runs before merge |
-| `skill-authoring` | Implement | adding, marking, renaming or retiring a skill, or marking a command | the skill or command file and its frontmatter | a skill or command file matching the rubric, or its removal | the tracked issue's title naming the skill, per `issue-rules` → Title | the `### Changed` or `### Removed` entry `changelog` → Subsections requires |
-| `writing-style` | cross-cutting | writing documentation, an issue, a PR, a commit, or any text artifact | a draft sentence or document | prose in the technical register with its force word named | the draft of the artifact whose structure `issue-rules`, `pr-rules` or `commit-rules` fixes | the re-read `writing-style` → Self-Check Before Sending requires before the text is sent |
+| Stated of the skill | Where it stands |
+|---|---|
+| its name alone, or its name and the clause conditioning it | the `Skills` cell of every stage row it fires at |
+| its input, its output, and the artifact its entry and its exit turn on | a row of the criteria table |
 
-No row assigns an issue-state transition to a role: `issue-rules` → Lifecycle defines each
-state by a condition rather than by an act with an actor. The acts reserved to the human
-are the merge (`pr-rules` → Merge Strategy 2) and submitting review feedback (Pending by
-Default); the issue comments `work-sequence` requires are the one kind an agent
-publishes freely.
+A skill may stand in both, and five do. The `Stage` cell of a criteria row names the
+stage whose output that skill produces, or holds the word `cross-cutting` where its
+output is produced at more than one — a declaration, not a missing value. A cell naming
+a stage requires that stage's `Skills` cell to name the skill; a `Skills` cell may name a
+skill whose `Stage` cell reads `cross-cutting` as well. No cell states a trigger: the
+frontmatter of a skill is the only place its triggers are declared.
 
-What the rows do not say on their own:
+| Skill | Stage | Input | Output | Entry criterion | Exit criterion |
+|-------|-------|-------|--------|------------------|-----------------|
+| `code-navigation` | cross-cutting | the symbol, at the file path, line and character it stands at, or the name a workspace-wide query carries | the set of sites the operation returns | the source `code-navigation` → Where the Answer Comes From names for the language | the answer naming the operation that produced it, per `code-navigation` → Naming the Operation |
+| `deprecation-and-migration` | cross-cutting | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
+| `editing` | cross-cutting | the artifact as it stands before the write | the artifact as it stands after the write | a reading of the artifact, per `editing` → Guard Against a Stale Reading | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
+| `hook-scripts` | Implement | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `commit-rules` → Branch Naming | the test file `node-testing` covers for the tool, `test/<name>.test.js` |
+| `node-testing` | Implement | the pure logic exported by the hook or tool under test | a test file asserting that logic's behaviour | the tool's exported logic, per `hook-scripts` → Tool Skeleton | the file `test/<name>.test.js` covering that logic, run at the moment `work-sequence` → When a Check Runs gives it |
+| `observability-and-instrumentation` | cross-cutting | the question an on-call engineer needs answered | a structured log line, metric, or trace answering it | the non-functional requirement `requirements` → Functional vs Non-Functional records | the Readiness Checklist item `shipping-and-launch` → Readiness Checklist for monitoring |
+| `performance-optimization` | Implement | a profiler or benchmark baseline for the hot path | a measured before/after comparison for the fix | the symptom and cost the bug template of `issue-rules` → Description Template asks for | the second measurement `performance-optimization` → Measure the Fix requires, read against the baseline |
+| `skill-authoring` | Implement | the skill or command file and its frontmatter | a skill or command file matching the rubric, or its removal | the tracked issue's title naming the skill, per `issue-rules` → Title | the `### Added`, `### Changed` or `### Removed` entry `changelog` → Subsections requires |
+| `writing-style` | cross-cutting | a draft sentence or document | prose in the technical register with its force word named | the draft of the artifact whose structure `issue-rules`, `pr-rules` or `commit-rules` fixes | the re-read `writing-style` → Self-Check Before Sending requires before the text is sent |
+
+No row of the stage table assigns an issue-state transition to a role: `issue-rules` →
+Lifecycle defines each state by a condition rather than by an act with an actor. The acts
+reserved to the human are the merge (`pr-rules` → Merge Strategy 2) and submitting review
+feedback (Pending by Default); the issue comments `work-sequence` requires are the one
+kind an agent publishes freely.
+
+An `Exit criterion` cell may name an artifact a later stage reads, as the rows for
+`hook-scripts`, `node-testing`, `skill-authoring` and `observability-and-instrumentation`
+do: what it fixes is what ends the skill's own work, not where that artifact is used.
+
+What the stage rows do not say on their own:
 
 - **The Spec row may run before the Scope and issue row.** `/spec` names no tracker, so
   a spec may precede the issue or be written against one that exists. An issue without a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - `code-navigation` skill: the questions a text search does not answer about a symbol - its callers, implementations, definition, a bare name's referent and the symbol's remaining users - the rule that an answer names the operation producing it, and `test/code-navigation.test.js` over the example
 - Independent work runs at the same time: `project-planning` states when two units are independent, the lowest bound the contended resources put on the degree of parallelism, and when one check runs alone before the rest; a pipeline arranges its jobs so by default
-- The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there
+- The lifecycle map in `AGENTS.md` carries a second table stating each skill's input, output and the artifacts its entry and exit turn on, its `Stage` cell naming the stage whose output that skill produces; a skill whose output no single stage produces declares `cross-cutting` there
 - A skill declares its relation to the conventions of the project it is applied in, as `project-relation` in its frontmatter: `overrides` where absent, and `binding` for a skill stating this repository's own conventions, which carries `## Project Binding` in place of `## Project Overrides`
 - What introduces an enumeration names what it holds, and what closes one is the statement that nothing else belongs to it rather than a count announced above it
 - A conversation is written in the personal register and every other text in the impersonal one, which fixes the subject of a sentence as well as the form a prescription takes
@@ -148,6 +148,7 @@
 - `comment-check` covers every language, not only C++: an extension, or a name like `Makefile`, maps to that family's comment openers, and the `comments` skill claims those files so the edit-time gate names it on any source file
 
 ### CI
+- The test file `test/citations.test.js` resolves every citation of the form `skill` -> Section against a heading of the skill it names, wherever the citation stands - a skill, a persona, a command, `AGENTS.md` or `README.md`; a heading standing only inside a fenced block resolves none
 
 - GitHub Actions runs `npm test` on Node 18, 20 and 22, on Linux and Windows, on every push and every pull request to `main`. Each combination reports as its own job and none cancels another
 - `npm test` fails when `config/retired.json` lists a path this repository still ships, naming the entry to remove

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -109,7 +109,7 @@ Use only what applies. Order:
      those. With no such version, every bullet reconciles this way.
    - Dropping is not a completeness check. It removes a bullet measured against a state
      no release had; whether `### Added` carries what that bullet said is confirmed by
-     `release` → Step 2.
+     `release` → Step 2 — Update CHANGELOG.md.
 2. Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` (today's date)
 3. Prepend a new empty `## [Unreleased]` section above it
 4. Leave empty subsections out — add them only when there's content

--- a/skills/cpp-api-design/SKILL.md
+++ b/skills/cpp-api-design/SKILL.md
@@ -65,7 +65,7 @@ meeting it is owned elsewhere:
   `code-navigation` skill.
 - Retiring the old path (deprecate before removing, grace period, migration guide) →
   `deprecation-and-migration` skill.
-- The version bump it forces → `release` skill → Step 1 — Decide Version.
+- The version bump it forces → `release` skill → Step 1 — Decide Version (semver).
 - The entry announcing it → `changelog` skill.
 
 ## API Hygiene

--- a/test/citations.test.js
+++ b/test/citations.test.js
@@ -1,0 +1,149 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoDir = path.join(__dirname, '..');
+const skillsDir = path.join(repoDir, 'skills');
+
+// A fenced block holds a template or a transcript rather than prose, so a citation
+// inside one cites nothing and a heading inside one is that template's heading rather
+// than a section of the skill carrying it.
+function outsideFences(text) {
+  const kept = [];
+  let fenced = false;
+  text.replace(/\r\n/g, '\n').split('\n').forEach((line, i) => {
+    if (/^\s*(```|~~~)/.test(line)) { fenced = !fenced; return; }
+    if (!fenced) kept.push({ line, number: i + 1 });
+  });
+  assert.ok(!fenced, 'a fence opens and never closes, which would hide the rest of the file');
+  return kept;
+}
+
+// A citation wraps across lines and its section name runs on into the sentence, so the
+// prose is read as one run of text. The offset each line starts at is carried alongside,
+// so a failure names the line a reader has to open.
+function prose(file) {
+  const starts = [];
+  let text = '';
+  for (const { line, number } of outsideFences(fs.readFileSync(file, 'utf8'))) {
+    starts.push({ offset: text.length, number });
+    text += line.trim().replace(/\s+/g, ' ') + ' ';
+  }
+  const lineAt = offset => {
+    let found = 0;
+    for (const s of starts) { if (s.offset <= offset) found = s.number; else break; }
+    return found;
+  };
+  return { text, lineAt };
+}
+
+const headingCache = new Map();
+function sectionHeadings(name) {
+  if (!headingCache.has(name)) {
+    const file = path.join(skillsDir, name, 'SKILL.md');
+    headingCache.set(name, fs.existsSync(file)
+      ? outsideFences(fs.readFileSync(file, 'utf8'))
+        .filter(entry => /^#{2,}\s/.test(entry.line))
+        .map(entry => entry.line.replace(/^#+\s+/, '').trim())
+      : null);
+  }
+  return headingCache.get(name);
+}
+
+// The citation resolves where a heading of the cited skill opens the span, at a word
+// boundary: "Lifecycle defines each state" resolves to the section `Lifecycle`. Nothing
+// delimits the end of a span, so what this holds is the leading heading and not the
+// words after it: a span opening with a real heading resolves whatever follows.
+function resolve(span, headings) {
+  return headings.find(heading => span === heading ||
+    (span.startsWith(heading) && /^[\s.,;:)'"\u2019]/.test(span.slice(heading.length))));
+}
+
+// A backticked lowercase name is a skill, a persona, a command or a context. Only the
+// first carries sections; a name that is none of the four is a citation left behind by a
+// rename (`skill-authoring` -> Renaming or Retiring).
+function knownNonSkillNames() {
+  const names = new Set();
+  for (const dir of ['agents', 'commands']) {
+    for (const file of fs.readdirSync(path.join(repoDir, dir))) {
+      if (file.endsWith('.md')) names.add(file.replace(/\.md$/, ''));
+    }
+  }
+  const vocabulary = JSON.parse(fs.readFileSync(path.join(repoDir, 'config', 'skill-contexts.json'), 'utf8'));
+  for (const name of Object.keys(vocabulary.contexts)) names.add(name);
+  return names;
+}
+
+// `<name>` -> Section Name, in either arrow form, with or without the word "skill"
+// between the name and the arrow.
+function citations(file) {
+  const { text, lineAt } = prose(file);
+  const found = [];
+  for (const hit of text.matchAll(/`([a-z][a-z0-9-]*)`(?:\s+skill)?\s*(?:\u2192|->)\s*([^|`]+)/g)) {
+    const span = hit[2].trim();
+    if (span) found.push({ name: hit[1], span, line: lineAt(hit.index) });
+  }
+  return found;
+}
+
+// Every file that carries a rule or an index and may cite a skill's section: the skills
+// themselves, the persona and command definitions composing them, and the two files
+// indexing the catalog.
+function citingFiles() {
+  const files = fs.readdirSync(skillsDir)
+    .map(name => [`skills/${name}/SKILL.md`, path.join(skillsDir, name, 'SKILL.md')])
+    .filter(entry => fs.existsSync(entry[1]));
+  if (files.length === 0) throw new Error(`no skill files found in ${skillsDir}`);
+  for (const dir of ['agents', 'commands']) {
+    for (const name of fs.readdirSync(path.join(repoDir, dir)).filter(n => n.endsWith('.md'))) {
+      files.push([`${dir}/${name}`, path.join(repoDir, dir, name)]);
+    }
+  }
+  files.push(['AGENTS.md', path.join(repoDir, 'AGENTS.md')]);
+  files.push(['README.md', path.join(repoDir, 'README.md')]);
+  return files;
+}
+
+test('the corpus carries citations to resolve', () => {
+  const total = citingFiles().reduce((n, entry) => n + citations(entry[1]).length, 0);
+  assert.ok(total > 0, 'no citation of the form `skill` -> Section was found, so nothing is held');
+});
+
+test('every name a citation carries is a skill, a persona, a command or a context', () => {
+  const known = knownNonSkillNames();
+  const unknown = [];
+  for (const [rel, full] of citingFiles()) {
+    for (const c of citations(full)) {
+      if (sectionHeadings(c.name) === null && !known.has(c.name)) {
+        unknown.push(`${rel}:${c.line}  ${c.name} -> ${c.span.slice(0, 60)}`);
+      }
+    }
+  }
+  assert.deepStrictEqual(unknown, []);
+});
+
+test('every citation of a skill section resolves to a heading of that skill', () => {
+  const unresolved = [];
+  for (const [rel, full] of citingFiles()) {
+    for (const c of citations(full)) {
+      const headings = sectionHeadings(c.name);
+      if (headings === null) continue;
+      if (!resolve(c.span, headings)) {
+        unresolved.push(`${rel}:${c.line}\n    ${c.name} -> ${c.span.slice(0, 80)}`);
+      }
+    }
+  }
+  assert.deepStrictEqual(unresolved, []);
+});
+
+test('a fenced block yields no heading', () => {
+  const template = path.join(repoDir, 'templates', 'SKILL.md');
+  const text = fs.readFileSync(template, 'utf8').replace(/\r\n/g, '\n');
+  assert.ok(/^#{2,}\s/m.test(text),
+    'templates/SKILL.md carries no heading, so this test measures nothing');
+  const fenced = outsideFences(['```markdown', ...text.split('\n'), '```'].join('\n'))
+    .filter(entry => /^#{2,}\s/.test(entry.line));
+  assert.deepStrictEqual(fenced, []);
+});

--- a/test/lifecycle-map.test.js
+++ b/test/lifecycle-map.test.js
@@ -8,8 +8,7 @@ const repoDir = path.join(__dirname, '..');
 const agentsPath = path.join(repoDir, 'AGENTS.md');
 const skillsDir = path.join(repoDir, 'skills');
 
-const COLUMNS = ['Skill', 'Stage', 'Trigger', 'Input', 'Output',
-  'Entry criterion', 'Exit criterion'];
+const COLUMNS = ['Skill', 'Stage', 'Input', 'Output', 'Entry criterion', 'Exit criterion'];
 
 function isSeparatorRow(row) {
   return row.length > 0 && row.every(cell => /^:?-+:?$/.test(cell));
@@ -19,8 +18,10 @@ function parseRow(line) {
   return line.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map(c => c.trim());
 }
 
-// The two markdown tables sitting under the "### Lifecycle map" heading, up to the next
-// heading of level 1-3. Each is returned as { header, rows }, the separator row dropped.
+// The stage table and the second table, sitting under the "### Lifecycle map" heading, up
+// to the next heading of level 1-3. Each is picked by the column its rows are keyed on
+// rather than by position, so a further table under that heading displaces neither. Each
+// is returned as { header, rows }, the separator row dropped.
 function lifecycleMapTables() {
   const text = fs.readFileSync(agentsPath, 'utf8').replace(/\r\n/g, '\n');
   const lines = text.split('\n');
@@ -39,13 +40,20 @@ function lifecycleMapTables() {
       current = null;
     }
   }
-  assert.strictEqual(blocks.length, 2,
-    `### Lifecycle map carries ${blocks.length} table(s) below its heading, expected 2`);
-
-  return blocks.map(rawRows => {
+  const tables = blocks.map(rawRows => {
     const [header, ...rest] = rawRows;
-    return { header, rows: rest.filter(r => !isSeparatorRow(r)) };
+    const rows = rest.filter(r => !isSeparatorRow(r));
+    assert.ok(rows.length > 0, `a table under ### Lifecycle map holds no row: ${JSON.stringify(header)}`);
+    return { header, rows };
   });
+
+  const pick = first => {
+    const matching = tables.filter(table => table.header[0] === first);
+    assert.strictEqual(matching.length, 1,
+      `### Lifecycle map carries ${matching.length} table(s) whose first column is ${first}, expected 1`);
+    return matching[0];
+  };
+  return [pick('Stage'), pick('Skill')];
 }
 
 function columnIndex(header, name) {
@@ -79,7 +87,7 @@ test('every directory under skills/ is named in the stage table or the second ta
   assert.deepStrictEqual(missing, []);
 });
 
-test('the second table carries the seven columns in order', () => {
+test('the second table carries its columns in order', () => {
   const [, secondTable] = lifecycleMapTables();
   assert.deepStrictEqual(secondTable.header, COLUMNS);
 });
@@ -141,4 +149,14 @@ test('a second-table row naming a stage is named in that stage row\'s Skills cel
     }
   }
   assert.deepStrictEqual(disagreements, []);
+});
+
+test('every Skill cell of the second table names a directory under skills/', () => {
+  const [, secondTable] = lifecycleMapTables();
+  const skillCol = columnIndex(secondTable.header, 'Skill');
+
+  const unresolved = secondTable.rows
+    .map(row => row[skillCol].replace(/`/g, ''))
+    .filter(name => !fs.existsSync(path.join(skillsDir, name, 'SKILL.md')));
+  assert.deepStrictEqual(unresolved, []);
 });


### PR DESCRIPTION
## Problem

The criteria table of the lifecycle map shipped with prose that is false of it: the rows
were said to be the skills no `Skills` cell names, while five of them are named in the
`Implement` cell, which the agreement between the two tables requires. Three rows named
an act of one stage under a `Stage` cell naming another, and two relations the text
asserted - a citation resolving to a heading, a `Skill` cell naming a skill - were held
by nothing.

## Summary

- The prose states where each thing said of a skill stands, in place of a membership rule that held for every skill of the catalog
- The `Trigger` column is dropped: a cell copying the frontmatter could be held only by an assertion that fails when the description is rephrased while its rule stands
- The rows whose exit criterion named an act of another stage are settled, and a paragraph states that such a criterion may name an artifact a later stage reads
- Every citation of the form `skill` -> Section, wherever it stands, resolves to a heading of the skill it names
- Two citations naming a heading of `release` by a shortened form are corrected to the heading as it stands

## Implementation

- `test/citations.test.js` reads a file's prose as one run, since a citation wraps across lines and its name runs on into the sentence; the heading is taken off the span by a leading-match, and the failure names the file and the line
- A name a citation carries is held against the skills, the personas, the commands and the contexts of `config/skill-contexts.json`, which is the state a rename leaves behind
- The vacuity floor sits in the table parser, so every test of `test/lifecycle-map.test.js` inherits it, and the two tables are picked by the column their rows are keyed on rather than by position
- The `Skill` cell is held against the catalog, replacing a `continue` that exempted a whole row from every check in the file
- `AGENTS.md` and `README.md` are the two indexes the change touches; no skill rule moved

## Test plan

- [x] `npm test` passes
- [x] Each check measured against its own subject: a `Skill` cell naming no directory, a citation resolving to no heading in a skill, a persona, a command and `AGENTS.md`, a citation naming a name that is no skill, persona, command or context, and each table emptied of rows - every one fails the run
- [x] The two corrected citations resolved against the headings of `release`
- [ ] The user runs `node install.js`: two skill files changed, so the corrected citations reach the installed configuration only after that run

## Review

Three passes of `code-reviewer` at depth `high`. The loop closed as not converging: every
pass found new consequences of the previous pass's fixes rather than remnants of its own
findings. Each blocking finding of all three passes is addressed, and the third pass's
notes on the count in the issue and on the `## Out of scope` paragraph are corrected in
GH-151 itself.
