### PR TITLE
GH-153: Add testing, the language-neutral test owner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `cpp-coding` — C++ implementation conventions.
 - `cpp-doxygen` — Doxygen blocks on public C++ headers.
 - `cpp-encapsulation` — the access level of each member of one C++ type.
-- `cpp-testing` — the structure of a C++ test.
+- `cpp-testing` — what a C++ test covers, and the GoogleTest syntax and naming scheme it is written in.
 - `ddd` — modelling inside one bounded context.
 - `debugging` — the investigation that precedes a fix.
 - `deprecation-and-migration` — retiring a public path.
@@ -93,7 +93,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `gitlab-cli` — `glab` mechanics.
 - `hook-scripts` — writing this repository's hooks and tools.
 - `issue-rules` — what a tracker issue contains.
-- `node-testing` — conventions for the tests under `test/`.
+- `node-testing` — what a test of this repository's hooks and tools covers, and the runner and command vocabulary it is written in.
 - `observability-and-instrumentation` — telemetry for production visibility.
 - `performance-optimization` — the process around one performance problem.
 - `pr-rules` — the pull request, from opening it to merging it.
@@ -106,14 +106,18 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
   rename — and the marker on a command's sections.
 - `submodule-sync` — submodule ref discipline.
 - `test-driven-development` — the order a behaviour is built in, test first.
+- `testing` — the level a test sits at, its layout, its data, its boundaries, and what makes a run repeatable.
 - `work-sequence` — the order of work from a task to a closed issue.
 - `writing-style` — prose register and vocabulary in any human language, above any mode the session runs in.
 
 Two pairs restate each other on purpose, because no task loads both: `cpp-testing` /
-`node-testing` (a task edits one language's tests, and `node-testing` says not to mix the
-conventions) and `github-cli` / `gitlab-cli` (a repository has one host). Their shared
-principles are stated in each one's own runner and command vocabulary; routing a JS test
-task through a `cpp-` prefixed skill for one line would cost more than the duplication.
+`node-testing` (a task edits one language's tests) and `github-cli` / `gitlab-cli` (a
+repository has one host). What the testing pair holds twice is the runner vocabulary alone
+— the macro or the call a test is written with; every
+principle the two share is stated once by `testing`, and what each of the two keeps is
+the means its runner gives for that principle. Routing a JS test task through a `cpp-`
+prefixed skill for one line would
+cost more than the duplication.
 
 `## The Caller's Text` is copied byte for byte into every command and restated in
 `config/claude-config-rules.md`: the boundary between an instruction and the text under
@@ -154,7 +158,7 @@ stage with no command or persona of its own says so rather than naming the neare
 | Spec | `/spec` → `spec-architect` | `Open`, once it exists | `requirements`, `ddd`, `architecture`, `cpp-api-design` |
 | Scope and issue | — | `Open` | `issue-rules`, `github-cli` / `gitlab-cli` |
 | Branch | — | → `In Progress` | `commit-rules` → Branch Naming |
-| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`, `hook-scripts`, `node-testing`; `debugging` on a fix; `performance-optimization` on a reported performance problem; `deprecation-and-migration` when retiring a public path; `skill-authoring` on a skill or a command file; `project-planning` → Running Independent Work in Parallel on each launch that section names; `commit-rules` per commit |
+| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `testing`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`, `hook-scripts`, `node-testing`; `debugging` on a fix; `performance-optimization` on a reported performance problem; `deprecation-and-migration` when retiring a public path; `skill-authoring` on a skill or a command file; `project-planning` → Running Independent Work in Parallel on each launch that section names; `commit-rules` per commit |
 | Publish | — | `In Progress` | `work-sequence` → When a Check Runs, `submodule-sync`, `changelog`, `commit-rules` |
 | Offer for review | — | → `In Review` | `pr-rules`, `ci-cd-and-automation`, `github-cli` / `gitlab-cli` |
 | Review | `/review`, or `/review-loop` to iterate → `code-reviewer` | `In Review` | `code-review-and-quality`, `cpp-api-design`, `cpp-encapsulation`, `comments` / `cpp-doxygen`, `pr-rules`; `changelog` when the change touches `CHANGELOG.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `testing` skill, owning in any language the levels of verification, test data and the environment, a boundary a test crosses, determinism between runs, the mutation showing a fail step failed for its intended reason, the values an assertion may not rest on, and when a suite may be trusted
 - `code-navigation` skill: the questions a text search does not answer about a symbol - its callers, implementations, definition, a bare name's referent and the symbol's remaining users - the rule that an answer names the operation producing it, and `test/code-navigation.test.js` over the example
 - Independent work runs at the same time: `project-planning` states when two units are independent, the lowest bound the contended resources put on the degree of parallelism, and when one check runs alone before the rest; a pipeline arranges its jobs so by default
 - The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there
@@ -70,6 +71,7 @@
 - `work-sequence` skill: the eight steps from a task to a closed issue, each with its condition and the skill owning what it produces. Read it rather than `pr-rules` for the order of work and for the moment a check runs at; `pr-rules` now states the pull request alone
 
 ### Changed
+- `cpp-testing` and `node-testing` keep the means their runner gives and what their own tests cover, `test-driven-development` the order of the work and `ci-cd-and-automation` the pipeline; the level, layout, data, boundaries and repeatability of a test move to `testing`, which `implementer` loads
 - `code-reviewer`, `implementer` and `spec-architect` load `code-navigation` and declare the `LSP` tool its operations belong to, so a rule about a symbol's callers reaches an operation wherever the environment offers one
 - The `## Project Overrides` section reads the same in every skill, one sentence differing only in the topic it names, and every skill carries one
 - `/review-loop` asks where every pass runs rather than assuming a working directory: it makes no place of its own, moves nothing aside, and states no step that needs a repository

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `cpp-coding` | C++ implementation conventions |
 | `cpp-doxygen` | Doxygen tag coverage for public C++ headers |
 | `cpp-encapsulation` | C++ access-specifier discipline (public/protected/private) |
-| `cpp-testing` | Unit test structure (AAA, naming, coverage) |
+| `cpp-testing` | What a C++ test covers, and the GoogleTest syntax and naming scheme it is written in |
 | `ddd` | Domain-Driven Design patterns in C++ |
 | `debugging` | Root-cause investigation before proposing a fix |
 | `deprecation-and-migration` | Retiring a public API and writing a migration guide |
@@ -104,7 +104,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `gitlab-cli` | `glab` mechanics — issues, MRs, labels, draft notes, stacks, merges |
 | `hook-scripts` | Writing Claude Code hooks and tools |
 | `issue-rules` | Tracker issue title, description, labels, priority, lifecycle |
-| `node-testing` | Conventions for this repo's `test/*.test.js` (node:test) |
+| `node-testing` | What a test of this repository's hooks and tools covers, and the `node:test` runner and command vocabulary it is written in |
 | `observability-and-instrumentation` | Logging, metrics, tracing for production visibility |
 | `performance-optimization` | Profile-measure-optimize workflow for a reported performance problem |
 | `pr-rules` | PR title, description, review comments, merge strategy |
@@ -116,6 +116,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `skill-authoring` | Writing a skill file — its concern, name, contexts, section markers, rename — and the marker on a command's sections |
 | `submodule-sync` | Git submodule sync discipline |
 | `test-driven-development` | Fail-pass-refactor workflow, before writing implementation code |
+| `testing` | Levels of verification, test data and the environment, determinism, the mutation check on a fail step, and when a suite may be trusted |
 | `work-sequence` | The eight steps from a task to a closed issue, and the moment each check runs at |
 | `writing-style` | Prose register and vocabulary in any human language, above any mode the session runs in |
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -22,10 +22,12 @@ this file:
    against the spec rather than an anticipated caller.
 5. `code-navigation` skill — where an answer about a symbol's callers or definition comes
    from.
-6. `cpp-testing` skill — the structure of the tests the loop produces.
-7. `work-sequence` skill — When a Check Runs, for which checks a round of edits runs and
+6. `testing` skill — the level, the layout and the data of the tests the loop produces.
+7. `cpp-testing` skill — the runner syntax and the naming scheme those tests are written
+   with, where the language is C++.
+8. `work-sequence` skill — When a Check Runs, for which checks a round of edits runs and
    which of them belong to a later moment.
-8. `project-planning` skill — Running Independent Work in Parallel, for each launch that
+9. `project-planning` skill — Running Independent Work in Parallel, for each launch that
    section names.
 
 If a step in the spec is ambiguous or missing, stop and surface the gap rather than

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -51,9 +51,10 @@ or command both the pipeline and a developer invoke (see this repo's own
 
 ## Fast Feedback First
 
-Order pipeline stages from fastest/cheapest to slowest/most expensive (lint before
-build, unit tests before integration tests, single-platform build before the full
-matrix) so a broken change fails in seconds, not after a 20-minute matrix build.
+Order pipeline stages from fastest/cheapest to slowest/most expensive: lint before build,
+then each level `testing` → Levels of Verification defines, cheapest first, and a
+single-platform build before the full matrix. A broken change then fails in seconds
+rather than after a 20-minute matrix build.
 
 A stage should launch its independent jobs at once by default. Which jobs qualify, what
 bounds the degree, and how the launch squares with the ordering above are stated in
@@ -81,10 +82,11 @@ job that needs it, never share one broad credential across every job in the pipe
 
 ## Flaky Checks
 
-A check that fails intermittently without a code change is a defect in the check, not
-noise to route around with retries until it passes. Quarantine it (mark known-flaky,
-tracked with an issue) rather than letting an intermittently failing build normalize
-ignoring CI failures generally.
+A pipeline must not route around a check that fails intermittently without a code change,
+whether by an automatic retry or by a rerun until it passes: one normalized failure costs
+the pipeline its signal on every check it reports. What such a check is, and what the
+project owes it, are `testing` → Determinism and Independence Between Runs; a check that
+is no test - a lint, a build - owes the same and has no other owner.
 
 ## Feeding a Pipeline Failure Back to an Agent
 

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -53,9 +53,9 @@ wrong):
 
 - Trace at least one success path and one failure path by hand — don't just read that a
   `try`/`catch` exists, check what happens inside it.
-- Check every changed boundary condition against the boundary cases the testing skill of
-  the language being written makes mandatory — a review that doesn't check for
-  off-by-one/empty/null is incomplete.
+- Check every changed boundary condition against the boundary cases `testing` → Boundary
+  Cases makes mandatory — a review that doesn't check for off-by-one/empty/null is
+  incomplete.
 - A bug fix without a regression test (`debugging` → Regression Test First) is not done,
   regardless of how correct the fix looks by inspection.
 

--- a/skills/cpp-testing/SKILL.md
+++ b/skills/cpp-testing/SKILL.md
@@ -8,6 +8,8 @@ metadata:
   tier: domain
   bound-to:
     - cpp
+  with:
+    - "testing"
   tags:
     - cpp
     - testing
@@ -17,9 +19,11 @@ metadata:
 
 Apply when writing, reviewing, or adding tests to C++ code.
 
-Framework choice is project-specific (check `AGENTS.md`). This skill covers principles only.
+The examples are GoogleTest's; a project on another framework substitutes that framework's
+own macros (check `AGENTS.md`).
 
 - The fail, pass, refactor order these tests are written in → `test-driven-development` skill.
+- The levels of verification, the isolation of a unit test, test data and the environment, determinism between runs, the mutation check on a fail step, and an assertion resting on an implementation-defined value → `testing` skill.
 
 ## Project Overrides
 
@@ -38,7 +42,9 @@ defines, instead of the rule here.
 
 ## Test Structure — AAA
 
-Each test follows three clearly separated phases:
+The three phases and the rule that no two of them merge are stated by `testing` → Test
+Layout - Arrangement, Action, Assertion. The three, written with the macro `TEST` of
+GoogleTest:
 
 ```cpp
 TEST(Money, AdditionProducesSumInSameCurrency) {
@@ -54,16 +60,14 @@ TEST(Money, AdditionProducesSumInSameCurrency) {
 }
 ```
 
-Never merge phases. "Arrange" sets up state. "Act" calls exactly one thing. "Assert" checks outcome.
+## One Reason to Fail in GoogleTest
 
-## One Reason to Fail
-
-Each test checks one behaviour — one logical assertion. Multiple `EXPECT_*` are allowed only when they together verify a single concept.
+One behaviour per test, and the name stating it, are `testing` → One Behaviour per Test,
+Named by It. GoogleTest's own means: several `EXPECT_*` in one body only where they
+establish that one behaviour together.
 
 - Bad: a test that checks addition, subtraction, and formatting in one body
 - Good: three separate tests, each failing for a distinct reason
-
-When a test fails, the name alone must tell the reader what broke.
 
 ## Test Names as Documentation
 
@@ -78,9 +82,10 @@ Container_InsertBeyondCapacity_GrowsAutomatically
 
 No `Test` prefix, no `test_` prefix — the framework already marks it as a test.
 
-## Boundary Cases Are Mandatory
+## Boundary Cases in C++
 
-For every function, write tests for:
+The obligation to cover a boundary and the kinds of boundary there are: `testing` →
+Boundary Cases. What each kind is in C++:
 
 | Boundary | Examples |
 |----------|---------|
@@ -90,25 +95,19 @@ For every function, write tests for:
 | Invalid input | null pointer, negative where positive expected |
 | Exact threshold | values at `==`, `<`, `>` of a documented limit |
 
-If the function documents a precondition, test the boundary just inside and just outside it.
+## Isolation and Determinism in C++
 
-## Test Isolation
+What a unit test may reach, and what holds between two runs of one: `testing` → Unit Test
+Isolation and `testing` → Determinism and Independence Between Runs. A collaborator to be
+replaced by a fake, a stub or a mock: `test-driven-development` → Prefer the Real Thing
+Over a Test Double gives the order to reach for.
 
-- Tests must not share mutable state — each test starts from a clean, deterministic state
-- No global variables mutated across tests; use fixtures (setup/teardown) instead
-- No order dependency — tests must pass in any execution order
+GoogleTest's own means for both:
 
-## Unit Test Scope
-
-Unit tests are fast and isolated:
-
-- No network, no disk I/O, no database — mock or stub infrastructure at the boundary
-- No `sleep` or time-based waits — use injectable clocks or time abstractions
-- Each test completes in milliseconds
+- A fixture class deriving from `::testing::Test`, with `SetUp` and `TearDown`, in place of a variable at namespace scope
+- An injected clock in place of `std::this_thread::sleep_for`
 
 ## Do Not
 
 - Do not test private members directly — redesign if they need testing
 - Do not copy production code into tests to "validate" it — test through the public interface
-- Do not suppress or ignore failing tests — fix or explicitly skip with a documented reason
-- Do not write tests that always pass (assertion-free tests)

--- a/skills/node-testing/SKILL.md
+++ b/skills/node-testing/SKILL.md
@@ -15,6 +15,7 @@ metadata:
   project-relation: binding
   with:
     - "test-driven-development"
+    - "testing"
   tags:
     - testing
     - node
@@ -27,6 +28,9 @@ tools, or install/uninstall logic (e.g. `~/.claude/hooks/`, `~/.claude/tools/` �
 see `hook-scripts` skill).
 
 - Writing the hook/tool itself → `hook-scripts` skill.
+- The principles a test holds to whatever the language — the levels of verification, the
+  isolation of a unit test, test data and the environment, determinism between runs, the
+  layout of a test and the boundaries it covers → `testing` skill.
 - Tests in another language → the testing skill of that language (different runner,
   different conventions — do not mix the two).
 
@@ -70,18 +74,17 @@ test('warns on rm -r foo/', () => {
 });
 ```
 
-Name the test after the behavior, not the input — `'blocks rm -rf /'`, not
-`'test case 1'` or `'check function'`. A failing test name should tell you what broke
-without opening the file.
+The name is a string here, and it states the behaviour: `'blocks rm -rf /'`, not
+`'test case 1'` or `'check function'`.
 
 Only reach for `describe` if a file's tests genuinely split into unrelated concerns
 that would otherwise be hard to scan — most tool/hook test files won't need it.
 
 ## One Behavior Per Test
 
-Each `test()` checks one input → one expected outcome. Don't fold multiple unrelated
-assertions into a single test — when it fails, you want the test name to already tell
-you which case broke, not "one of these five assertions."
+The rule is `testing` → One Behaviour per Test, Named by It. Here it reads:
+each `test()` checks one input → one expected outcome, and the string naming it says
+which case broke.
 
 ## Testing Pure Logic Directly
 
@@ -109,10 +112,11 @@ assert.strictEqual(r.status, 2);
 
 ## Filesystem Fixtures
 
-Any test that touches the filesystem (install/uninstall, manifest writes) must run
-against a temp directory, never the real `~/.claude/`. Use the `CLAUDE_CONFIG_DIR`
-env override (the same one the hooks themselves resolve against — see `hook-scripts`
-skill) to redirect the script under test into an isolated temp dir:
+The rule for a test touching the filesystem is `testing` → Test Data and the Environment;
+what Node offers for it is the call `fs.mkdtempSync` over the directory `os.tmpdir()` gives, never the real
+`~/.claude/`. Use the `CLAUDE_CONFIG_DIR` env override (the same one the hooks themselves
+resolve against — see `hook-scripts` skill) to redirect the script under test into that
+directory:
 
 ```javascript
 function mkTmp() {
@@ -136,8 +140,7 @@ test('install creates files and manifest on empty dir', () => {
 });
 ```
 
-Always clean up in a `finally` block — a failed assertion must not leave a stray temp
-directory behind, and must not skip cleanup either.
+The cleanup goes in a `finally` block, which runs on the failing path too.
 
 ## What to Cover
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -16,9 +16,11 @@ metadata:
 # Skill: Test-Driven Development
 
 Apply when implementing a feature or bug fix, before writing implementation code. This
-skill governs the order of work — fail, pass, refactor. Test structure, naming, and
-coverage rules belong to the testing skill of the language being written.
+skill governs the order of work — fail, pass, refactor. The shape of the test each step
+produces belongs to `testing`, and the runner syntax, the naming scheme and the coverage
+list of one language to the testing skill of the language being written.
 
+- The level a test sits at, its layout, its data, its determinism, and the mutation showing that a fail step failed for the intended reason → `testing` skill.
 - Reproducing a bug as a failing test before fixing it → `debugging` skill (Regression Test First).
 - Once the tests pass and the implementation stands, reviewing it → `code-review-and-quality` skill.
 
@@ -56,10 +58,10 @@ so it can catch the implementation being wrong, not just being different.
 
 ## One Behavior Per Fail Step
 
-Each fail-pass cycle targets one new behavior or boundary case, matching the
-one-behaviour-per-test rule of the testing skill of the language being written. Do not
-write five tests up front and then implement until all
-five pass — that reintroduces the "test after" problem for tests 2 through 5, which sit
+Each fail-pass cycle targets one new behavior or boundary case, matching `testing` → One
+Behaviour per Test, Named by It. Do not write five tests up front and then implement
+until all five pass — that reintroduces the "test after" problem for tests 2 through 5,
+which sit
 failing for longer than necessary and stop guiding the implementation step by step.
 
 ## Minimal Implementation
@@ -89,8 +91,8 @@ only last a mock that asserts *which* calls were made. A test built around call-
 assertions breaks the moment the implementation is refactored, even when the observable
 behavior hasn't changed — assert on outcomes, not on how the outcome was reached. Reach
 for a mock only when the real collaborator is slow, non-deterministic, or has a side
-effect the test can't afford — what that excludes at the unit-test boundary belongs to
-the testing skill of the language being written.
+effect the test can't afford — what that excludes at the unit-test boundary is
+`testing` → Unit Test Isolation.
 
 ## When TDD Doesn't Fit
 

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: testing
+version: "1.0.0"
+description: Apply when writing, reviewing or adding a test at any level of verification, in any language
+license: Unlicense
+metadata:
+  author: ssoft
+  tier: process
+  bound-to:
+    - universal
+  rubric: applied
+  tags:
+    - testing
+    - quality
+---
+
+# Skill: Testing
+
+Apply when writing, reviewing or adding a test at any level of verification, in any
+language. This skill states what each level checks, what a test runs against, and what
+makes a suite's verdict worth acting on. The runner syntax, the naming scheme and the
+coverage list of one language are stated by the testing skill of the language being
+written.
+
+- The order the test and the implementation are written in, and the preference order between a real collaborator, a fake, a stub and a mock → `test-driven-development` skill.
+- Reproducing a defect as a failing test before the fix → `debugging` skill.
+- The pipeline running these levels on a server, and the order it runs them in → `ci-cd-and-automation` skill, which hands the verdict on a test that varies to Determinism and Independence Between Runs.
+- The acceptance criteria an end-to-end assertion is read off → `requirements` skill.
+- The measurement behind a performance claim, and the benchmark carrying it → `performance-optimization` skill.
+
+## Project Overrides
+
+**Must**
+
+Must follow the test conventions the repository's `AGENTS.md` file or a project skill
+defines, instead of the rule here.
+
+---
+
+## Levels of Verification
+
+**Should**
+
+A test should sit at the level of the outermost boundary it is about, whatever the amount
+of code behind it and whatever it reaches at run time: a test over one function that
+opens a socket is an integration test rather than a unit test, and a test asserting a
+recorded agreement is a contract test though it reaches nothing outside its process.
+
+| Level | The boundary the test is about | What a test at this level may put in place of the other side |
+|---|---|---|
+| Unit | none — one process, one unit and the collaborators it calls in-process | every collaborator carrying a boundary, since none may be reached |
+| Integration | a boundary between two parts the deployment itself carries — a process, a file system, a queue, a database | both sides are the parts that ship, a store the project deploys rather than builds included |
+| Contract | the boundary with a party the project neither builds nor deploys — an external service, or its own interface as a published promise | the recorded agreement, on either side of it, or nothing where the test runs against that party itself |
+| End-to-end | every boundary the system has, from the entry a user meets to the store behind it | nothing the deployment carries; a party outside it may stand in |
+
+The number of tests should fall as the level rises — the pyramid — because a defect
+catchable one level down is caught there for less: an end-to-end run pays for every
+boundary before it reports anything, and reports a whole path as broken rather than one
+unit.
+
+Each level should be run by a command of its own, so a change touching one level does not
+pay for the levels above it.
+
+The names in use elsewhere for these levels:
+
+| Name also in use | What it names |
+|---|---|
+| system test, acceptance test | end-to-end, where the outcome asserted is the one the requirement states for a user |
+| component test | integration, where every part on both sides is one the project builds |
+| smoke test | a subset of any level, run first to decide whether running the rest is worth it |
+
+## One Behaviour per Test, Named by It
+
+**Must**
+
+Each test must cover one behaviour, and its name must state that behaviour. Several
+assertions belong to one test only where they establish that one behaviour together.
+
+A test whose failure admits two causes must be split, and a name stating the input rather
+than the behaviour must be rewritten. The form a name takes, and the syntax carrying the
+assertions, are stated by the testing skill of the language being written.
+
+## Unit Test Isolation
+
+**Must**
+
+A unit test must reach nothing outside its own process: no network access, no disk access,
+no database access, no clock it does not set, and no wait on wall-clock time. Each unit
+test must complete in milliseconds, so the whole level runs on every edit.
+
+The author must replace a collaborator carrying one of those, in the order
+`test-driven-development` → Prefer the Real Thing Over a Test Double fixes. A test that
+cannot be written that way is no unit test, and the author must name and run it at the
+level whose boundary it is about.
+
+## Test Data and the Environment
+
+**Must**
+
+| Subject | Rule |
+|---|---|
+| The data an assertion turns on | Must be built by the test that asserts on it or read from a checked-in fixture, never inherited from another test and never read off the machine the run happens on |
+| A temporary directory | A test touching the file system must run against a directory created for that test alone, and must remove it whether the test passes or fails |
+| A shared location | No test may write a fixed path, a shared database, a well-known port or a real account; the location must come from configuration the test sets |
+| A checked-in fixture | Must be read and never written by the test using it; a test needing a changed copy must make the copy |
+| Setup | Must establish every precondition the assertions name, so no assertion rests on a state the test did not put there |
+| Teardown | Must run on the failing path as well as the passing one, and must restore what setup changed — an environment variable, a working directory, a registered handler, a global instance |
+| A credential | Must be minted for the run and must reach no artifact the run leaves behind (the `security-and-hardening` skill states what handling one requires) |
+
+## Crossing a Process or Network Boundary
+
+**Must**
+
+| Subject | Rule |
+|---|---|
+| Timeout | Every call crossing the boundary must carry a timeout the test sets, so a dependency that never answers fails that test instead of hanging the run |
+| Waiting | A test must wait for the condition it is about — a reply, a file, a recorded state — and must not wait a fixed span of time instead |
+| Retry | A retry must carry a bound stated in the test: a maximum number of attempts and a maximum total wait |
+| Ordering | An assertion must not turn on the order two operations across the boundary complete in, unless the requirement fixes that order; where it does not, the assertion must name the set of outcomes admitted |
+| Cleanup | Everything the test allocates beyond its own process — a record, a queue, a container, a port, a subprocess — must be released in teardown, on the failing path as well |
+| Address | The endpoint must come from configuration the test sets, never from a host name compiled into the test |
+
+## Determinism and Independence Between Runs
+
+**Must**
+
+| Subject | Rule |
+|---|---|
+| Repeatability | A test must return the same verdict on every run against the same commit, on every platform the project supports |
+| Independence | Each test must pass run alone, and must pass in any order beside the others; no test may read state another test left behind |
+| A varying input | The current time, the time zone, the locale, the random seed, the process identifier, the host name and the order a directory is listed in must be fixed by the test wherever an assertion turns on one |
+| Concurrency | An assertion must not turn on the scheduling of threads or processes; a test over concurrent code must state the outcome the requirement admits, whatever the interleaving |
+| A test that varies | A test whose verdict differs between runs of one commit is a defect of that test, and the author must repair it, remove it, or disable it under the condition When a Suite May Be Trusted states, rather than re-run it until it passes |
+
+## The Fail Step Fails for the Intended Reason
+
+**Must**
+
+The fail step of `test-driven-development` → The Loop must fail for the behaviour the test
+covers, and the check is a mutation of the code under test:
+
+| The mutation | The test |
+|---|---|
+| removes the behaviour that test covers | must fail |
+| leaves that behaviour intact — a local renamed, two independent statements reordered | must pass |
+
+A test that fails on a missing fixture, an unresolved name or a typo in a path reports
+nothing about the behaviour, and passes on a coincidence the moment the file appears. The
+mutation is what separates the two: the author applies it to the code under test and must
+revert it before the pass step, and it needs no tooling of its own.
+
+## No Assertion on an Implementation-Defined Value
+
+**Must**
+
+An assertion must not rest on a value the implementation defines rather than the
+requirement. The closed set:
+
+- `sizeof` of a built-in type
+- byte order
+- pointer width
+- the signedness of the type `char`
+- the width of the type `long`
+
+Each of those differs across the compilers, operating systems and architectures a build
+matrix covers (`ci-cd-and-automation`), so an assertion resting on one states where it was
+written rather than what the code owes. What replaces it is a relation or an invariant read
+off the requirement:
+
+| Instead of | Assert |
+|---|---|
+| a type's size against a number | the type holds every value the requirement names, its minimum and its maximum included |
+| the byte order the machine happens to have | the value survives the round trip through the encoding the requirement fixes |
+| a pointer's width | the pointer read back equals the pointer written |
+| the signedness a character type happens to carry | the value range the requirement states is representable |
+
+## Test Layout - Arrangement, Action, Assertion
+
+**Must**
+
+Each test must separate these phases, and must merge no two of them:
+
+| Phase | Holds |
+|---|---|
+| Arrangement | the state the behaviour is checked against, built by this test |
+| Action | one call of the thing under test |
+| Assertion | the outcome, compared against what the requirement states |
+
+An action written inside an assertion, or a state the action itself arranges, leaves a
+failure that does not say which of the three broke. The syntax each phase is written in is
+stated by the testing skill of the language being written.
+
+## Boundary Cases
+
+**Must**
+
+Every unit under test must carry a test for each kind of boundary that applies to it:
+
+| Kind | What it is |
+|---|---|
+| Empty or zero | the input carrying nothing |
+| Minimum or maximum | the extreme value the type or the requirement admits |
+| Off by one | the value on each side of a limit |
+| Invalid input | the value the requirement rejects |
+| Exact threshold | the value a documented limit is stated at |
+
+Where the requirement states a precondition, the boundary just inside it and the one just
+outside it must both carry a test. The example each kind takes in one language is given by
+the testing skill of the language being written.
+
+## When a Suite May Be Trusted
+
+**Must**
+
+A suite carries a verdict on a change only where every condition below holds; short of
+one, its result says nothing about the change and must not be reported as if it did.
+
+| Condition | What establishes it |
+|---|---|
+| The run covers the change | the run happened on the commit under review, per `work-sequence` → When a Check Runs |
+| Every declared test ran | no test skipped, disabled or filtered out without an issue naming it and the release it is restored by |
+| Every test can fail | no test without an assertion, and each new test failed at its fail step for the reason the section The Fail Step Fails for the Intended Reason names |
+| The levels the change touches ran | a change crossing a boundary ran the level of that boundary, not the level below it alone |
+| A failure was read, not re-run | the cause of each failure was established, per the `debugging` skill, and a test whose verdict varies was settled per Determinism and Independence Between Runs |

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -145,8 +145,8 @@ function skillsDeclaringRubric() {
 
 // Extended by the pass that marks the next skill; every name here is checked below.
 const MARKED_SKILLS = ['code-navigation', 'comments', 'editing', 'github-cli',
-  'gitlab-cli', 'pr-rules', 'skill-authoring', 'submodule-sync', 'work-sequence',
-  'writing-style'];
+  'gitlab-cli', 'pr-rules', 'skill-authoring', 'submodule-sync', 'testing',
+  'work-sequence', 'writing-style'];
 
 function commandFiles() {
   const names = fs.readdirSync(commandsDir).filter(name => name.endsWith('.md'));


### PR DESCRIPTION
## Problem

Three skills stated the principles of a test in three wordings: `cpp-testing` and
`node-testing` each held its own copy, `test-driven-development` routed the shape of a
test to whichever language skill the reader was in, and a project in a third language
reached none of them. A reader loading two of the three met two thresholds for one act,
with nothing saying which wins.

## Summary

- A new skill `testing` owns what does not turn on a runner: the level a test sits at, its isolation, its data, the boundary it crosses, one behaviour per test, its layout, its boundaries, and when a suite carries a verdict
- The fail step of the loop must fail for the behaviour the test covers, and the check is a mutation of the code under test
- `cpp-testing` and `node-testing` keep the means their runner gives and what their own tests cover
- `ci-cd-and-automation` hands the verdict on a check that varies to the same owner, and orders its stages by the levels the new skill defines
- `code-review-and-quality` sends a reviewer to the owner of the boundary cases rather than to a language skill that no longer makes them mandatory

## Implementation

- `bound-to: universal`, a category, which is what lets the language skills name the owner in backticks; the owner names them by role in return
- Ten of eleven sections carry `**Must**`, each naming the artifact carrying the verdict; the one section holding an unmeasurable statement, the pyramid, carries `**Should**`
- The level table keys on the boundary a test is about rather than the one it crosses, so a contract test asserting a recorded agreement is a contract test though it reaches nothing outside its process
- `agents/implementer.md` names the new skill before the language one, since a persona loads only what its body names
- Fourteen rules left the two language skills and one left the pipeline skill; each was traced to a named section of the owner

## Test plan

- [x] `npm test` passes
- [x] `grep -rln "findReferences"`-style checks of the issue run: `git grep -n cpp-testing -- skills/node-testing/SKILL.md` empty, and `git grep -n -i "mock\|stub" -- skills/cpp-testing/SKILL.md` one line naming `test-driven-development`
- [x] The skill-gate probe answers `[ 'test-driven-development', 'testing', 'node-testing', 'comments' ]` for a file under `test/`
- [ ] The user runs `node install.js`, which is the step that puts the edited files where an agent reads them

## Review

Three passes of `code-reviewer` at depth `high`. The loop closed as not converging: each
pass found new consequences of the previous pass's fixes. Every blocking finding of all
three is addressed. Four acceptance criteria of GH-153 turned out false against the tree -
a `Build` row that does not exist, a line in `node-testing` that names `cpp-testing`
nowhere, a colour word the corpus check rejects, and a hand-off the ownership map reserves
to the skill - and each is reported rather than implemented. One question the third pass
leaves open: how a test running against a live third party classifies in the level table.
