### PR TITLE
GH-155: Collect the git mechanics into one workflow skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ install.js  Bootstrap script — copies files to ~/.claude/
 - Node built-ins only: no npm package in a hook, a tool, `install.js` or a test.
 - `install.js`, `lib/` and `test/` follow the same two hard rules a hook or a tool does,
   built-ins and no hardcoded user path — `skills/hook-scripts/SKILL.md` → Hard Rules.
-- Commit and branch format: `skills/commit-rules/SKILL.md`. Direct commits to `main` are
-  blocked — work on a feature branch.
+- Commit message format: `skills/commit-rules/SKILL.md`; branch name and every git
+  command: `skills/git-workflow/SKILL.md`. Direct commits to `main` are blocked — work
+  on a feature branch.
 
 ## Hook architecture
 
@@ -79,7 +80,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `code-navigation` — where an answer about a symbol comes from.
 - `code-review-and-quality` — what a review looks for.
 - `comments` — a comment in any language, whatever marker opens it.
-- `commit-rules` — the commit message and the branch name.
+- `commit-rules` — the commit message; the commands making and correcting a commit are `git-workflow`'s.
 - `cpp-api-design` — the shape of a public C++ surface.
 - `cpp-coding` — C++ implementation conventions.
 - `cpp-doxygen` — Doxygen blocks on public C++ headers.
@@ -89,6 +90,7 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `debugging` — the investigation that precedes a fix.
 - `deprecation-and-migration` — retiring a public path.
 - `editing` — the guard against a stale reading of a file, of a tracker or forge artifact, and of the branch head at a merge.
+- `git-workflow` — every git command moving a branch, a commit, a tag or a remote ref, in one ordered sequence; what a commit message, a version and a pull request say sit in `commit-rules`, `release` and `pr-rules`.
 - `github-cli` — `gh` mechanics.
 - `gitlab-cli` — `glab` mechanics.
 - `hook-scripts` — writing this repository's hooks and tools.
@@ -96,9 +98,9 @@ a copy that drifts, and the agent reading both has nothing telling it which one 
 - `node-testing` — conventions for the tests under `test/`.
 - `observability-and-instrumentation` — telemetry for production visibility.
 - `performance-optimization` — the process around one performance problem.
-- `pr-rules` — the pull request, from opening it to merging it.
+- `pr-rules` — the pull request, from opening it to the decision to merge; the merge command is `git-workflow`'s.
 - `project-planning` — stakeholder-facing planning, and whether independent work runs at the same time.
-- `release` — the version number and the mechanical steps to ship it.
+- `release` — the version number and what holds before it is frozen; the tag and the pushes shipping it are `git-workflow`'s.
 - `requirements` — turning an ask into a requirement.
 - `security-and-hardening` — design-time security.
 - `shipping-and-launch` — whether a built release may reach users, and how widely.
@@ -153,16 +155,16 @@ stage with no command or persona of its own says so rather than naming the neare
 | Intake | — | not created yet | `requirements`, `project-planning` |
 | Spec | `/spec` → `spec-architect` | `Open`, once it exists | `requirements`, `ddd`, `architecture`, `cpp-api-design` |
 | Scope and issue | — | `Open` | `issue-rules`, `github-cli` / `gitlab-cli` |
-| Branch | — | → `In Progress` | `commit-rules` → Branch Naming |
-| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`, `hook-scripts`, `node-testing`; `debugging` on a fix; `performance-optimization` on a reported performance problem; `deprecation-and-migration` when retiring a public path; `skill-authoring` on a skill or a command file; `project-planning` → Running Independent Work in Parallel on each launch that section names; `commit-rules` per commit |
-| Publish | — | `In Progress` | `work-sequence` → When a Check Runs, `submodule-sync`, `changelog`, `commit-rules` |
+| Branch | — | → `In Progress` | `git-workflow` → Naming the Branch |
+| Implement | `/implement` → `implementer` | `In Progress` | `work-sequence` → When a Check Runs, `test-driven-development`, `cpp-coding`, `ddd`, `cpp-encapsulation`, `cpp-testing`, `hook-scripts`, `node-testing`; `debugging` on a fix; `performance-optimization` on a reported performance problem; `deprecation-and-migration` when retiring a public path; `skill-authoring` on a skill or a command file; `project-planning` → Running Independent Work in Parallel on each launch that section names; `commit-rules` and `git-workflow` per commit |
+| Publish | — | `In Progress` | `work-sequence` → When a Check Runs, `submodule-sync`, `changelog`, `commit-rules`, `git-workflow` → Sending the Branch |
 | Offer for review | — | → `In Review` | `pr-rules`, `ci-cd-and-automation`, `github-cli` / `gitlab-cli` |
-| Review | `/review`, or `/review-loop` to iterate → `code-reviewer` | `In Review` | `code-review-and-quality`, `cpp-api-design`, `cpp-encapsulation`, `comments` / `cpp-doxygen`, `pr-rules`; `changelog` when the change touches `CHANGELOG.md` |
+| Review | `/review`, or `/review-loop` to iterate → `code-reviewer` | `In Review` | `code-review-and-quality`, `cpp-api-design`, `cpp-encapsulation`, `comments` / `cpp-doxygen`, `pr-rules`, the workflow skill of the version control system → Reading One Round of Review; `changelog` when the change touches `CHANGELOG.md` |
 | Security audit | `/review`, or `/review-loop` to iterate → `security-auditor` | `In Review` | `security-and-hardening`, `pr-rules` |
 | Pre-merge issue check | — | `In Review` | `pr-rules` → Pre-Merge Checklist, `issue-rules` → Progress Comments, `github-cli` / `gitlab-cli` |
-| Integrate | — | `In Review` | `pr-rules` → Merge Strategy, `commit-rules`, `github-cli` / `gitlab-cli` |
+| Integrate | — | `In Review` | `pr-rules` → Merge Strategy, `commit-rules`, `git-workflow` → Merging, `github-cli` / `gitlab-cli` |
 | Close issue | — | issue closed; not `Done` until deployed (`issue-rules` → Lifecycle), or left `In Review` with a follow-up linked | `issue-rules` → Lifecycle, `github-cli` / `gitlab-cli` |
-| Release | — (`release-manager` directly) | → `Done` | `changelog`, `release`, `shipping-and-launch`, `submodule-sync` |
+| Release | — (`release-manager` directly) | → `Done` | `changelog`, `release`, `shipping-and-launch`, `submodule-sync`, `git-workflow` → Tagging a Release |
 
 A second table follows, one row for each skill named in no `Skills` cell above. Its
 `Stage` cell holds a stage name of the table above, or the word `cross-cutting` — itself
@@ -174,7 +176,7 @@ missing value.
 | `code-navigation` | cross-cutting | an edit or a verdict turning on a symbol's callers, its implementations, its definition, what a bare name refers to, or whether the symbol has any user left | the symbol, at the file path, line and character it stands at, or the name a workspace-wide query carries | the set of sites the operation returns | the source `code-navigation` → Where the Answer Comes From names for the language | the answer naming the operation that produced it, per `code-navigation` → Naming the Operation |
 | `deprecation-and-migration` | Implement | retiring a public API, planning a breaking change, or writing a migration guide | the public symbol or path being retired | a deprecation marker, a migration guide, and a removal-tracking issue | the breaking-change classification `cpp-api-design` → Breaking Changes gives the symbol | the removal issue's milestone, set per `issue-rules` → Milestone |
 | `editing` | cross-cutting | a write to a file, a tracker issue body or a PR description, and a merge | the artifact as it stands before the write | the artifact as it stands after the write | a reading of the artifact, per `editing` → Guard Against a Stale Reading | the checks a round of edits runs, per `work-sequence` → When a Check Runs |
-| `hook-scripts` | Implement | writing or modifying a file under `hooks/` or `tools/` | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `commit-rules` → Branch Naming | the test file `node-testing` covers for the tool, `test/<name>.test.js` |
+| `hook-scripts` | Implement | writing or modifying a file under `hooks/` or `tools/` | the event or tool the change routes to | a dispatcher or tool file matching the Dispatcher or Tool Skeleton | the feature branch named per `git-workflow` → Naming the Branch | the test file `node-testing` covers for the tool, `test/<name>.test.js` |
 | `node-testing` | Implement | writing or reviewing a file under `test/*.test.js` | the pure logic exported by the hook or tool under test | a test file asserting that logic's behaviour | the tool's exported logic, per `hook-scripts` → Tool Skeleton | the tool covered and `npm test` run, per `hook-scripts` → Adding or Retiring a Tool |
 | `observability-and-instrumentation` | cross-cutting | adding logging, metrics, or tracing, or checking a running system's reported behaviour | the question an on-call engineer needs answered | a structured log line, metric, or trace answering it | the non-functional requirement `requirements` → Functional vs Non-Functional records | the Readiness Checklist item `shipping-and-launch` → Readiness Checklist for monitoring |
 | `performance-optimization` | Implement | diagnosing a reported performance problem, or evaluating a change's performance cost | a profiler or benchmark baseline for the hot path | a measured before/after comparison for the fix | the symptom and cost the bug template of `issue-rules` → Description Template asks for | the hot-path check `code-review-and-quality` → Performance runs before merge |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- `git-workflow` skill: the git commands moving a branch, a commit or a tag, in one sequence from the branch to the released tag, each with what git records and the refusals it answers; the name form `<user>/<type>/<TRACKER-N>/<subject>`, the protected branch and the removal included
+- `git-workflow` states what one round of review is read with: the three-dot diff against the target, which leaves out the commits the target itself gained, and the range-diff pairing two rounds across a rebase
 - `code-navigation` skill: the questions a text search does not answer about a symbol - its callers, implementations, definition, a bare name's referent and the symbol's remaining users - the rule that an answer names the operation producing it, and `test/code-navigation.test.js` over the example
 - Independent work runs at the same time: `project-planning` states when two units are independent, the lowest bound the contended resources put on the degree of parallelism, and when one check runs alone before the rest; a pipeline arranges its jobs so by default
 - The lifecycle map in `AGENTS.md` carries a second table for every skill its stage table names in no `Skills` cell, stating each one's stage, trigger, input, output and the artifact its entry and exit turn on; a skill firing at more than one stage declares `cross-cutting` there
@@ -70,6 +72,8 @@
 - `work-sequence` skill: the eight steps from a task to a closed issue, each with its condition and the skill owning what it produces. Read it rather than `pr-rules` for the order of work and for the moment a check runs at; `pr-rules` now states the pull request alone
 
 ### Changed
+- `commit-rules`, `release` and `pr-rules` name no git command for the branch, the correction, the rebase, the pushes, the merge or the tag: those sit in `git-workflow`, which each of the three points to by role, so a project on another version control system reads only rules it can apply
+- `github-cli` and `gitlab-cli` point at `git-workflow` for the removal of a merged local branch, keeping their own account of what the forge itself deletes
 - `code-reviewer`, `implementer` and `spec-architect` load `code-navigation` and declare the `LSP` tool its operations belong to, so a rule about a symbol's callers reaches an operation wherever the environment offers one
 - The `## Project Overrides` section reads the same in every skill, one sentence differing only in the topic it names, and every skill carries one
 - `/review-loop` asks where every pass runs rather than assuming a working directory: it makes no place of its own, moves nothing aside, and states no step that needs a repository
@@ -86,7 +90,6 @@
 - `AGENTS.md` -> Lifecycle map lines each pipeline stage up against the command or persona carrying it, the `issue-rules` state the issue is in, and the skills that apply there
 - A dot-file or dot-directory is ignored unless `.gitignore` names it as one this repository tracks, so a tool's leftover no longer sits in `git status` beside a file that should have been committed
 - `pr-rules` and `issue-rules` keep the rules and point at `github-cli`/`gitlab-cli` for the command, so a `gh` or `glab` change no longer means editing rules that are not about a CLI
-- `commit-rules`: added Branch Naming - `<user>/<type>/<TRACKER-N>/<subject>`, the tracker segment omitted when no issue exists
 - `pr-rules`: the PR title uses the tracker ID in place of `Type(scope)` when a tracked issue exists, and the subject starts with uppercase in every variant
 - `cpp-api-design`: added the rationale behind the structure rules and a wrong/right example for the "no `void*`" rule
 - `skills-reminder` generates its prompt from `skills/*/SKILL.md` frontmatter at runtime instead of a hardcoded list, so a new skill appears automatically

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,10 @@ version of them.
 
 ## Commits and branches
 
-Conventional Commits. The message format, the type vocabulary, the body and the branch
-name pattern are owned by `skills/commit-rules/SKILL.md` - read it before the first
-commit rather than copying the shape of a nearby one.
+Conventional Commits. The message format, the type vocabulary and the body are owned by
+`skills/commit-rules/SKILL.md`, and the branch name pattern with every git command
+carrying it by `skills/git-workflow/SKILL.md` - read both before the first commit rather
+than copying the shape of a nearby one.
 
 One of its rules is enforced rather than left to the reader: the `commit-trailer-guard`
 tool blocks a `git commit` an agent runs with an AI-attribution trailer in the message.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `code-navigation` | Where an answer about a symbol comes from, and what a text search does not answer |
 | `code-review-and-quality` | Review substance — correctness, readability, architecture, security, performance |
 | `comments` | Code comment style in any language, Doxygen aside (brief, general, no fix narration) |
-| `commit-rules` | Conventional Commits format and branch naming |
+| `commit-rules` | Conventional Commits format |
 | `cpp-api-design` | C++ public API structure and hygiene |
 | `cpp-coding` | C++ implementation conventions |
 | `cpp-doxygen` | Doxygen tag coverage for public C++ headers |
@@ -100,6 +100,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `debugging` | Root-cause investigation before proposing a fix |
 | `deprecation-and-migration` | Retiring a public API and writing a migration guide |
 | `editing` | Guard against a stale reading of a file, of a tracker or forge artifact, and of a branch head |
+| `git-workflow` | The git commands from branch to tag — branch, commit, fixup, rebase, merge, tag, push |
 | `github-cli` | `gh` mechanics — issues, PRs, labels, pending review threads, stacks, merges |
 | `gitlab-cli` | `glab` mechanics — issues, MRs, labels, draft notes, stacks, merges |
 | `hook-scripts` | Writing Claude Code hooks and tools |
@@ -109,7 +110,7 @@ skills that always apply alongside it, and optional `reminder: false` for a skil
 | `performance-optimization` | Profile-measure-optimize workflow for a reported performance problem |
 | `pr-rules` | PR title, description, review comments, merge strategy |
 | `project-planning` | Scoping, estimation, milestones, risk, status updates, and the launch of independent work at once |
-| `release` | Semver release workflow |
+| `release` | Semver version decision and the gates before it is frozen |
 | `requirements` | Requirements gathering, user stories, acceptance criteria |
 | `security-and-hardening` | Trust boundaries, input validation, secrets, least privilege |
 | `shipping-and-launch` | Release readiness, staged rollout, rollback planning |

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -18,16 +18,18 @@ this file:
 
 1. `code-review-and-quality` skill — what counts as a finding, and which axis is worth
    checking before which.
-2. `code-navigation` skill — where an answer about a symbol's callers, implementations or
+2. the workflow skill of the version control system — Reading One Round of Review, for
+   what a round of review is read with and what a re-review recomputes.
+3. `code-navigation` skill — where an answer about a symbol's callers, implementations or
    definition comes from.
-3. `cpp-encapsulation` skill — the access level of anything the change adds to a type.
-4. `cpp-api-design` skill — the shape of a changed public surface, and whether the change
+4. `cpp-encapsulation` skill — the access level of anything the change adds to a type.
+5. `cpp-api-design` skill — the shape of a changed public surface, and whether the change
    breaks the callers of it.
-5. `comments` / `cpp-doxygen` skills — the comments the change leaves behind, and the
+6. `comments` / `cpp-doxygen` skills — the comments the change leaves behind, and the
    documentation a new public header owes.
-6. `pr-rules` skill — how a finding is worded, and where review feedback may be published
+7. `pr-rules` skill — how a finding is worded, and where review feedback may be published
    at all.
-7. `changelog` skill — on a change that touches `CHANGELOG.md`. The entry is part of the
+8. `changelog` skill — on a change that touches `CHANGELOG.md`. The entry is part of the
    diff under review, and `pr-rules` → Pre-Merge Checklist expects one for every
    user-visible change.
 

--- a/agents/release-manager.md
+++ b/agents/release-manager.md
@@ -17,8 +17,10 @@ Apply, in order, loading each with the Skill tool — the rules are stated there
 this file:
 
 1. `changelog` skill — what the release tells its readers changed.
-2. `release` skill — the version number and the mechanical steps that carry it.
-3. `shipping-and-launch` skill — beyond the version-bump mechanics: whether the release,
+2. `release` skill — the version number and what each step of a release leaves behind.
+3. `git-workflow` skill — Tagging a Release, for the commands that record the bump, the
+   tag and the two pushes.
+4. `shipping-and-launch` skill — beyond the version-bump mechanics: whether the release,
    once built, may reach users at all.
 
 Do not cut a release with an open blocking finding from `code-reviewer` or

--- a/commands/review-loop.md
+++ b/commands/review-loop.md
@@ -64,7 +64,9 @@ At most 3 passes. Each pass, in order:
    else carries the work's state — a tracker item, a proposed change — reading that state
    directly where the named tool has no notion of it.
    With more than one tool named, run them in parallel and merge their reports, the
-   fan-out `/review` uses for `code-reviewer` + `security-auditor`.
+   fan-out `/review` uses for `code-reviewer` + `security-auditor`. The workflow skill of the version
+   control system states what a round is read with, and what a re-review recomputes, in
+   Reading One Round of Review.
 2. Classify the pass — Blocking and Clean.
 3. The pass reports and changes nothing; this step is what changes the work. Fix every
    blocking finding directly, no subagent owning the step, and resolve any nit or

--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-rules
 version: "1.0.0"
-description: Apply when writing or reviewing commit messages or naming branches
+description: Apply when writing or reviewing a commit message
 license: Unlicense
 metadata:
   author: ssoft
@@ -19,12 +19,13 @@ Apply when writing commit messages or reviewing commits.
 
 - The step of the work a commit or a branch is made at → `work-sequence` skill.
 - Prose register, and the rule that a body states the result rather than the process → `writing-style` skill.
+- The commands naming a branch, making a commit, correcting one already made and rewriting what is already recorded → the workflow skill of the version control system.
 
 ## Project Overrides
 
 **Must**
 
-Must follow the commit and branch-naming conventions the repository's `AGENTS.md`
+Must follow the commit-message conventions the repository's `AGENTS.md`
 file or a project skill defines, instead of the rule here.
 
 ---
@@ -105,77 +106,14 @@ issues. Both go after the explanatory paragraph, not instead of it.
 
 ---
 
-## Branch Naming
-
-```
-<user>/<type>/<TRACKER-N>/<subject>
-```
-
-- **user** — git username (always; marks personal branches).
-- **type** — same values as commit types (`feat`, `fix`, `chore`, …).
-- **TRACKER-N** — issue identifier from the tracker (`PROJ-42`, `GH-7`, …). Omit the segment entirely when there is no tracked issue.
-- **subject** — kebab-case, imperative, concise.
-
-```
-<user>/feat/PROJ-42/add-siphash
-<user>/chore/update-submodule-refs
-```
-
----
-
 ## Consistency Rules
 
-- **Check branch before committing** — confirm you are on a feature branch, not `main`.
-  Direct commits to `main` are blocked by the pre-commit hook.
 - **Repository must be consistent at every commit** — docs, tests, and implementation
   must not diverge within a single commit. A commit that adds a feature must also
   update any documentation or tests that reference it.
 - **Do not describe a result before it exists** — a commit that only adds tests for
   feature X must not say "add feature X". The subject must match what is actually
   committed, not what will be committed later.
-
----
-
-## Fixup Commits
-
-When correcting an earlier commit on the same branch, use `--fixup` instead of a free-form commit:
-
-```bash
-git commit --fixup=<hash>          # code-only fix; target's message is left untouched
-git commit --fixup=amend:<hash>    # fix also changes what the message must say
-git commit --fixup=reword:<hash>   # message-only correction, no code change
-git rebase -i --autosquash <base>  # squashes fixups automatically before merge
-```
-
-Plain `--fixup` never opens an editor: `rebase --autosquash` folds the code silently and
-keeps the target commit's original message exactly as it was, even when the fix makes
-that message no longer describe the code. Use `amend:` (or `reword:` for a message-only
-correction) whenever the fixup changes what the commit should say about itself — it
-opens the editor immediately, pre-filled with the target's message, and the edited
-result replaces the target's message during autosquash. `amend:`/`reword:` require
-git ≥ 2.32; on an older git, amend the target commit's message by hand after autosquash
-instead.
-
-Use `--fixup` when the change belongs to a specific earlier commit — reviewer sees the correction attached to its target, not floating. Use a normal commit only when the change is logically independent.
-
-## Fixup / Squash Merges
-
-Squash fixup commits before the Publish step, not at merge time (`work-sequence` →
-The Sequence).
-
-Before running `rebase -i --autosquash`, check whether any fixup changes what its target
-commit's body claims. If so, that fixup must be `--fixup=amend:<hash>`, not plain
-`--fixup` — otherwise the merged commit keeps describing the pre-fix behaviour.
-
-After autosquash completes, re-read each final message (`git log -1 <hash>`) against the
-diff it now covers (`git show <hash>`) and amend anything that drifted. The merged
-commit must read as if it was written that way from the start.
-
-## No Correction Commits Within a PR
-
-A PR branch must not contain correction commits (fixups, renames, moves) for mistakes introduced earlier in the same branch. If a commit is wrong, rewrite history — do not layer a fix on top.
-
-**Rule:** If a correction belongs to an earlier commit in the same PR, rebase and amend that commit. A reviewer should see each commit as correct from the start, not as a sequence of mistake + fix.
 
 ---
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: git-workflow
+version: "1.0.0"
+description: Apply when a git command moves a branch, a commit, a tag or a remote ref - branching, committing, correcting, rebasing, merging, tagging, pushing
+license: Unlicense
+metadata:
+  author: ssoft
+  tier: domain
+  bound-to:
+    - git
+  rubric: applied
+  tags:
+    - git
+    - workflow
+---
+
+# Skill: Git Workflow
+
+Apply when a git command is about to run against a branch, a commit, a tag or a remote
+ref.
+
+## Project Overrides
+
+**Must**
+
+Must follow the git commands and their order the repository's `AGENTS.md` file or a
+project skill defines, instead of the rule here.
+
+## The Command Sequence
+
+**Must**
+
+The steps below carry one change from a branch to a released tag, and nothing else
+belongs to the sequence. Each step must run after the one above it, and the step
+conditions — when a round of edits closes, when the branch is offered for review — are
+`work-sequence` → The Sequence's.
+
+| Step | The command | What git records |
+|---|---|---|
+| Branch | `git checkout -b <name> <target>` | a new ref at the target's tip |
+| Commit | `git commit` | one commit on that ref |
+| Correct | `git commit --fixup=<hash>` | a correction attached to its target commit |
+| Rebase | `git rebase --autosquash <target>` | the branch replayed on the target's tip, corrections folded in |
+| Send | `git push -u origin HEAD` | the branch on the remote, with an upstream set |
+| Merge | `git merge --no-ff <name>` | a merge commit on the target, with both parents |
+| Tag | `git tag <tag>` | a tag ref at the merge commit |
+| Publish the tag | `git push`, then `git push --tags` | the merge commit, and then the tag, on the remote |
+
+A round of review returns to the Commit step and runs forward from there, so every step
+from Commit to Send runs once per round rather than once per change.
+
+## Naming the Branch
+
+**Must**
+
+```
+<user>/<type>/<TRACKER-N>/<subject>
+```
+
+| Segment | What it holds |
+|---|---|
+| `user` | the git account name, always, which marks the branch personal |
+| `type` | one value of the type vocabulary `commit-rules` → Types fixes |
+| `TRACKER-N` | the issue identifier — `PROJ-42`, `GH-7`; the author must drop the segment entirely where no issue is tracked |
+| `subject` | kebab-case, imperative, and at most five words |
+
+The command must name the target branch, since a branch made without one starts wherever
+`HEAD` stands:
+
+```bash
+git checkout -b ssoft/feat/PROJ-42/add-siphash main
+git checkout -b ssoft/chore/update-submodule-refs main
+```
+
+## The Protected Branch
+
+**Must**
+
+Must read the current branch before the first commit of a round of edits, and must not
+commit where the answer is a shared branch — `main`, `master`, or whatever the project
+declares:
+
+```bash
+git branch --show-current   # the Branch step has not run where this answers the target
+```
+
+A pre-commit hook, where the project or the machine installs one, refuses such a commit
+instead of recording it, and a forge may refuse the push instead — so a branch made after
+the fact costs a rewrite of what is already recorded.
+
+## Correcting a Commit Already Made
+
+**Must**
+
+| The correction | The command | The editor |
+|---|---|---|
+| code only, the target's message still true of it | `git commit --fixup=<hash>` | none opens; the target's message survives the fold untouched |
+| code, and what the message says about it | `git commit --fixup=amend:<hash>` | opens at once, pre-filled with the target's message |
+| the message alone | `git commit --fixup=reword:<hash>` | opens at once; no staged change is needed |
+| the tip commit, before it is sent | `git commit --amend` | opens unless `--no-edit` is passed |
+
+- Must reach for `amend:` wherever the fix changes what the commit says about itself,
+  which the Rebase step's `git log -1 <hash>` against `git show <hash>` establishes:
+  under plain `--fixup` the Rebase step folds the code and keeps the target's message,
+  which then describes the pre-fix behaviour.
+- The forms `amend:` and `reword:` need git ≥ 2.32. On an older git the author must
+  amend the target's message by hand after the Rebase step instead.
+- Must attach the correction to its target rather than commit it free-standing, wherever
+  the change belongs to an earlier commit of the same branch: the reviewer then reads the
+  correction against what it corrects. A change that stands on its own is a normal commit.
+- A branch offered for review must carry no correction of a mistake made earlier on that
+  same branch. The Rebase step folds them in first, so each commit reads as correct from
+  the start.
+
+## Rebasing onto the Target
+
+**Must**
+
+```bash
+git rebase --autosquash <target>   # -i as well, before git 2.44
+git log -1 <hash>                  # the message the fold produced
+git show <hash>                    # the diff it now covers
+```
+
+- The command replays the branch under the `--autosquash` flag on the target's tip and folds every `fixup!` and
+  `amend!` commit into the commit it names. From git 2.44 the command squashes without `-i`; before
+  that it needs `-i`, and with it an editor.
+- Must re-read each folded message against the diff it now covers and amend what drifted:
+  the merged commit reads as if it had been written that way from the start.
+- Must run the Rebase step before the branch is sent and before the merge, and ahead of
+  every check measured against the head, which the rebase moves
+  (`work-sequence` → When a Check Runs).
+
+## Sending the Branch
+
+**Must**
+
+```bash
+git push -u origin HEAD              # first send, recording the upstream
+git push --force-with-lease          # after a rewrite
+```
+
+| The answer | What it means | The next move |
+|---|---|---|
+| `! [rejected] ... (non-fast-forward)` | the branch was rewritten after it was sent | `--force-with-lease` |
+| `! [rejected] ... (stale info)` | the remote ref moved since this clone last saw it | must read the remote branch before overwriting a commit that is not this branch's |
+| `+ <old>...<new> ... (forced update)` | the remote now carries the rewritten branch | — |
+
+- Must not run `git fetch` between reading the remote branch and the forced push: the
+  lease compares against the remote-tracking ref, which the fetch updates, and the push
+  then discards the other author's commit without a word.
+- Must not reach for the `--force` flag, under which the push overwrites whatever the remote holds in every case.
+
+## Merging
+
+**Must**
+
+```bash
+git merge --no-ff <branch>   # run from the target's tip
+```
+
+- Must not fast-forward and must not squash. The merge commit is what records both
+  parents, and a squash replaces every message the branch carried with one of its own.
+- The merge commit's subject and body are `pr-rules` → Merge Strategy's, and a merge run
+  on the forge rather than locally belongs to the CLI skill of the hosting platform.
+
+## Removing the Merged Branch
+
+**Must**
+
+Must remove the local branch with the merge: `git branch -d <name>`, run from the target, which
+answers `Deleted branch <name> (was <hash>)`. git refuses that removal in two cases:
+
+| The refusal | Why | The answer |
+|---|---|---|
+| `error: cannot delete branch '<name>' used by worktree at '<path>'` | a worktree has the branch checked out | `git worktree remove <path>` first, then the removal |
+| `error: the branch '<name>' is not fully merged` | the branch holds a commit the current branch does not | must run it from the target after the merge; `-D` discards the commits the target does not carry |
+
+The remote branch is removed through the CLI skill of the hosting platform, which states
+what the forge deletes on the merge and what it leaves.
+
+## Tagging a Release
+
+**Must**
+
+The version bump is a change like any other and takes the eight steps above: the Branch,
+Commit, Send and Merge steps carry it, and the Tag and Publish steps follow on the
+target.
+
+```bash
+git add <the files release Step 5 names>
+git commit                  # the version bump, on the working branch
+# the Send and Merge steps run here
+git tag <tag>               # on the merge commit, from the target
+git push
+git push --tags             # a push of its own: the first carries no tag
+```
+
+- Must tag the merge commit rather than the bump commit on the working branch. A tag
+  names one commit, and a reader of the release reads the history that commit carries;
+  a commit the target does not carry names history the release does not contain.
+- Must keep that order. A tag made before the merge names a commit the target has yet
+  to carry. What the bump commit holds and what the tag is called are `release` →
+  Step 5's and Step 1's.
+- Must run `git push --tags` as a push of its own. A plain push leaves the remote with
+  no tag at all, and the release workflow the tag triggers therefore never starts.
+
+## Reading One Round of Review
+
+**Must**
+
+```bash
+git diff <target>...HEAD                                     # the subject of one round
+git range-diff <old-base>..<old-tip> <new-base>..<new-tip>    # two rounds, across a rewrite
+```
+
+- Must read the subject of a round with three dots, which diffs from the merge base. Two
+  dots diff the two endpoints, so every commit the target gained since the branch started
+  arrives as this branch's own reversal of it — a file the target added is reported as a
+  deletion, against an author who never touched it.
+- `range-diff` pairs the commits of the two rounds across a rebase or an autosquash: `=`
+  for a commit the round left alone, `!` for a paired commit with the difference below it,
+  `<` and `>` for one the old or the new range holds alone.
+- A rebase and an autosquash give every commit a new hash, so a hash read in an earlier
+  round names a commit the branch no longer carries
+  (`pr-rules` → No Figures That Go Stale).
+
+## Cross-References
+
+**Recommended**
+
+- `commit-rules` — the message every commit above carries.
+- `pr-rules` — the pull request the branch is offered as, its checklists and its merge commit.
+- `release` — the version the tag names, and what holds before it is frozen.
+- `work-sequence` — the step each command runs at, and the checks a moved head owes.
+- `submodule-sync` — the module refs a branch records, and the module's own branch key.
+- The CLI skill of the hosting platform — the merge and the branch removal run on the forge.

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -148,7 +148,7 @@ then what is left takes one command each:
 
 | What is left | What it takes |
 |---|---|
-| the local head branch | the same `gh pr merge <n> --merge --delete-branch` again, after either refusal: it answers `! Pull request <owner>/<repo>#<n> was already merged` with an exit status of 0, switches a tree still holding the head branch onto the base branch, deletes the head branch, and reaches no remote branch. `git branch -d <name>` deletes it too, and, run from the base branch, answers `error: the branch '<name>' is not fully merged` until that branch carries the merge |
+| the local head branch | the same `gh pr merge <n> --merge --delete-branch` again, after either refusal: it answers `! Pull request <owner>/<repo>#<n> was already merged` with an exit status of 0, switches a tree still holding the head branch onto the base branch, deletes the head branch, and reaches no remote branch. The local removal the workflow skill of the version control system states deletes it too, under the refusals stated there |
 | the remote head branch | `git push origin --delete <name>`, which answers `error: unable to delete '<name>': remote ref does not exist` where the branch went with the merge |
 
 `merge-async` is a second merge endpoint `gh` exposes no command for, and the one a
@@ -213,7 +213,7 @@ Registration decides how the bottom is merged, and what becomes of the rest:
 `merge-async` merges the one pull request named. `gh stack merge` merges it and every one
 below, and the authorisation that needs is `pr-rules` → Merge Strategy 2; it also takes the
 merge method last used unless `--merge` is given, which is a squash or a rebase where that
-ran last, both forbidden by `pr-rules` → Merge Strategy 4.
+ran last, both refused by the workflow skill of the version control system.
 
 The cascading rebase moves every head above the merged pull request and leaves every tree,
 so read the head sha again with `gh pr view <n> --json headRefOid` — full, per Pull

--- a/skills/gitlab-cli/SKILL.md
+++ b/skills/gitlab-cli/SKILL.md
@@ -151,10 +151,9 @@ glab mr merge <iid> --message '<subject>
 | `--remove-source-branch` | sets the merge request's own attribute, which GitLab acts on at the merge: the source branch is deleted on the server. Where another merge request targets it, see Stacks | the project's setting |
 
 - `glab mr merge` deletes no local branch and says nothing about one, so the local branch
-  survives the merge and goes with `git branch -d <name>` — refused by git while a worktree
-  holds that branch, and, run from the target branch, refused as not fully merged until that
-  branch carries the merge. A worktree stops the merge itself no more than it stops any
-  other request over the API.
+  survives the merge and goes with the removal the workflow skill of the version control
+  system states, under the refusals stated there. A worktree stops the merge itself no
+  more than it stops any other request over the API.
 
 - The REST equivalent, when the flag names on the installed `glab` do not match, and the
   form that keeps `--auto-merge` out of the picture entirely:

--- a/skills/issue-rules/SKILL.md
+++ b/skills/issue-rules/SKILL.md
@@ -161,7 +161,7 @@ Open → In Progress → In Review → Done
 ```
 
 - **Open** — triaged, not started.
-- **In Progress** — branch exists (see `commit-rules` Branch Naming).
+- **In Progress** — branch exists, named as the workflow skill of the version control system states.
 - **In Review** — the change is offered for review (`work-sequence` → The Sequence).
 - **Done** — merged and deployed, with every checklist checkbox in the issue checked (reconciled at the Pre-merge issue check step, `work-sequence` → The Sequence). If checkboxes remain after merge, stay **In Review** with a follow-up PR/MR linked — do not mark Done.
 - **Closed** — explicitly not going to be fixed; add a comment explaining why.
@@ -183,6 +183,6 @@ A reader should be able to reconstruct, from comments alone, which PR/MR impleme
 ## Cross-References
 
 - `work-sequence` — the step of the work each act on this issue runs at, and the condition behind each lifecycle state.
-- `commit-rules` — branch naming convention references the issue identifier (`TRACKER-N`).
+- The workflow skill of the version control system — the branch name form carrying this issue's identifier (`TRACKER-N`).
 - `pr-rules` — PR title and description mirror the issue being resolved; its Pre-Merge Checklist gates merge on this issue's checkbox state.
 - The CLI skill of the issue tracker — the commands that create, label, and comment on an issue.

--- a/skills/pr-rules/SKILL.md
+++ b/skills/pr-rules/SKILL.md
@@ -194,11 +194,13 @@ review-thread box: a thread opened after the thread list was last read moves no 
 2. **The human authorises the merge.** An agent merges on an explicit instruction
    naming this PR, which does not carry to the next one: the authorisation is per pull
    request, so a command merging several needs an instruction naming each of them.
-3. **Rebase before merge.** `git rebase <target>`, then merge from the current target
-   tip; the rebase moves the head, so the branch returns to the Publish step and the
-   checks of that moment run again (`work-sequence` → When a Check Runs). The merge is
-   guarded with the head SHA read afterwards (`editing` → Guard Against a Stale Reading).
-4. **`--no-ff` only.** No fast-forward merge, no squash merge.
+3. **Rebase before merge.** Rebase onto the target as the workflow skill of the version
+   control system states, then merge from the current target tip; the rebase moves the
+   head, so the branch returns to the Publish step and the checks of that moment run
+   again (`work-sequence` → When a Check Runs). The merge is guarded with the head SHA
+   read afterwards (`editing` → Guard Against a Stale Reading).
+4. **The merge form.** Fixed by the workflow skill of the version control system, along
+   with the forms it refuses.
 5. **Merge subject:** `Merge PR #<pr-number>: <pr subject>`, the PR subject verbatim
    and never re-prefixed with `type(scope):`, so a tracker ID in the title leaves both
    identifiers in place (`Merge PR #7: PROJ-42: Add SipHash...`).
@@ -207,10 +209,11 @@ review-thread box: a thread opened after the thread list was last read moves no 
 7. **Merge body required.** What was integrated and why, never empty (`commit-rules`).
 8. **Trailers:** the ban in `commit-rules` holds; `Co-authored-by` injected by the
    forge when committer differs from author is allowed.
-9. **Cleanup before the Publish step.** Squash fixups (`commit-rules` → Fixup Commits)
-   before the branch is sent, never at merge time: a rewrite afterwards takes a
-   force-push and owes every check that step ran.
-10. **Rewrite squashed commit bodies** per `commit-rules` → Fixup / Squash Merges.
+9. **Cleanup before the Publish step.** Squash the corrections, as the workflow skill of
+   the version control system states: a rewrite after the branch is sent takes a forced
+   push and owes every check that step ran.
+10. **Rewrite the messages the squash leaves** — the workflow skill of the version
+    control system states what each one is read against.
 11. **Read the thread list before the merge command.** Immediately before it, read the review
     threads again and match them against the list read when the review was addressed
     (`editing` → Guard Against a Stale Reading).
@@ -232,10 +235,11 @@ is split before review.
 
 - `work-sequence` — the order of work the Offer for review step belongs to, and the moment each check runs at.
 - `issue-rules` — the issue this PR resolves: title, templates, labels, lifecycle, progress comments.
-- `commit-rules` — commit message format and branch naming on the PR's branch.
+- `commit-rules` — the message format of every commit on the PR's branch.
 - `code-review-and-quality` — what a review looks for, where this skill states how a finding is worded.
 - `editing` — the head-SHA read Merge Strategy turns on, the thread-list read it owes before the merge command, and the thread state the Pre-Merge Checklist reads.
 - `writing-style` — prose register in the description and in the review threads.
 - `ci-cd-and-automation` — the pipeline answering the checks reported on the pull request.
+- The workflow skill of the version control system — the commands behind the rebase, the send, the merge and the removal of the merged branch.
 - The module-sync skill of the version control system — the pre-PR check and the merge order the checklists gate on.
 - The CLI skill of the hosting platform — the commands behind the steps that reach this platform, and the draft mechanics behind Pending by Default.

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -77,13 +77,10 @@ to users is a separate gate → `shipping-and-launch` skill.
 
 ## Step 5 — Commit and Tag
 
-```bash
-git add CHANGELOG.md <version-files>
-git commit -m "chore(release): bump version to X.Y.Z"
-git tag vX.Y.Z
-git push
-git push --tags    # separate push — triggers CI release workflow
-```
+The release commit carries `CHANGELOG.md` and every version file of Step 3, under the
+subject `chore(release): bump version to X.Y.Z`. The commit, the tag on it and the
+pushes that publish both belong to the workflow skill of the version control system,
+which fixes the order they run in and what each one leaves behind.
 
 ## Step 6 — Submodule Root Update (if applicable)
 

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -16,9 +16,10 @@ metadata:
 # Skill: Shipping and Launch
 
 Apply when preparing to ship a release to users — the readiness, rollout, and rollback
-concerns around a release, beyond the version-bump/changelog/tag mechanics already
-covered by `release` skill. Use both together: `release` for the mechanical steps,
-this skill for whether the release is actually safe to expose to users and how widely.
+concerns around a release, beyond the version and the changelog `release` covers and the
+commands the workflow skill of the version control system states. Use them together:
+those two for what a release records, this skill for whether the release is safe to
+expose to users and how widely.
 
 - Monitoring/alerting that must be in place before launch → `observability-and-instrumentation` skill.
 - A breaking change being shipped → `deprecation-and-migration` skill for how it was

--- a/skills/submodule-sync/SKILL.md
+++ b/skills/submodule-sync/SKILL.md
@@ -41,7 +41,7 @@ git add module/foo
 git commit -m "chore: update module/foo ref"
 ```
 
-Branch name → `commit-rules`. Never record a ref pointing at an uncommitted or half-merged
+Branch name → `git-workflow` → Naming the Branch. Never record a ref pointing at an uncommitted or half-merged
 module state.
 
 ## Detached HEAD
@@ -180,7 +180,7 @@ on no target branch. `pr-rules` → Pre-Merge Checklist gates on this.
 
 `submodule.<name>.branch` in `.gitmodules` is the second reference, which that condition
 does not reach. `--remote` follows the key, so its value must not take the working branch
-shape `<user>/<type>/<TRACKER-N>/<subject>` that `commit-rules` → Branch Naming fixes,
+shape `<user>/<type>/<TRACKER-N>/<subject>` that `git-workflow` → Naming the Branch fixes,
 and the module's remote must carry a branch by that name:
 
 ```bash

--- a/skills/work-sequence/SKILL.md
+++ b/skills/work-sequence/SKILL.md
@@ -36,9 +36,9 @@ named beside it.
 | Step | Achieves | Runs when | Stated by |
 |---|---|---|---|
 | Scope and issue | the change has a tracked issue in the repository it belongs to, a module's in that module's own repository | the task is taken up | `issue-rules` |
-| Branch | the work has a branch of its own, named | before the first commit | `commit-rules` → Branch Naming |
+| Branch | the work has a branch of its own, named | before the first commit | the workflow skill of the version control system |
 | Commits | the change is recorded on that branch | a round of edits closes | `commit-rules` |
-| Publish | the branch stands where a reviewer reads it | the local remarks are exhausted | `pr-rules` → Pre-Open Checklist |
+| Publish | the branch stands where a reviewer reads it | the local remarks are exhausted | `pr-rules` → Pre-Open Checklist, and the workflow skill of the version control system for the command that sends the branch |
 | Offer for review | the change is offered for review | the Publish step has run | `pr-rules` |
 | Pre-merge issue check | the tracked issue is reconciled against what the change delivers, with a comment there naming which items it resolves | the review has passed | `pr-rules` → Pre-Merge Checklist, `issue-rules` → Progress Comments |
 | Integrate | the change sits on the target branch | the Pre-merge issue check clears | `pr-rules` → Merge Strategy |
@@ -73,7 +73,8 @@ project declares is the project's own; the pipeline that runs them on a server i
 **Recommended**
 
 - `issue-rules` — the issue's title, description, labels, lifecycle and progress comments.
-- `commit-rules` — the branch name and the commit message.
+- `commit-rules` — the commit message.
+- The workflow skill of the version control system — the command each step above runs, and the order they run in.
 - `pr-rules` — what the offer for review carries: its title, description, review comments, two checklists and merge strategy.
 - `ci-cd-and-automation` — the pipeline running a project's checks on a server.
 - `changelog` — the entry a branch carries before it is published.

--- a/test/rubric.test.js
+++ b/test/rubric.test.js
@@ -144,9 +144,9 @@ function skillsDeclaringRubric() {
 }
 
 // Extended by the pass that marks the next skill; every name here is checked below.
-const MARKED_SKILLS = ['code-navigation', 'comments', 'editing', 'github-cli',
-  'gitlab-cli', 'pr-rules', 'skill-authoring', 'submodule-sync', 'work-sequence',
-  'writing-style'];
+const MARKED_SKILLS = ['code-navigation', 'comments', 'editing', 'git-workflow',
+  'github-cli', 'gitlab-cli', 'pr-rules', 'skill-authoring', 'submodule-sync',
+  'work-sequence', 'writing-style'];
 
 function commandFiles() {
   const names = fs.readdirSync(commandsDir).filter(name => name.endsWith('.md'));


### PR DESCRIPTION
## Problem

The git mechanics were scattered across three skills that own something else: the branch
name and the fixup family sat in `commit-rules`, the tag and its two pushes in `release`,
the rebase and the merge form in `pr-rules`. Each of the three declares a context no git
reader is bound to, so a project on another version control system read rules it cannot
apply, and no file stated the order the commands run in.

## Summary

- A new skill `git-workflow` owns the commands that move a branch, a commit or a tag, in one sequence from the branch to the released tag
- Each step names what git records, and each section names the refusal git answers with, verbatim
- The three source skills keep their own concern and hand the commands over by role, since none of them is bound to git
- The lease on a forced push is stated with its hazard: a fetch between reading the remote and pushing discards another author's commit silently
- What one round of review is read with - the three-dot diff, and the range-diff pairing two rounds across a rebase - is stated where a reviewer reaches it

## Implementation

- `bound-to: git`, an instance under `vcs`, so every skill outside git names this one by role and only `submodule-sync` names it in backticks
- Every command was run in a throwaway repository before being written into the skill, and every quoted refusal reproduced verbatim on git 2.47.1
- The version bump takes the same eight steps as any other change, so the tag lands on the merge commit and no step commits on a shared branch
- The Review row of the lifecycle map, `agents/code-reviewer.md` and `commands/review-loop.md` each reach the review-reading section, a persona loading only what its body names
- `github-cli` and `gitlab-cli` keep what their own merge command deletes and point at the workflow skill for the local removal

## Test plan

- [x] `npm test` passes
- [x] The eight steps run in order in a throwaway repository, each as printed
- [x] The three refusals of `git branch -d`, the three answers of a push and the two-dot against the three-dot diff reproduced verbatim
- [x] `--fixup=amend:` and `reword:` measured: both write an `amend!` commit, and `reword:` needs nothing staged
- [ ] The user runs `node install.js`, which is the step that puts the edited files where an agent reads them

## Review

Two passes of `code-reviewer` at depth `high`, both blocking, every finding addressed. The
second pass falsified two statements the skill made and both are corrected: the correction
command was credited with a fold the rebase performs, and a tag was said to be lost with
the branch its commit lives on, where a tag is a ref and keeps its commit alive - what is
true is that the release then names history the target does not carry. Six acceptance
criteria of GH-155 turned out false against the tree, among them the count of git commands
in `pr-rules` and a push step that skill no longer has; each is reported rather than
implemented. A third pass has not run.
